### PR TITLE
Avg snr display fix

### DIFF
--- a/src-core/common/widgets/snr_plot.cpp
+++ b/src-core/common/widgets/snr_plot.cpp
@@ -22,7 +22,9 @@ namespace widgets
         float avg_snr = 0.0f;
         for (int i = 0; i < 200; i++)
         {
-            avg_snr += snr_history[i];
+            if (snr_history[i] >= 0 && snr_history[i] <= peak_snr){
+                avg_snr += snr_history[i];
+            }
         }
         avg_snr = avg_snr / 200; 
 


### PR DESCRIPTION
Added check that only counts snr_history values greater than 0 and lower than peak_snr to prevent issues during the first 200 counts before the history is fully populated (seems to be Windows specific)