### PR TITLE
Fix NOAA-18 GAC Correction Width

### DIFF
--- a/resources/projections_settings/noaa_18_avhrr.json
+++ b/resources/projections_settings/noaa_18_avhrr.json
@@ -15,6 +15,7 @@
         "max_diff": 1.0
     },
     ///////////////////////
+    "corr_width": 2048,
     "corr_swath": 2900,
     "corr_resol": 1.1,
     "corr_altit": 865


### PR DESCRIPTION
This PR fixes a bug when using the "Correct" feature with NOAA-18 GAC dumps.
[Example NOAA-18 GAC FRM for testing](https://www.dropbox.com/s/segmjrler9lzibt/2023-04-04%200321%20UTC%20-%20NOAA%2018.frm?dl=1)

**Without this PR:** the image is stretched far too wide when applying correction:

![beforeFix](https://user-images.githubusercontent.com/24253715/230701596-3f5f0077-8e36-4900-9ba5-c655ac7fe5da.png)

**After applying this patch:** (which uses the same corr_width as NOAA 19), the correction appears more natural:

![afterFix](https://user-images.githubusercontent.com/24253715/230701615-92e931e4-cac4-4db7-a5c9-d488d2b20453.png)