### PR TITLE
Fix build issues due to missing definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ mkdir build && cd build
 # If you want to disable some SDRs, you can add -DPLUGIN_HACKRF_SDR_SUPPORT=OFF or similar
 cmake -DCMAKE_BUILD_TYPE=Release ..                             # MacOS
 cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr .. # Linux
-make -j4
+make -j`nproc`
 
 # To run without installing
 ln -s ../pipelines .        # Symlink pipelines so it can run

--- a/plugins/goes_support/goes/grb/data/glm/glm_parser.h
+++ b/plugins/goes_support/goes/grb/data/glm/glm_parser.h
@@ -2,7 +2,7 @@
 
 #include <string>
 #include "glm_products.h"
-
+#include <cstdint>
 namespace goes
 {
     namespace grb

--- a/plugins/sdr_sources/sdrpp_server_support/sdrpp_server/smgui.h
+++ b/plugins/sdr_sources/sdrpp_server_support/sdrpp_server/smgui.h
@@ -3,7 +3,7 @@
 #include <string>
 #include <vector>
 #include <map>
-
+#include <cstdint>
 namespace SmGui {
     enum DrawStep {
         // Format calls

--- a/plugins/sdr_sources/spyserver_support/spyserver/networking.cpp
+++ b/plugins/sdr_sources/spyserver_support/spyserver/networking.cpp
@@ -1,6 +1,6 @@
 #include "networking.h"
 #include <assert.h>
-
+#include <stdexcept>
 namespace net
 {
 

--- a/src-core/common/detect_header.cpp
+++ b/src-core/common/detect_header.cpp
@@ -1,5 +1,5 @@
 #include "detect_header.h"
-
+#include <cstdint>
 #include "wav.h"
 #ifdef BUILD_ZIQ
 #include "ziq.h"

--- a/src-core/common/detect_header.h
+++ b/src-core/common/detect_header.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <cstdint>
 
 struct HeaderInfo
 {

--- a/src-core/common/dsp/demod/constellation.h
+++ b/src-core/common/dsp/demod/constellation.h
@@ -2,7 +2,7 @@
 
 #include "common/dsp/complex.h"
 #include <vector>
-
+#include <cstdint>
 namespace dsp
 {
     enum constellation_type_t


### PR DESCRIPTION
Fixes build issues due to <cstdint> and <stdexcept> not being included in certain files
Also changes the readme.md to say make -j`nproc` instead of make -j4 to use all cores if someone has more than 4
The commit names are a bit messed up since i used the github web ui and had to commit after every change
Builds fine on arch linux, without disabling any sdrs