### PR TITLE
Don't overwrite duplicate-named raw images on GOES HRIT

### DIFF
--- a/plugins/goes_support/goes/hrit/module_goes_lrit_data_decoder_proc.cpp
+++ b/plugins/goes_support/goes/hrit/module_goes_lrit_data_decoder_proc.cpp
@@ -388,11 +388,21 @@ namespace goes
                     }
                     else // Write raw image dats
                     {
-                        logger->info("Writing image " + directory + "/IMAGES/" + current_filename + ".png" + "...");
+                        //Sometimes, multiple different images can be sent down with the same name
+                        //Do not overwrite files
+                        std::string suffix = "";
+                        int suffixInt = 1;
+                        while(std::filesystem::exists(directory + "/IMAGES/" + current_filename + suffix + ".png"))
+                        {
+                            suffixInt++;
+                            suffix = "-" + std::to_string(suffixInt);
+                        }
+
+                        logger->info("Writing image " + directory + "/IMAGES/" + current_filename + suffix + ".png" + "...");
                         image::Image<uint8_t> image(&file.lrit_data[primary_header.total_header_length], image_structure_record.columns_count, image_structure_record.lines_count, 1);
                         if (is_goesn)
                             image.resize(image.width(), image.height() * 1.75);
-                        image.save_png(std::string(directory + "/IMAGES/" + current_filename + ".png").c_str());
+                        image.save_png(std::string(directory + "/IMAGES/" + current_filename + suffix + ".png").c_str());
 
                         // Check if this is GOES-R
                         if (primary_header.file_type_code == 0 && (noaa_header.product_id == 16 ||


### PR DESCRIPTION
**On the GOES-R HRIT downlink, NOAA is sending two separate products with the same name and timestamp every hour**: "OR_ABI-L2-DSIF-*.lrit," where * is the current ABI mode and timestamp. Under the hood, the difference between the DSI files is that one is the DSI CAPE product, while the other is DSI Lifted Indexes (LI). These products are documented [here](http://cimss.ssec.wisc.edu/goes/OCLOFactSheetPDFs/ABIQuickGuide_BaselineDerivedStabilityIndices.pdf).

**With SatDump's current behavior**, the second file simply overwrites the first, and the first file is lost.

**With this PR**, SatDump looks for existing files with the same filename. If it exists, it tries appending a -2, -3, etc to the end until it finds an available filename, then saves the file. This way, no data is lost.

**FYI**, I've written a similar patch for goestools [here](https://github.com/pietern/goestools/pull/163/files). On the goestools side, they were already parsing product information more deeply for the Non-CMIP data. I wrote that patch to differentiate between DSI CAPE and DSI LI, instead of just adding a -1 to the end. You can do that by looking at the _NAME value in the Image Data Function Header (the same header that maps luminance to units).

Since it looks like SatDump doesn't do anything with the Non-CMIP imagery other than dump it to disk, I felt this level of processing is unnecessary for now. Maybe something to look into later!

**Sample CADU:** [dsi_cape_and_li_example.zip](https://github.com/SatDump/SatDump/files/11992443/dsi_cape_and_li_example.zip)

**Example SatDump Output with the patch**
![image](https://github.com/SatDump/SatDump/assets/24253715/2d9544d8-6b21-4691-bac7-b06f3fda4c94)

**OR_ABI-L2-DSIF-M6_G16_s20231892250203_e20231892259511_c20231892301012.lrit.png [CAPE]**
![OR_ABI-L2-DSIF-M6_G16_s20231892250203_e20231892259511_c20231892301012 lrit](https://github.com/SatDump/SatDump/assets/24253715/5785ec5e-92fd-4d5f-b8b0-5122b439f6b5)

**OR_ABI-L2-DSIF-M6_G16_s20231892250203_e20231892259511_c20231892301012.lrit.png [LI]**
![OR_ABI-L2-DSIF-M6_G16_s20231892250203_e20231892259511_c20231892301012 lrit-2](https://github.com/SatDump/SatDump/assets/24253715/58204238-04dd-446d-bb91-e188bb6b7a84)
