### PR TITLE
Memory safety fixes related to METEOR decoding

### DIFF
--- a/plugins/meteor_support/meteor/instruments/msumr/module_meteor_msumr_lrpt.cpp
+++ b/plugins/meteor_support/meteor/instruments/msumr/module_meteor_msumr_lrpt.cpp
@@ -91,8 +91,13 @@ namespace meteor
             logger->info("Writing images.... (Can take a while)");
 
             // Identify satellite, and apply per-sat settings...
-            int msumr_serial_number = most_common(msumr_ids.begin(), msumr_ids.end());
-            msumr_ids.clear();
+            int msumr_serial_number = 0;
+            if (msumr_ids.empty()) {
+                logger->error("Could not find any MSUMR IDs!\n");
+            } else {
+                msumr_serial_number = most_common(msumr_ids.begin(), msumr_ids.end());
+                msumr_ids.clear();
+            }
 
             std::string sat_name = "Unknown Meteor";
             if (msumr_serial_number == 0)

--- a/src-core/common/map/map_drawer.cpp
+++ b/src-core/common/map/map_drawer.cpp
@@ -208,7 +208,7 @@ namespace map
     template void drawProjectedCapitalsGeoJson(std::vector<std::string>, image::Image<uint16_t> &, uint16_t[3], std::function<std::pair<int, int>(float, float, int, int)>, int);
 
     template <typename T>
-    void drawProjectedMapShapefile(std::vector<std::string> shapeFiles, image::Image<T> &map_image, T color[3], std::function<std::pair<int, int>(float, float, int, int)> projectionFunc, int maxLength)
+    void drawProjectedMapShapefile(std::vector<std::string> shapeFiles, image::Image<T> &map_image, T color[], std::function<std::pair<int, int>(float, float, int, int)> projectionFunc, int maxLength)
     {
         for (std::string currentShapeFile : shapeFiles)
         {

--- a/src-core/products/processor/image_processor.cpp
+++ b/src-core/products/processor/image_processor.cpp
@@ -45,10 +45,11 @@ namespace satdump
             {
                 auto proj_func = satdump::reprojection::setupProjectionFunction(ret.img.width(), ret.img.height(), ret.settings, metadata);
                 logger->info("Drawing map");
-                unsigned short color[3] = {0, 65535, 0};
+                std::vector<unsigned short> color(ret.img.channels(), 0);
+                color[1] = 65535;
                 map::drawProjectedMapShapefile({resources::getResourcePath("maps/ne_10m_admin_0_countries.shp")},
                                                ret.img,
-                                               color,
+                                               color.data(),
                                                proj_func);
             }
         }


### PR DESCRIPTION
If no MSU-MR serial IDs are found, don't try to find the most common SN because that will be UB.

Create as many elements in the `color` array as there are channels in the image so the projection drawing does not index into `color` out-of-bounds.