### PR TITLE
Add option to GOES HRIT pipeline to save .lrit files

### DIFF
--- a/pipelines/GOES.json
+++ b/pipelines/GOES.json
@@ -131,7 +131,8 @@
                     "write_emwin": true,
                     "write_messages": true,
                     "write_dcs": true,
-                    "write_unknown": false
+                    "write_unknown": false,
+                    "write_lrit": true
                 }
             }
         }

--- a/pipelines/GOES.json
+++ b/pipelines/GOES.json
@@ -132,7 +132,7 @@
                     "write_messages": true,
                     "write_dcs": true,
                     "write_unknown": false,
-                    "write_lrit": true
+                    "write_lrit": false
                 }
             }
         }

--- a/plugins/goes_support/goes/hrit/module_goes_lrit_data_decoder.cpp
+++ b/plugins/goes_support/goes/hrit/module_goes_lrit_data_decoder.cpp
@@ -17,7 +17,8 @@ namespace goes
                                                                                                                                                 write_emwin(parameters["write_emwin"].get<bool>()),
                                                                                                                                                 write_messages(parameters["write_messages"].get<bool>()),
                                                                                                                                                 write_dcs(parameters["write_dcs"].get<bool>()),
-                                                                                                                                                write_unknown(parameters["write_unknown"].get<bool>())
+                                                                                                                                                write_unknown(parameters["write_unknown"].get<bool>()),
+                                                                                                                                                write_lrit(parameters["write_lrit"].get<bool>())
         {
             goes_r_fc_composer_full_disk = std::make_shared<GOESRFalseColorComposer>();
             goes_r_fc_composer_meso1 = std::make_shared<GOESRFalseColorComposer>();
@@ -168,7 +169,11 @@ namespace goes
                 std::vector<::lrit::LRITFile> files = lrit_demux.work(cadu);
 
                 for (auto &file : files)
+                {
                     processLRITFile(file);
+                    if(write_lrit)
+                        saveLRITFile(file, directory + "/LRIT");
+                }
 
                 if (input_data_type == DATA_FILE)
                     progress = data_in.tellg();
@@ -391,12 +396,12 @@ namespace goes
 
         std::vector<std::string> GOESLRITDataDecoderModule::getParameters()
         {
-            return {"write_images", "write_emwin", "write_messages", "write_dcs", "write_unknown"};
+            return {"write_images", "write_emwin", "write_messages", "write_lrit", "write_dcs", "write_unknown"};
         }
 
         std::shared_ptr<ProcessingModule> GOESLRITDataDecoderModule::getInstance(std::string input_file, std::string output_file_hint, nlohmann::json parameters)
         {
             return std::make_shared<GOESLRITDataDecoderModule>(input_file, output_file_hint, parameters);
         }
-    } // namespace avhrr
-} // namespace metop
+    } // namespace hrit
+} // namespace goes

--- a/plugins/goes_support/goes/hrit/module_goes_lrit_data_decoder.h
+++ b/plugins/goes_support/goes/hrit/module_goes_lrit_data_decoder.h
@@ -24,6 +24,7 @@ namespace goes
             bool write_messages;
             bool write_dcs;
             bool write_unknown;
+            bool write_lrit;
 
             std::shared_ptr<GOESRFalseColorComposer> goes_r_fc_composer_full_disk;
             std::shared_ptr<GOESRFalseColorComposer> goes_r_fc_composer_meso1;
@@ -54,6 +55,7 @@ namespace goes
             std::map<int, std::unique_ptr<wip_images>> all_wip_images;
 
             void processLRITFile(::lrit::LRITFile &file);
+            void saveLRITFile(::lrit::LRITFile &file, std::string path);
 
         public:
             GOESLRITDataDecoderModule(std::string input_file, std::string output_file_hint, nlohmann::json parameters);
@@ -69,5 +71,5 @@ namespace goes
             static std::vector<std::string> getParameters();
             static std::shared_ptr<ProcessingModule> getInstance(std::string input_file, std::string output_file_hint, nlohmann::json parameters);
         };
-    } // namespace avhrr
-} // namespace metop
+    } // namespace hrit
+} // namespace goes


### PR DESCRIPTION
Allow saving all .LRIT files for GOES-R HRIT, instead of just unknown/DCS files. Useful for analysis in other programs.

If the lrit file is segmented, the segment number is appended to the name to keep it from overwriting the previous segment (matches goeslrit behavior).