### PR TITLE
GOES-R Segmentation Fixes

### DIFF
--- a/plugins/goes_support/goes/hrit/data/goes_r_fc_composer.cpp
+++ b/plugins/goes_support/goes/hrit/data/goes_r_fc_composer.cpp
@@ -59,6 +59,9 @@ namespace goes
 
         void GOESRFalseColorComposer::push2(image::Image<uint8_t> img, time_t time)
         {
+            if (time2 != 0 && time2 != time)
+                save();
+
             ch2 = img;
             time2 = time;
 
@@ -68,6 +71,9 @@ namespace goes
 
         void GOESRFalseColorComposer::push13(image::Image<uint8_t> img, time_t time)
         {
+            if (time13 != 0 && time13 != time)
+                save();
+
             ch13 = img;
             time13 = time;
 
@@ -75,13 +81,14 @@ namespace goes
                 generateCompo();
         }
 
-        void GOESRFalseColorComposer::save(std::string directory)
+        void GOESRFalseColorComposer::save()
         {
             imageStatus = SAVING;
             logger->info("Writing image " + directory + "/IMAGES/" + filename + ".png" + "...");
-            logger->warn("This false color LUT was made by Harry Dove-Robinson, see resources/goes/abi/wxstar/README.md for more infos.");
+            logger->info("This false color LUT was made by Harry Dove-Robinson, see resources/goes/abi/wxstar/README.md for more infos.");
             falsecolor.save_png(std::string(directory + "/IMAGES/" + filename + ".png").c_str());
             hasData = false;
+            time2 = time13 = 0;
             imageStatus = IDLE;
         }
     }

--- a/plugins/goes_support/goes/hrit/data/goes_r_fc_composer.cpp
+++ b/plugins/goes_support/goes/hrit/data/goes_r_fc_composer.cpp
@@ -62,6 +62,11 @@ namespace goes
             if (time2 != 0 && time2 != time)
                 save();
 
+            //Keep Composer in sync - purge old data from composites where no data
+            //Was received on one of the channels
+            if (time13 != 0 && time > time13)
+                time13 = 0;
+
             ch2 = img;
             time2 = time;
 
@@ -73,6 +78,11 @@ namespace goes
         {
             if (time13 != 0 && time13 != time)
                 save();
+
+            //Keep Composer in sync - purge old data from composites where no data
+            //Was received on one of the channels
+            if (time2 != 0 && time > time2)
+                time2 = 0;
 
             ch13 = img;
             time13 = time;

--- a/plugins/goes_support/goes/hrit/data/lrit_data.h
+++ b/plugins/goes_support/goes/hrit/data/lrit_data.h
@@ -52,10 +52,9 @@ namespace goes
 
             bool hasData = false;
 
-            std::string filename;
+            std::string filename, directory;
 
-            void save(std::string directory);
-
+            void save();
             void push2(image::Image<uint8_t> img, time_t time);
             void push13(image::Image<uint8_t> img, time_t time);
 

--- a/plugins/goes_support/goes/hrit/module_goes_lrit_data_decoder.cpp
+++ b/plugins/goes_support/goes/hrit/module_goes_lrit_data_decoder.cpp
@@ -66,7 +66,8 @@ namespace goes
             if (input_data_type == DATA_FILE)
                 data_in = std::ifstream(d_input_file, std::ios::binary);
 
-            std::string directory = d_output_file_hint.substr(0, d_output_file_hint.rfind('/'));
+            directory = d_output_file_hint.substr(0, d_output_file_hint.rfind('/'));
+            goes_r_fc_composer_full_disk->directory = goes_r_fc_composer_meso1->directory = goes_r_fc_composer_meso2->directory = directory;
 
             if (!std::filesystem::exists(directory))
                 std::filesystem::create_directory(directory);
@@ -81,8 +82,6 @@ namespace goes
             logger->info("Demultiplexing and deframing...");
 
             ::lrit::LRITDemux lrit_demux;
-
-            this->directory = directory;
 
             lrit_demux.onParseHeader =
                 [this](::lrit::LRITFile &file) -> void
@@ -197,11 +196,11 @@ namespace goes
             }
 
             if (goes_r_fc_composer_full_disk->hasData)
-                goes_r_fc_composer_full_disk->save(directory);
+                goes_r_fc_composer_full_disk->save();
             if (goes_r_fc_composer_meso1->hasData)
-                goes_r_fc_composer_meso1->save(directory);
+                goes_r_fc_composer_meso1->save();
             if (goes_r_fc_composer_meso2->hasData)
-                goes_r_fc_composer_meso2->save(directory);
+                goes_r_fc_composer_meso2->save();
         }
 
         void GOESLRITDataDecoderModule::drawUI(bool window)

--- a/plugins/goes_support/goes/hrit/module_goes_lrit_data_decoder_proc.cpp
+++ b/plugins/goes_support/goes/hrit/module_goes_lrit_data_decoder_proc.cpp
@@ -137,42 +137,27 @@ namespace goes
 
                                 current_filename = subdir + "/" + getHRITImageFilename(&scanTimestamp, "G" + std::to_string(noaa_header.product_id), channel);
 
-                                if ((region == "Full Disk" || region == "Mesoscale 1" || region == "Mesoscale 2"))
+                                //Configure mesoscale color compoer - FD is defined further down
+                                if ((region == "Mesoscale 1" || region == "Mesoscale 2"))
                                 {
                                     std::shared_ptr<GOESRFalseColorComposer> goes_r_fc_composer;
 
-                                    if (region == "Full Disk")
-                                    {
-                                        goes_r_fc_composer = goes_r_fc_composer_full_disk;
+                                    if (region == "Mesoscale 1")
+                                        goes_r_fc_composer = goes_r_fc_composer_meso1;
+                                    else if (region == "Mesoscale 2")
+                                        goes_r_fc_composer = goes_r_fc_composer_meso2;
 
-                                        /*if (channel == 2)
-                                        {
-                                            goes_r_fc_composer->push2(segmentedDecoder.image, mktime(&scanTimestamp));
-                                        }
-                                        else if (channel == 13)
-                                        {
-                                            goes_r_fc_composer->push13(segmentedDecoder.image, mktime(&scanTimestamp));
-                                        }*/
+                                    image::Image<uint8_t> image(&file.lrit_data[primary_header.total_header_length],
+                                                                image_structure_record.columns_count,
+                                                                image_structure_record.lines_count, 1);
+
+                                    if (channel == 2)
+                                    {
+                                        goes_r_fc_composer->push2(image, mktime(&scanTimestamp));
                                     }
-                                    else if (region == "Mesoscale 1" || region == "Mesoscale 2")
+                                    else if (channel == 13)
                                     {
-                                        if (region == "Mesoscale 1")
-                                            goes_r_fc_composer = goes_r_fc_composer_meso1;
-                                        else if (region == "Mesoscale 2")
-                                            goes_r_fc_composer = goes_r_fc_composer_meso2;
-
-                                        image::Image<uint8_t> image(&file.lrit_data[primary_header.total_header_length],
-                                                                    image_structure_record.columns_count,
-                                                                    image_structure_record.lines_count, 1);
-
-                                        if (channel == 2)
-                                        {
-                                            goes_r_fc_composer->push2(image, mktime(&scanTimestamp));
-                                        }
-                                        else if (channel == 13)
-                                        {
-                                            goes_r_fc_composer->push13(image, mktime(&scanTimestamp));
-                                        }
+                                        goes_r_fc_composer->push13(image, mktime(&scanTimestamp));
                                     }
 
                                     goes_r_fc_composer->filename = subdir + "/" + getHRITImageFilename(&scanTimestamp, "G" + std::to_string(noaa_header.product_id), "FC");
@@ -280,41 +265,22 @@ namespace goes
 
                     SegmentedLRITImageDecoder &segmentedDecoder = segmentedDecoders[file.vcid];
 
-                    if (segmentedDecoder.image_id != file.vcid)
+                    if (segmentedDecoder.image_id != segment_id_header.image_identifier)
                     {
                         if (segmentedDecoder.image_id != -1)
                         {
                             wip_img->imageStatus = SAVING;
-                            logger->info("Writing image " + directory + "/IMAGES/" + current_filename + ".png" + "...");
+                            logger->info("Writing image " + directory + "/IMAGES/" + segmentedDecoder.filename + ".png" + "...");
                             if (is_goesn)
                                 segmentedDecoder.image.resize(segmentedDecoder.image.width(), segmentedDecoder.image.height() * 1.75);
-                            segmentedDecoder.image.save_png(std::string(directory + "/IMAGES/" + current_filename + ".png").c_str());
+                            segmentedDecoder.image.save_png(std::string(directory + "/IMAGES/" + segmentedDecoder.filename + ".png").c_str());
                             wip_img->imageStatus = RECEIVING;
-
-                            // Check if this is GOES-R
-                            if (primary_header.file_type_code == 0 && (noaa_header.product_id == 16 ||
-                                                                       noaa_header.product_id == 17 ||
-                                                                       noaa_header.product_id == 18 ||
-                                                                       noaa_header.product_id == 19))
-                            {
-                                int mode = -1;
-                                int channel = -1;
-                                std::vector<std::string> cutFilename = splitString(old_filename, '-');
-                                if (cutFilename.size() > 3)
-                                {
-                                    if (sscanf(cutFilename[3].c_str(), "M%dC%02d", &mode, &channel) == 2)
-                                    {
-                                        if (goes_r_fc_composer_full_disk->hasData && (channel == 2 || channel == 2))
-                                            goes_r_fc_composer_full_disk->save(directory);
-                                    }
-                                }
-                            }
                         }
 
                         segmentedDecoder = SegmentedLRITImageDecoder(segment_id_header.max_segment,
                                                                      image_structure_record.columns_count,
                                                                      image_structure_record.lines_count,
-                                                                     file.vcid);
+                                                                     segment_id_header.image_identifier);
                         segmentedDecoder.filename = current_filename;
                     }
 
@@ -323,7 +289,7 @@ namespace goes
                     else
                         segmentedDecoder.pushSegment(&file.lrit_data[primary_header.total_header_length], segment_id_header.segment_sequence_number);
 
-                    // Check if this is GOES-R, if yes, MS
+                    // Check if this is GOES-R, if yes, this is Full Disk
                     if (primary_header.file_type_code == 0 && (noaa_header.product_id == 16 ||
                                                                noaa_header.product_id == 17 ||
                                                                noaa_header.product_id == 18 ||
@@ -347,9 +313,20 @@ namespace goes
                                 }
 
                                 if (channel == 2)
+                                {
                                     goes_r_fc_composer_full_disk->push2(segmentedDecoder.image, mktime(&scanTimestamp));
-                                else if (channel == 13)
+                                    std::string subdir = "GOES-" + std::to_string(noaa_header.product_id) + "/Full Disk";
+                                    goes_r_fc_composer_full_disk->filename = subdir + "/" + getHRITImageFilename(&scanTimestamp, "G" + std::to_string(noaa_header.product_id), "FC");
+                                }
+
+                                else if (channel == 13 && file.vcid == 13) //Redundant check keeps relayed channel 13 from entering the color composer
+                                {
                                     goes_r_fc_composer_full_disk->push13(segmentedDecoder.image, mktime(&scanTimestamp));
+                                    std::string subdir = "GOES-" + std::to_string(noaa_header.product_id) + "/Full Disk";
+                                    goes_r_fc_composer_full_disk->filename = subdir + "/" + getHRITImageFilename(&scanTimestamp, "G" + std::to_string(noaa_header.product_id), "FC");
+                                }
+
+
                             }
                         }
                     }
@@ -389,8 +366,8 @@ namespace goes
                             {
                                 if (sscanf(cutFilename[3].c_str(), "M%dC%02d", &mode, &channel) == 2)
                                 {
-                                    if (goes_r_fc_composer_full_disk->hasData && (channel == 2 || channel == 2))
-                                        goes_r_fc_composer_full_disk->save(directory);
+                                    if (goes_r_fc_composer_full_disk->hasData && channel == 2)
+                                        goes_r_fc_composer_full_disk->save();
                                 }
                             }
                         }
@@ -434,9 +411,9 @@ namespace goes
                                                                    noaa_header.product_id == 19))
                         {
                             if (goes_r_fc_composer_meso1->hasData)
-                                goes_r_fc_composer_meso1->save(directory);
+                                goes_r_fc_composer_meso1->save();
                             if (goes_r_fc_composer_meso2->hasData)
-                                goes_r_fc_composer_meso2->save(directory);
+                                goes_r_fc_composer_meso2->save();
                         }
                     }
                 }

--- a/plugins/goes_support/goes/hrit/module_goes_lrit_data_decoder_proc.cpp
+++ b/plugins/goes_support/goes/hrit/module_goes_lrit_data_decoder_proc.cpp
@@ -5,6 +5,10 @@
 #include "libs/miniz/miniz_zip.h"
 #include "imgui/imgui_image.h"
 
+#ifdef _MSC_VER
+#define timegm _mkgmtime
+#endif
+
 namespace goes
 {
     namespace hrit
@@ -153,11 +157,11 @@ namespace goes
 
                                     if (channel == 2)
                                     {
-                                        goes_r_fc_composer->push2(image, mktime(&scanTimestamp));
+                                        goes_r_fc_composer->push2(image, timegm(&scanTimestamp));
                                     }
                                     else if (channel == 13)
                                     {
-                                        goes_r_fc_composer->push13(image, mktime(&scanTimestamp));
+                                        goes_r_fc_composer->push13(image, timegm(&scanTimestamp));
                                     }
 
                                     goes_r_fc_composer->filename = subdir + "/" + getHRITImageFilename(&scanTimestamp, "G" + std::to_string(noaa_header.product_id), "FC");
@@ -314,14 +318,14 @@ namespace goes
 
                                 if (channel == 2)
                                 {
-                                    goes_r_fc_composer_full_disk->push2(segmentedDecoder.image, mktime(&scanTimestamp));
+                                    goes_r_fc_composer_full_disk->push2(segmentedDecoder.image, timegm(&scanTimestamp));
                                     std::string subdir = "GOES-" + std::to_string(noaa_header.product_id) + "/Full Disk";
                                     goes_r_fc_composer_full_disk->filename = subdir + "/" + getHRITImageFilename(&scanTimestamp, "G" + std::to_string(noaa_header.product_id), "FC");
                                 }
 
                                 else if (channel == 13 && file.vcid == 13) //Redundant check keeps relayed channel 13 from entering the color composer
                                 {
-                                    goes_r_fc_composer_full_disk->push13(segmentedDecoder.image, mktime(&scanTimestamp));
+                                    goes_r_fc_composer_full_disk->push13(segmentedDecoder.image, timegm(&scanTimestamp));
                                     std::string subdir = "GOES-" + std::to_string(noaa_header.product_id) + "/Full Disk";
                                     goes_r_fc_composer_full_disk->filename = subdir + "/" + getHRITImageFilename(&scanTimestamp, "G" + std::to_string(noaa_header.product_id), "FC");
                                 }


### PR DESCRIPTION
This PR makes a number of changes within the GOES-R HRIT Plugin:

- **Fixed the Segmented LRIT decoder when segments are missing:** There was logic there before to save partially-written data, but it no longer worked. I'm guessing some other changes broke it. This resulted in incomplete files never being saved, and the buffer would be "carried forward" to the next image. 
    
    This resulted in a loss of data, as well as strange things when 2 back-to-back images of the same channel had missing segments: if between them, all the segments were there, it would save a Frankenstein combination of the segments in the buffer.
    
    This PR fixes it, and along with it, this issue: #273.
    
- **Moved around logic on when to save FD color images:** Necessitated by the first change
- **Fixed timestamp on full color mesoscale images:** They were ahead by an hour on Windows, thanks mktime()
- **Reduced logger level for the LUT author to informational:** Feel free to undo this, but in my mind this is not a warning. It seems unnecessary to pop up in the GUI