### PR TITLE
LRIT Demuxer - Salvage some LRIT files with bad packets

### DIFF
--- a/src-core/common/lrit/lrit_file.h
+++ b/src-core/common/lrit/lrit_file.h
@@ -107,6 +107,7 @@ namespace lrit
 
         bool file_in_progress = false;
         bool header_parsed = false;
+        bool needs_fixed = false;
 
         std::map<int, int> custom_flags;
 


### PR DESCRIPTION
In the current implementation, SatDump's LRIT demuxer will discard the entire LRIT file/segment if any packet within it has a CRC failure. In image files, this results in the file being entirely missing, or (if segmented) large areas of the image are gone.

This PR changes the LRIT Demuxer so it will keep LRIT files/segments with bad packets if:
- The LRIT file is already in progress
- The LRIT header is already complete
- The LRIT Sequence Flag is 0 (a continuation of data from previous packets, but not the last)
- The LRIT file type is 0 (image), and has an ImageStructureRecord

This results in significantly better images, especially in cases where there was only 1 or 2 CRC failures. Tested on GOES-R HRIT and GK-2A LRIT only.

**GOES 16 - Before & After** (click to zoom in)
![G16_14_20230722T180020Z](https://github.com/SatDump/SatDump/assets/24253715/0d26c728-aad3-4ce6-ac65-4ebc9854ef1a)

**GK-2A - Before & After** (very bad recording)
![GK2a](https://github.com/SatDump/SatDump/assets/24253715/98da3576-ea6d-4055-9cdf-5a88954a6267)
