### PR TITLE
Add ability to scroll ZIQ Recordings

### DIFF
--- a/src-core/common/dsp/io/baseband_interface.h
+++ b/src-core/common/dsp/io/baseband_interface.h
@@ -114,10 +114,12 @@ namespace dsp
             if (should_repeat && input_file.eof())
             {
                 input_file.clear();
-                input_file.seekg(0);
-
-                if (format == ZIQ2)
+                if (format == ZIQ)
+                    ziqReader->seekg(0);
+                else if (format == ZIQ2)
                     input_file.seekg(4);
+                else
+                    input_file.seekg(0);
             }
 
             switch (format)
@@ -186,7 +188,12 @@ namespace dsp
         {
 #ifdef BUILD_ZIQ
             if (format == ZIQ)
+            {
+                main_mtx.lock();
+                ziqReader->seekg(filesize * (progress / 100.0f));
+                main_mtx.unlock();
                 return;
+            }
 #endif
 
             if (format == ZIQ2)

--- a/src-core/common/dsp_source_sink/file_source.cpp
+++ b/src-core/common/dsp_source_sink/file_source.cpp
@@ -167,6 +167,10 @@ void FileSource::drawControlUI()
         baseband_reader.set_progress(file_progress);
     if (!is_started)
         style::endDisabled();
+#ifdef BUILD_ZIQ
+    if (select_sample_format == 4)
+        ImGui::TextColored(ImColor(255, 0, 0), "ZIQ seeking\nmay be slow!");
+#endif
 }
 
 void FileSource::set_samplerate(uint64_t samplerate)

--- a/src-core/common/dsp_source_sink/file_source.cpp
+++ b/src-core/common/dsp_source_sink/file_source.cpp
@@ -161,24 +161,12 @@ void FileSource::drawControlUI()
 
     if (is_started)
         style::endDisabled();
-
-#ifdef BUILD_ZIQ
-    if (select_sample_format == 4)
-        style::beginDisabled();
-#endif
     if (!is_started)
         style::beginDisabled();
     if (ImGui::SliderFloat("Progress", &file_progress, 0, 100))
         baseband_reader.set_progress(file_progress);
     if (!is_started)
         style::endDisabled();
-#ifdef BUILD_ZIQ
-    if (select_sample_format == 4)
-    {
-        ImGui::TextColored(ImColor(255, 0, 0), "Scrolling not\navailable on ZIQ!");
-        style::endDisabled();
-    }
-#endif
 }
 
 void FileSource::set_samplerate(uint64_t samplerate)

--- a/src-core/common/ziq.cpp
+++ b/src-core/common/ziq.cpp
@@ -114,16 +114,16 @@ namespace ziq
     // Reader
     ziq_reader::ziq_reader(std::ifstream &stream) : stream(stream)
     {
-        // Write header
+        // Read header
         char signature[4];
+        annotation_size = 0;
         stream.read((char *)signature, 4);
         stream.read((char *)&cfg.is_compressed, 1);
         stream.read((char *)&cfg.bits_per_sample, 1);
         stream.read((char *)&cfg.samplerate, 8);
-        uint64_t string_size = 0;
-        stream.read((char *)&string_size, 8);
-        cfg.annotation.resize(string_size);
-        stream.read((char *)cfg.annotation.c_str(), string_size);
+        stream.read((char *)&annotation_size, 8);
+        cfg.annotation.resize(annotation_size);
+        stream.read((char *)cfg.annotation.c_str(), annotation_size);
 
         if (std::string(&signature[0], &signature[4]) != ZIQ_SIGNATURE)
         {
@@ -166,6 +166,40 @@ namespace ziq
             delete[] buffer_i8;
         else if (cfg.bits_per_sample == 16)
             delete[] buffer_i16;
+    }
+
+    bool ziq_reader::seekg(size_t pos)
+    {
+        //Move to location in file
+        if (cfg.is_compressed)
+        {
+            size_t err;
+            decompressed_cnt = 0;
+            if (pos + annotation_size + 22 < stream.tellg())
+            {
+                err = ZSTD_DCtx_reset(zstd_ctx, ZSTD_reset_session_only);
+                if (ZSTD_isError(err)) return false;
+                stream.seekg(annotation_size + 22);
+            }
+            while (stream.tellg() < pos + annotation_size + 22)
+            {
+                stream.read((char*)compressed_buffer, ZIQ_DECOMPRESS_BUFSIZE);
+                zstd_input = { compressed_buffer, (unsigned long)ZIQ_DECOMPRESS_BUFSIZE, 0 };
+                zstd_output = { output_decompressed, max_buffer_size, 0 };
+                while (zstd_input.pos < zstd_input.size)
+                {
+                    err = ZSTD_decompressStream(zstd_ctx, &zstd_output, &zstd_input);
+                    if (ZSTD_isError(err)) return false;
+                }
+            }
+        }
+        else
+        {
+            stream.seekg(pos + annotation_size + 22);
+            return true;
+        }
+
+        return true;
     }
 
     int ziq_reader::decompress_at_least(int size)

--- a/src-core/common/ziq.h
+++ b/src-core/common/ziq.h
@@ -76,6 +76,7 @@ namespace ziq
         std::ifstream &stream;
         int8_t *buffer_i8;
         int16_t *buffer_i16;
+        uint64_t annotation_size;
 
     private:
         ZSTD_DCtx *zstd_ctx;
@@ -96,6 +97,7 @@ namespace ziq
         ~ziq_reader();
 
         int read(complex_t *output, int size);
+        bool seekg(size_t pos);
     };
 
     bool isValidZIQ(std::string file);


### PR DESCRIPTION
This PR is pretty straight forward: it adds the ability to seek through ZIQ files in the recorder. My original intent was to fix the bug where ZIQ playback gets stuck at 100% and does not loop like other recorded file types - and I got a bit carried away 😄 

The repeat fix is really fast, but there is a delay in seeking from the beginning of the file to near the end. Incrementing forward, or scrolling towards the beginning, is nearly immediate. On my machine with the "worst case" I regularly run (a 15-minute S8 ZIQ at 6 Msps) can be scrolled from 0% to 95% in 15 seconds. Not too bad, but not nearly as fast as a simple `istream::seekg`.

Let me know your thoughts - I'm not sure how much the performance can be improved, or how well it would work with higher sample rate ZIQs. I like having the ability to seek since I often record back-to-back NOAA GAC dumps in the same file, but if you feel the User Experience is too bad with the slow seek time, I'll happily re-submit a PR that just fixes ZIQ repeat.

![image](https://github.com/SatDump/SatDump/assets/24253715/b6e13522-95a5-447b-b294-9efd4a7bc861)
