### PR TITLE
GUI fixes

### DIFF
--- a/src-core/imgui/imgui_flags.h
+++ b/src-core/imgui/imgui_flags.h
@@ -1,4 +1,4 @@
 #pragma once
 
 // Has to be cast otherwise the compiler will complain...
-#define NOWINDOW_FLAGS (long int)ImGuiWindowFlags_NoMove | (long int)ImGuiWindowFlags_NoCollapse | (long int)ImGuiWindowFlags_NoBringToFrontOnFocus /*| ImGuiWindowFlags_NoTitleBar*/ | (long int)ImGuiWindowFlags_NoResize | (long int)ImGuiWindowFlags_NoBackground
+#define NOWINDOW_FLAGS (long int)ImGuiWindowFlags_NoMove | (long int)ImGuiWindowFlags_NoCollapse /*| ImGuiWindowFlags_NoTitleBar*/ | (long int)ImGuiWindowFlags_NoResize | (long int)ImGuiWindowFlags_NoBackground

--- a/src-interface/imgui_notify/imgui_notify.h
+++ b/src-interface/imgui_notify/imgui_notify.h
@@ -31,6 +31,7 @@
 #include <vector>
 #include <string>
 #include "imgui/imgui.h"
+#include "imgui/imgui_internal.h"
 #include <chrono>
 #include <algorithm>
 #include <stdarg.h>
@@ -46,7 +47,7 @@ const float NOTIFY_PADDING_X = 20.f;			// Bottom-left X padding
 const float NOTIFY_PADDING_Y = 20.f;			// Bottom-left Y padding
 const float NOTIFY_PADDING_MESSAGE_Y = 10.f;	// Padding Y between each message
 const float NOTIFY_OPACITY = 1.0f;				// 0-1 Toast opacity
-const ImGuiWindowFlags NOTIFY_TOAST_FLAGS = ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoInputs | ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoFocusOnAppearing;
+const ImGuiWindowFlags NOTIFY_TOAST_FLAGS = ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoInputs | ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoSavedSettings;
 
 // Comment out if you don't want any separator between title and content
 #define NOTIFY_USE_SEPARATOR
@@ -248,6 +249,7 @@ namespace ImGui
 			sprintf(window_name, "##TOAST%d", i);
 			i++;
 			Begin(window_name, NULL, NOTIFY_TOAST_FLAGS);
+			BringWindowToDisplayFront(GetCurrentWindow());
 
 			// Here we render the toast content
 			{

--- a/src-interface/offline.cpp
+++ b/src-interface/offline.cpp
@@ -17,8 +17,13 @@ namespace satdump
         {
             pipeline_selector = std::make_unique<PipelineUISelector>(false);
 
-            pipeline_selector->inputfileselect.default_dir = config::main_cfg["satdump_directories"]["default_input_directory"]["value"].get<std::string>() + "/";
-            pipeline_selector->outputdirselect.default_dir = config::main_cfg["satdump_directories"]["default_output_directory"]["value"].get<std::string>() + "/";
+            pipeline_selector->inputfileselect.default_dir = config::main_cfg["satdump_directories"]["default_input_directory"]["value"].get<std::string>();
+            pipeline_selector->outputdirselect.default_dir = config::main_cfg["satdump_directories"]["default_output_directory"]["value"].get<std::string>();
+
+#ifndef _MSC_VER
+            pipeline_selector->inputfileselect.default_dir += "/";
+            pipeline_selector->outputdirselect.default_dir += "/";
+#endif
         }
 
         void render()

--- a/src-interface/recorder/recorder.cpp
+++ b/src-interface/recorder/recorder.cpp
@@ -568,6 +568,7 @@ namespace satdump
                 float live_height = 250 * ui_scale;
                 float winwidth = live_pipeline->modules.size() > 0 ? live_width / live_pipeline->modules.size() : live_width;
                 float currentPos = 0;
+                ImGui::PushStyleColor(11, ImGui::GetStyleColorVec4(10));
                 for (std::shared_ptr<ProcessingModule> &module : live_pipeline->modules)
                 {
                     ImGui::SetNextWindowPos({currentPos, y_pos});
@@ -579,6 +580,7 @@ namespace satdump
                     //     currentPos += ImGui::GetCurrentContext()->last_window->Size.x;
                     //  logger->info(ImGui::GetCurrentContext()->last_window->Name);
                 }
+                ImGui::PopStyleColor();
             }
         }
 

--- a/src-interface/viewer/image_handler.cpp
+++ b/src-interface/viewer/image_handler.cpp
@@ -534,12 +534,24 @@ namespace satdump
 
             if (ImGui::Button("Save"))
             {
-                std::string default_path = config::main_cfg["satdump_directories"]["default_image_output_directory"]["value"].get<std::string>() + "/";
+                std::string default_path = config::main_cfg["satdump_directories"]["default_image_output_directory"]["value"].get<std::string>();
+#ifdef _MSC_VER
+                if (default_path == ".")
+                {
+                    char* cwd;
+                    cwd = _getcwd(NULL, 0);
+                    if (cwd != 0)
+                        default_path = cwd;
+                }
+                default_path += "\\";
+#else
+                default_path += "/";
+#endif
                 std::string default_name = default_path +
                                            products->instrument_name + "_" + (select_image_id == 0 ? "composite" : ("ch" + channel_numbers[select_image_id - 1])) + ".png";
 
 #ifndef __ANDROID__
-                auto result = pfd::save_file("Save Image", default_name, {"*.png"});
+                auto result = pfd::save_file("Save Image", default_name, { "PNG Files", "*.png" });
                 while (!result.ready(1000))
                     std::this_thread::sleep_for(std::chrono::milliseconds(1));
 

--- a/src-interface/viewer/radiation_handler.cpp
+++ b/src-interface/viewer/radiation_handler.cpp
@@ -5,6 +5,10 @@
 #include "core/style.h"
 #include "common/projection/reprojector.h"
 
+#ifdef _MSC_VER
+#include <direct.h>
+#endif
+
 namespace satdump
 {
     void RadiationViewerHandler::init()
@@ -67,10 +71,23 @@ namespace satdump
                 style::beginDisabled();
             if (ImGui::Button("Save"))
             {
-                std::string default_name = products->instrument_name + "_map.png";
+                std::string default_path = config::main_cfg["satdump_directories"]["default_image_output_directory"]["value"].get<std::string>();
+#ifdef _MSC_VER
+                if (default_path == ".")
+                {
+                    char* cwd;
+                    cwd = _getcwd(NULL, 0);
+                    if (cwd != 0)
+                        default_path = cwd;
+                }
+                default_path += "\\";
+#else
+                default_path += "/";
+#endif
+                std::string default_name = default_path + products->instrument_name + "_map.png";
 
 #ifndef __ANDROID__
-                auto result = pfd::save_file("Save Image", default_name, {"*.png"});
+                auto result = pfd::save_file("Save Image", default_name, { "PNG Files", "*.png" });
                 while (!result.ready(1000))
                     std::this_thread::sleep_for(std::chrono::milliseconds(1));
 

--- a/src-interface/viewer/scatterometer_handler.cpp
+++ b/src-interface/viewer/scatterometer_handler.cpp
@@ -5,6 +5,10 @@
 #include "core/style.h"
 #include "common/map/map_drawer.h"
 
+#ifdef _MSC_VER
+#include <direct.h>
+#endif
+
 namespace satdump
 {
     void ScatterometerViewerHandler::init()
@@ -107,12 +111,25 @@ namespace satdump
 
             if (ImGui::Button("Save"))
             {
+                std::string default_path = config::main_cfg["satdump_directories"]["default_image_output_directory"]["value"].get<std::string>();
+#ifdef _MSC_VER
+                if (default_path == ".")
+                {
+                    char* cwd;
+                    cwd = _getcwd(NULL, 0);
+                    if (cwd != 0)
+                        default_path = cwd;
+                }
+                default_path += "\\";
+#else
+                default_path += "/";
+#endif
                 std::string ch_normal = std::to_string(select_channel_image_id);
                 std::string ch_ascatp = std::to_string(ascat_select_channel_id);
-                std::string default_name = products->instrument_name + "_" + ((selected_visualization_id == 1 && current_scat_type == SCAT_ASCAT) ? ch_ascatp : ch_normal) + ".png";
+                std::string default_name = default_path + products->instrument_name + "_" + ((selected_visualization_id == 1 && current_scat_type == SCAT_ASCAT) ? ch_ascatp : ch_normal) + ".png";
 
 #ifndef __ANDROID__
-                auto result = pfd::save_file("Save Image", default_name, {"*.png"});
+                auto result = pfd::save_file("Save Image", default_name, { "PNG Files", "*.png" });
                 while (!result.ready(1000))
                     std::this_thread::sleep_for(std::chrono::milliseconds(1));
 

--- a/src-interface/viewer/viewer_projection.cpp
+++ b/src-interface/viewer/viewer_projection.cpp
@@ -10,6 +10,10 @@
 #include "common/widgets/switch.h"
 #include "libs/tiny-regex-c/re.h"
 
+#ifdef _MSC_VER
+#include <direct.h>
+#endif
+
 namespace satdump
 {
     re_t osm_url_regex = re_compile("https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,4}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)\\/\\{([xyz])\\}\\/\\{((?!\\3)[xyz])\\}\\/\\{((?!\\3)(?!\\4)[xyz])\\}(\\.png|\\.jpg|\\.jpeg|)");
@@ -104,11 +108,23 @@ namespace satdump
 
             if (ImGui::Button("Save Projected Image"))
             {
-                std::string default_path = config::main_cfg["satdump_directories"]["default_projection_output_directory"]["value"].get<std::string>() + "/";
+                std::string default_path = config::main_cfg["satdump_directories"]["default_projection_output_directory"]["value"].get<std::string>();
+#ifdef _MSC_VER
+                if (default_path == ".")
+                {
+                    char* cwd;
+                    cwd = _getcwd(NULL, 0);
+                    if (cwd != 0)
+                        default_path = cwd;
+                }
+                default_path += "\\";
+#else
+                default_path += "/";
+#endif
                 std::string default_name = default_path + "projection.png";
 
 #ifndef __ANDROID__
-                auto result = pfd::save_file("Save Projection", default_name, {"*.png"});
+                auto result = pfd::save_file("Save Image", default_name, { "PNG Files", "*.png" });
                 while (!result.ready(1000))
                     std::this_thread::sleep_for(std::chrono::milliseconds(1));
 


### PR DESCRIPTION
This PR fixes 4 issues with the UI:

- Fixes #283
- Fixes #286 (borrowed fix from https://github.com/patrickcjk/imgui-notify/pull/20/commits/8a391630b70296157e068b067aaee36110a9660d)
- Fixes the viewer/projector not saving images via the GUI on Windows unless the .png file extension is manually typed in the save dialog
- Fixes user interaction with processing modules when docked in the recorder/live decoder - before, clicking through VCID tabs/mousing over line graphs did not work unless the windows were floating