### PR TITLE
User-Selectable Image Format (and more)

### DIFF
--- a/plugins/aim_support/aim/module_aim_instruments.cpp
+++ b/plugins/aim_support/aim/module_aim_instruments.cpp
@@ -97,7 +97,7 @@ namespace aim
                     int img_cnt = 0;
                     for (auto &img : cips_readers[i].images)
                     {
-                        img.save_png(cips_directory + "/CIPS_" + std::to_string(img_cnt++ + 1) + ".png");
+                        img.save_img(cips_directory + "/CIPS_" + std::to_string(img_cnt++ + 1));
                     }
 
                     cips_status[i] = DONE;

--- a/plugins/analog_support/noaa_apt/module_noaa_apt_decoder.cpp
+++ b/plugins/analog_support/noaa_apt/module_noaa_apt_decoder.cpp
@@ -214,9 +214,7 @@ namespace noaa_apt
         std::string main_dir = d_output_file_hint.substr(0, d_output_file_hint.rfind('/'));
 
         apt_status = SAVING;
-
-        logger->info("Saving...");
-        wip_apt_image_sync.save_png(main_dir + "/raw.png");
+        wip_apt_image_sync.save_img(main_dir + "/raw");
 
         // Products ARE not yet being processed properly. Need to parse the wedges!
         int norad = 0;
@@ -288,7 +286,7 @@ namespace noaa_apt
 
             // std::string names[6] = {"1", "2", "3a", "3b", "4", "5"};
             // for (int i = 0; i < 6; i++)
-            //     avhrr_products.images.push_back({"AVHRR-" + names[i] + ".png", names[i], avhrr_reader.getChannel(i)});
+            //     avhrr_products.images.push_back({"AVHRR-" + names[i], names[i], avhrr_reader.getChannel(i)});
 
             if (d_parameters.contains("start_timestamp") && norad != 0)
             {
@@ -318,8 +316,8 @@ namespace noaa_apt
             cha = wip_apt_image_sync.crop_to(86, 86 + 909);
             chb = wip_apt_image_sync.crop_to(1126, 1126 + 909);
 
-            avhrr_products.images.push_back({"APT-A.png", "a", cha});
-            avhrr_products.images.push_back({"APT-B.png", "b", chb});
+            avhrr_products.images.push_back({"APT-A", "a", cha});
+            avhrr_products.images.push_back({"APT-B", "b", chb});
 
             avhrr_products.save(main_dir);
             dataset.products_list.push_back(".");

--- a/plugins/cubesat_support/lucky7/module_lucky7_decoder.cpp
+++ b/plugins/cubesat_support/lucky7/module_lucky7_decoder.cpp
@@ -83,11 +83,8 @@ namespace lucky7
             image::Image<uint8_t> img;
             img.load_jpeg(imgp.second.payload.data(), imgp.second.payload.size());
 
-            std::string name = "Img_" + std::to_string(imgp.first) + ".png";
-
-            logger->info("Saving to " + name);
-
-            img.save_png(directory + "/" + name);
+            std::string name = "Img_" + std::to_string(imgp.first);
+            img.save_img(directory + "/" + name);
         }
     }
 

--- a/plugins/dmsp_support/dmsp/module_dmsp_rtd_instruments.cpp
+++ b/plugins/dmsp_support/dmsp/module_dmsp_rtd_instruments.cpp
@@ -95,8 +95,8 @@ namespace dmsp
             ols_products.has_timestamps = false;
             ols_products.bit_depth = 8;
 
-            ols_products.images.push_back({"OLS-VIS.png", "vis", ols_reader.getChannelVIS().to16bits()});
-            ols_products.images.push_back({"OLS-IR.png", "ir", ols_reader.getChannelIR().to16bits()});
+            ols_products.images.push_back({"OLS-VIS", "vis", ols_reader.getChannelVIS().to16bits()});
+            ols_products.images.push_back({"OLS-IR", "ir", ols_reader.getChannelIR().to16bits()});
 
             ols_products.save(directory);
             dataset.products_list.push_back("OLS");

--- a/plugins/dscovr_support/dscovr/instruments/epic/epic_reader.cpp
+++ b/plugins/dscovr_support/dscovr/instruments/epic/epic_reader.cpp
@@ -36,9 +36,7 @@ namespace dscovr
                     std::string filename(&wip_payload[126], &wip_payload[126 + 8]);
 
                     auto img = image::decompress_jpeg12(wip_payload.data() + pos, wip_payload.size() - 140);
-                    img.save_png(directory + "/" + filename + ".png");
-
-                    logger->info("Saving EPIC image to " + directory + "/" + filename + ".png");
+                    img.save_img(directory + "/" + filename);
 
                     img_c++;
                 }

--- a/plugins/dscovr_support/dscovr/module_dscovr_instruments.cpp
+++ b/plugins/dscovr_support/dscovr/module_dscovr_instruments.cpp
@@ -78,7 +78,7 @@ namespace dscovr
                     int img_cnt = 0;
                     for (auto &img : cips_readers[i].images)
                     {
-                        img.save_png(cips_directory + "/CIPS_" + std::to_string(img_cnt++ + 1) + ".png");
+                        img.save_img(cips_directory + "/CIPS_" + std::to_string(img_cnt++ + 1));
                     }
 
                     cips_status[i] = DONE;

--- a/plugins/elektro_arktika_support/elektro_arktika/instruments/msugs/module_msugs.cpp
+++ b/plugins/elektro_arktika_support/elektro_arktika/instruments/msugs/module_msugs.cpp
@@ -26,7 +26,6 @@ namespace elektro_arktika
             logger->info("Decoding to " + directory);
 
             time_t lastTime = 0;
-            std::string filename;
             uint8_t cadu[1024];
 
             def::SimpleDeframer deframerVIS1(0x0218a7a392dd9abf, 64, 121680, 10, true);
@@ -117,20 +116,17 @@ namespace elektro_arktika
 
             image1.crop(0, 1421, 12008, 1421 + 12008);
             channels_statuses[0] = SAVING;
-            filename = directory + "/MSU-GS-1";
-            WRITE_IMAGE(image1, filename);
+            WRITE_IMAGE(image1, directory + "/MSU-GS-1");
             channels_statuses[0] = DONE;
 
             image2.crop(0, 1421 + 1804, 12008, 1421 + 1804 + 12008);
             channels_statuses[1] = SAVING;
-            filename = directory + "/MSU-GS-2";
-            WRITE_IMAGE(image2, filename);
+            WRITE_IMAGE(image2, directory + "/MSU-GS-2");
             channels_statuses[1] = DONE;
 
             image3.crop(0, 1421 + 3606, 12008, 1421 + 3606 + 12008);
             channels_statuses[2] = SAVING;
-            filename = directory + "/MSU-GS-3";
-            WRITE_IMAGE(image3, filename);
+            WRITE_IMAGE(image3, directory + "/MSU-GS-3");
             channels_statuses[2] = DONE;
 
             for (int i = 0; i < 7; i++)
@@ -140,8 +136,7 @@ namespace elektro_arktika
                 image::Image<uint16_t> img = infr_reader.getImage(i);
                 img.crop(183, 3294);
                 channels_statuses[3 + i] = SAVING;
-                filename = directory + "/MSU-GS-" + std::to_string(i + 4);
-                WRITE_IMAGE(img, filename);
+                WRITE_IMAGE(img, directory + "/MSU-GS-" + std::to_string(i + 4));
                 channels_statuses[3 + i] = DONE;
             }
 
@@ -155,8 +150,7 @@ namespace elektro_arktika
                     image221.draw_image(2, image1, 0, 0);
                 }
                 image221.white_balance();
-                filename = directory + "/MSU-GS-RGB-221";
-                WRITE_IMAGE(image221, filename);
+                WRITE_IMAGE(image221, directory + "/MSU-GS-RGB-221");
             }
 
             logger->info("Natural Color Composite...");
@@ -175,8 +169,7 @@ namespace elektro_arktika
 
                     imageNC.white_balance();
                 }
-                filename = directory + "/MSU-GS-RGB-NC";
-                WRITE_IMAGE(imageNC, filename);
+                WRITE_IMAGE(imageNC, directory + "/MSU-GS-RGB-NC");
             }
             */
         }

--- a/plugins/elektro_arktika_support/elektro_arktika/instruments/msugs/module_msugs.cpp
+++ b/plugins/elektro_arktika_support/elektro_arktika/instruments/msugs/module_msugs.cpp
@@ -26,7 +26,7 @@ namespace elektro_arktika
             logger->info("Decoding to " + directory);
 
             time_t lastTime = 0;
-
+            std::string filename;
             uint8_t cadu[1024];
 
             def::SimpleDeframer deframerVIS1(0x0218a7a392dd9abf, 64, 121680, 10, true);
@@ -117,20 +117,20 @@ namespace elektro_arktika
 
             image1.crop(0, 1421, 12008, 1421 + 12008);
             channels_statuses[0] = SAVING;
-            logger->info("Channel VIS 1...");
-            WRITE_IMAGE(image1, directory + "/MSU-GS-1");
+            filename = directory + "/MSU-GS-1";
+            WRITE_IMAGE(image1, filename);
             channels_statuses[0] = DONE;
 
             image2.crop(0, 1421 + 1804, 12008, 1421 + 1804 + 12008);
             channels_statuses[1] = SAVING;
-            logger->info("Channel VIS 2...");
-            WRITE_IMAGE(image2, directory + "/MSU-GS-2");
+            filename = directory + "/MSU-GS-2";
+            WRITE_IMAGE(image2, filename);
             channels_statuses[1] = DONE;
 
             image3.crop(0, 1421 + 3606, 12008, 1421 + 3606 + 12008);
             channels_statuses[2] = SAVING;
-            logger->info("Channel VIS 3...");
-            WRITE_IMAGE(image3, directory + "/MSU-GS-3");
+            filename = directory + "/MSU-GS-3";
+            WRITE_IMAGE(image3, filename);
             channels_statuses[2] = DONE;
 
             for (int i = 0; i < 7; i++)
@@ -140,7 +140,8 @@ namespace elektro_arktika
                 image::Image<uint16_t> img = infr_reader.getImage(i);
                 img.crop(183, 3294);
                 channels_statuses[3 + i] = SAVING;
-                WRITE_IMAGE(img, directory + "/MSU-GS-" + std::to_string(i + 4));
+                filename = directory + "/MSU-GS-" + std::to_string(i + 4);
+                WRITE_IMAGE(img, filename);
                 channels_statuses[3 + i] = DONE;
             }
 
@@ -154,7 +155,8 @@ namespace elektro_arktika
                     image221.draw_image(2, image1, 0, 0);
                 }
                 image221.white_balance();
-                WRITE_IMAGE(image221, directory + "/MSU-GS-RGB-221");
+                filename = directory + "/MSU-GS-RGB-221";
+                WRITE_IMAGE(image221, filename);
             }
 
             logger->info("Natural Color Composite...");
@@ -173,8 +175,8 @@ namespace elektro_arktika
 
                     imageNC.white_balance();
                 }
-                logger->info("Saving...");
-                WRITE_IMAGE(imageNC, directory + "/MSU-GS-RGB-NC");
+                filename = directory + "/MSU-GS-RGB-NC";
+                WRITE_IMAGE(imageNC, filename);
             }
             */
         }

--- a/plugins/elektro_arktika_support/elektro_arktika/instruments/msugs/module_msugs.cpp
+++ b/plugins/elektro_arktika_support/elektro_arktika/instruments/msugs/module_msugs.cpp
@@ -118,19 +118,19 @@ namespace elektro_arktika
             image1.crop(0, 1421, 12008, 1421 + 12008);
             channels_statuses[0] = SAVING;
             logger->info("Channel VIS 1...");
-            WRITE_IMAGE(image1, directory + "/MSU-GS-1.png");
+            WRITE_IMAGE(image1, directory + "/MSU-GS-1");
             channels_statuses[0] = DONE;
 
             image2.crop(0, 1421 + 1804, 12008, 1421 + 1804 + 12008);
             channels_statuses[1] = SAVING;
             logger->info("Channel VIS 2...");
-            WRITE_IMAGE(image2, directory + "/MSU-GS-2.png");
+            WRITE_IMAGE(image2, directory + "/MSU-GS-2");
             channels_statuses[1] = DONE;
 
             image3.crop(0, 1421 + 3606, 12008, 1421 + 3606 + 12008);
             channels_statuses[2] = SAVING;
             logger->info("Channel VIS 3...");
-            WRITE_IMAGE(image3, directory + "/MSU-GS-3.png");
+            WRITE_IMAGE(image3, directory + "/MSU-GS-3");
             channels_statuses[2] = DONE;
 
             for (int i = 0; i < 7; i++)
@@ -140,7 +140,7 @@ namespace elektro_arktika
                 image::Image<uint16_t> img = infr_reader.getImage(i);
                 img.crop(183, 3294);
                 channels_statuses[3 + i] = SAVING;
-                WRITE_IMAGE(img, directory + "/MSU-GS-" + std::to_string(i + 4) + ".png");
+                WRITE_IMAGE(img, directory + "/MSU-GS-" + std::to_string(i + 4));
                 channels_statuses[3 + i] = DONE;
             }
 
@@ -154,7 +154,7 @@ namespace elektro_arktika
                     image221.draw_image(2, image1, 0, 0);
                 }
                 image221.white_balance();
-                WRITE_IMAGE(image221, directory + "/MSU-GS-RGB-221.png");
+                WRITE_IMAGE(image221, directory + "/MSU-GS-RGB-221");
             }
 
             logger->info("Natural Color Composite...");
@@ -174,7 +174,7 @@ namespace elektro_arktika
                     imageNC.white_balance();
                 }
                 logger->info("Saving...");
-                WRITE_IMAGE(imageNC, directory + "/MSU-GS-RGB-NC.png");
+                WRITE_IMAGE(imageNC, directory + "/MSU-GS-RGB-NC");
             }
             */
         }

--- a/plugins/elektro_arktika_support/elektro_arktika/lrit/data/elektro_221_composer.cpp
+++ b/plugins/elektro_arktika_support/elektro_arktika/lrit/data/elektro_221_composer.cpp
@@ -71,8 +71,7 @@ namespace elektro
         void ELEKTRO221Composer::save(std::string directory)
         {
             imageStatus = SAVING;
-            logger->info("Writing image " + directory + "/IMAGES/" + filename + ".png" + "...");
-            compo221.save_png(std::string(directory + "/IMAGES/" + filename + ".png").c_str());
+            compo221.save_img(std::string(directory + "/IMAGES/" + filename).c_str());
             hasData = false;
             imageStatus = IDLE;
         }

--- a/plugins/elektro_arktika_support/elektro_arktika/lrit/data/elektro_321_composer.cpp
+++ b/plugins/elektro_arktika_support/elektro_arktika/lrit/data/elektro_321_composer.cpp
@@ -100,20 +100,16 @@ namespace elektro
         void ELEKTRO321Composer::save(std::string directory)
         {
             imageStatus = SAVING;
-            logger->info("Writing image " + directory + "/IMAGES/" + filename321 + ".png" + "...");
-            compo321.save_png(std::string(directory + "/IMAGES/" + filename321 + ".png").c_str());
+            compo321.save_img(std::string(directory + "/IMAGES/" + filename321).c_str());
+            compo231.save_img(std::string(directory + "/IMAGES/" + filename231).c_str());
 
-            logger->info("Writing image " + directory + "/IMAGES/" + filename231 + ".png" + "...");
-            compo231.save_png(std::string(directory + "/IMAGES/" + filename231 + ".png").c_str());
-
-            logger->info("Writing image " + directory + "/IMAGES/" + filenameNC + ".png" + "...");
             image::HueSaturation hueTuning;
             hueTuning.hue[image::HUE_RANGE_YELLOW] = -45.0 / 180.0;
             hueTuning.hue[image::HUE_RANGE_RED] = 90.0 / 180.0;
             hueTuning.overlap = 100.0 / 100.0;
             image::hue_saturation(compoNC, hueTuning);
             logger->warn("This natural color composite was originally found by Derek (@dereksgc)!");
-            compoNC.save_png(std::string(directory + "/IMAGES/" + filenameNC + ".png").c_str());
+            compoNC.save_img(std::string(directory + "/IMAGES/" + filenameNC).c_str());
             hasData = false;
             imageStatus = IDLE;
         }

--- a/plugins/elektro_arktika_support/elektro_arktika/lrit/module_elektro_lrit_data_decoder.cpp
+++ b/plugins/elektro_arktika_support/elektro_arktika/lrit/module_elektro_lrit_data_decoder.cpp
@@ -124,13 +124,8 @@ namespace elektro
             data_in.close();
 
             for (auto &segmentedDecoder : segmentedDecoders)
-            {
                 if (segmentedDecoder.second.image_id != "")
-                {
-                    logger->info("Writing image " + directory + "/IMAGES/" + segmentedDecoder.second.image_id + ".png" + "...");
-                    segmentedDecoder.second.image.save_png(std::string(directory + "/IMAGES/" + segmentedDecoder.second.image_id + ".png").c_str());
-                }
-            }
+                    segmentedDecoder.second.image.save_img(std::string(directory + "/IMAGES/" + segmentedDecoder.second.image_id).c_str());
 
             if (elektro_221_composer_full_disk->hasData)
                 elektro_221_composer_full_disk->save(directory);

--- a/plugins/elektro_arktika_support/elektro_arktika/lrit/module_elektro_lrit_data_decoder_proc.cpp
+++ b/plugins/elektro_arktika_support/elektro_arktika/lrit/module_elektro_lrit_data_decoder_proc.cpp
@@ -251,8 +251,7 @@ namespace elektro
                             current_filename = image_id;
 
                             wip_img->imageStatus = SAVING;
-                            logger->info("Writing image " + directory + "/IMAGES/" + current_filename + ".png" + "...");
-                            segmentedDecoder.image.save_png(std::string(directory + "/IMAGES/" + current_filename + ".png").c_str());
+                            segmentedDecoder.image.save_img(std::string(directory + "/IMAGES/" + current_filename).c_str());
 
                             if (elektro_221_composer_full_disk->hasData)
                                 elektro_221_composer_full_disk->save(directory);
@@ -304,8 +303,7 @@ namespace elektro
                         current_filename = image_id;
 
                         wip_img->imageStatus = SAVING;
-                        logger->info("Writing image " + directory + "/IMAGES/" + current_filename + ".png" + "...");
-                        segmentedDecoder.image.save_png(std::string(directory + "/IMAGES/" + current_filename + ".png").c_str());
+                        segmentedDecoder.image.save_img(std::string(directory + "/IMAGES/" + current_filename).c_str());
 
                         if (elektro_221_composer_full_disk->hasData)
                             elektro_221_composer_full_disk->save(directory);
@@ -319,9 +317,8 @@ namespace elektro
                 else
                 {
                     // Write raw image dats
-                    logger->info("Writing image " + directory + "/IMAGES/" + current_filename + ".png" + "...");
                     image::Image<uint8_t> image(&file.lrit_data[primary_header.total_header_length], image_structure_record.columns_count, image_structure_record.lines_count, 1);
-                    image.save_png(std::string(directory + "/IMAGES/" + current_filename + ".png").c_str());
+                    image.save_img(std::string(directory + "/IMAGES/" + current_filename).c_str());
                 }
             }
             else

--- a/plugins/eos_support/eos/module_eos_instruments.cpp
+++ b/plugins/eos_support/eos/module_eos_instruments.cpp
@@ -324,19 +324,19 @@ namespace eos
                 logger->info("Lines (FM4) : " + std::to_string(ceres_fm4_reader.lines));
 
                 logger->info("Shortwave Channel 1...");
-                WRITE_IMAGE(ceres_fm3_reader.getImage(0), directory + "/CERES1-SHORTWAVE.png");
+                WRITE_IMAGE(ceres_fm3_reader.getImage(0), directory + "/CERES1-SHORTWAVE");
                 logger->info("Longwave Channel 1...");
-                WRITE_IMAGE(ceres_fm3_reader.getImage(1), directory + "/CERES1-LONGWAVE.png");
+                WRITE_IMAGE(ceres_fm3_reader.getImage(1), directory + "/CERES1-LONGWAVE");
                 logger->info("Total Channel 1...");
-                WRITE_IMAGE(ceres_fm3_reader.getImage(2), directory + "/CERES1-TOTAL.png");
+                WRITE_IMAGE(ceres_fm3_reader.getImage(2), directory + "/CERES1-TOTAL");
                 ceres_fm3_status = DONE;
 
                 logger->info("Shortwave Channel 2...");
-                WRITE_IMAGE(ceres_fm4_reader.getImage(0), directory + "/CERES2-SHORTWAVE.png");
+                WRITE_IMAGE(ceres_fm4_reader.getImage(0), directory + "/CERES2-SHORTWAVE");
                 logger->info("Longwave Channel 2...");
-                WRITE_IMAGE(ceres_fm4_reader.getImage(1), directory + "/CERES2-LONGWAVE.png");
+                WRITE_IMAGE(ceres_fm4_reader.getImage(1), directory + "/CERES2-LONGWAVE");
                 logger->info("Total Channel 2...");
-                WRITE_IMAGE(ceres_fm4_reader.getImage(2), directory + "/CERES2-TOTAL.png");
+                WRITE_IMAGE(ceres_fm4_reader.getImage(2), directory + "/CERES2-TOTAL");
                 ceres_fm4_status = DONE;
             }
 
@@ -352,18 +352,18 @@ namespace eos
                 logger->info("Lines (UV) : " + std::to_string(omi_1_reader.lines));
                 logger->info("Lines (VIS) : " + std::to_string(omi_2_reader.lines));
 
-                WRITE_IMAGE(omi_1_reader.getImageRaw(), directory + "/OMI-1.png");
-                WRITE_IMAGE(omi_2_reader.getImageRaw(), directory + "/OMI-2.png");
+                WRITE_IMAGE(omi_1_reader.getImageRaw(), directory + "/OMI-1");
+                WRITE_IMAGE(omi_2_reader.getImageRaw(), directory + "/OMI-2");
 
-                WRITE_IMAGE(omi_1_reader.getImageVisible(), directory + "/OMI-VIS-1.png");
-                WRITE_IMAGE(omi_2_reader.getImageVisible(), directory + "/OMI-VIS-2.png");
+                WRITE_IMAGE(omi_1_reader.getImageVisible(), directory + "/OMI-VIS-1");
+                WRITE_IMAGE(omi_2_reader.getImageVisible(), directory + "/OMI-VIS-2");
 
                 image::Image<uint16_t> imageAll1 = image::make_manyimg_composite<uint16_t>(33, 24, 792, [this](int c)
                                                                                            { return omi_1_reader.getChannel(c); });
                 image::Image<uint16_t> imageAll2 = image::make_manyimg_composite<uint16_t>(33, 24, 792, [this](int c)
                                                                                            { return omi_2_reader.getChannel(c); });
-                WRITE_IMAGE(imageAll1, directory + "/OMI-ALL-1.png");
-                WRITE_IMAGE(imageAll2, directory + "/OMI-ALL-2.png");
+                WRITE_IMAGE(imageAll1, directory + "/OMI-ALL-1");
+                WRITE_IMAGE(imageAll2, directory + "/OMI-ALL-2");
                 omi_status = DONE;
             }
 

--- a/plugins/eos_support/eos/module_eos_instruments.cpp
+++ b/plugins/eos_support/eos/module_eos_instruments.cpp
@@ -39,6 +39,7 @@ namespace eos
             logger->info("Using input frames " + d_input_file);
 
             time_t lastTime = 0;
+            std::string filename;
             uint8_t cadu[1024];
 
             // Demuxers
@@ -323,20 +324,20 @@ namespace eos
                 logger->info("Lines (FM3) : " + std::to_string(ceres_fm3_reader.lines));
                 logger->info("Lines (FM4) : " + std::to_string(ceres_fm4_reader.lines));
 
-                logger->info("Shortwave Channel 1...");
-                WRITE_IMAGE(ceres_fm3_reader.getImage(0), directory + "/CERES1-SHORTWAVE");
-                logger->info("Longwave Channel 1...");
-                WRITE_IMAGE(ceres_fm3_reader.getImage(1), directory + "/CERES1-LONGWAVE");
-                logger->info("Total Channel 1...");
-                WRITE_IMAGE(ceres_fm3_reader.getImage(2), directory + "/CERES1-TOTAL");
+                filename = directory + "/CERES1-SHORTWAVE";
+                WRITE_IMAGE(ceres_fm3_reader.getImage(0), filename);
+                filename = directory + "/CERES1-LONGWAVE";
+                WRITE_IMAGE(ceres_fm3_reader.getImage(1), filename);
+                filename = directory + "/CERES1-TOTAL";
+                WRITE_IMAGE(ceres_fm3_reader.getImage(2), filename);
                 ceres_fm3_status = DONE;
 
-                logger->info("Shortwave Channel 2...");
-                WRITE_IMAGE(ceres_fm4_reader.getImage(0), directory + "/CERES2-SHORTWAVE");
-                logger->info("Longwave Channel 2...");
-                WRITE_IMAGE(ceres_fm4_reader.getImage(1), directory + "/CERES2-LONGWAVE");
-                logger->info("Total Channel 2...");
-                WRITE_IMAGE(ceres_fm4_reader.getImage(2), directory + "/CERES2-TOTAL");
+                filename = directory + "/CERES2-SHORTWAVE";
+                WRITE_IMAGE(ceres_fm4_reader.getImage(0), filename);
+                filename = directory + "/CERES2-LONGWAVE";
+                WRITE_IMAGE(ceres_fm4_reader.getImage(1), filename);
+                filename = directory + "/CERES2-TOTAL";
+                WRITE_IMAGE(ceres_fm4_reader.getImage(2), filename);
                 ceres_fm4_status = DONE;
             }
 
@@ -352,18 +353,24 @@ namespace eos
                 logger->info("Lines (UV) : " + std::to_string(omi_1_reader.lines));
                 logger->info("Lines (VIS) : " + std::to_string(omi_2_reader.lines));
 
-                WRITE_IMAGE(omi_1_reader.getImageRaw(), directory + "/OMI-1");
-                WRITE_IMAGE(omi_2_reader.getImageRaw(), directory + "/OMI-2");
+                filename = directory + "/OMI-1";
+                WRITE_IMAGE(omi_1_reader.getImageRaw(), filename);
+                filename = directory + "/OMI-2";
+                WRITE_IMAGE(omi_2_reader.getImageRaw(), filename);
 
-                WRITE_IMAGE(omi_1_reader.getImageVisible(), directory + "/OMI-VIS-1");
-                WRITE_IMAGE(omi_2_reader.getImageVisible(), directory + "/OMI-VIS-2");
+                filename = directory + "/OMI-VIS-1";
+                WRITE_IMAGE(omi_1_reader.getImageVisible(), filename);
+                filename = directory + "/OMI-VIS-2";
+                WRITE_IMAGE(omi_2_reader.getImageVisible(), filename);
 
                 image::Image<uint16_t> imageAll1 = image::make_manyimg_composite<uint16_t>(33, 24, 792, [this](int c)
                                                                                            { return omi_1_reader.getChannel(c); });
                 image::Image<uint16_t> imageAll2 = image::make_manyimg_composite<uint16_t>(33, 24, 792, [this](int c)
                                                                                            { return omi_2_reader.getChannel(c); });
-                WRITE_IMAGE(imageAll1, directory + "/OMI-ALL-1");
-                WRITE_IMAGE(imageAll2, directory + "/OMI-ALL-2");
+                filename = directory + "/OMI-ALL-1";
+                WRITE_IMAGE(imageAll1, filename);
+                filename = directory + "/OMI-ALL-2";
+                WRITE_IMAGE(imageAll2, filename);
                 omi_status = DONE;
             }
 

--- a/plugins/eos_support/eos/module_eos_instruments.cpp
+++ b/plugins/eos_support/eos/module_eos_instruments.cpp
@@ -39,7 +39,6 @@ namespace eos
             logger->info("Using input frames " + d_input_file);
 
             time_t lastTime = 0;
-            std::string filename;
             uint8_t cadu[1024];
 
             // Demuxers
@@ -324,20 +323,14 @@ namespace eos
                 logger->info("Lines (FM3) : " + std::to_string(ceres_fm3_reader.lines));
                 logger->info("Lines (FM4) : " + std::to_string(ceres_fm4_reader.lines));
 
-                filename = directory + "/CERES1-SHORTWAVE";
-                WRITE_IMAGE(ceres_fm3_reader.getImage(0), filename);
-                filename = directory + "/CERES1-LONGWAVE";
-                WRITE_IMAGE(ceres_fm3_reader.getImage(1), filename);
-                filename = directory + "/CERES1-TOTAL";
-                WRITE_IMAGE(ceres_fm3_reader.getImage(2), filename);
+                WRITE_IMAGE(ceres_fm3_reader.getImage(0), directory + "/CERES1-SHORTWAVE");
+                WRITE_IMAGE(ceres_fm3_reader.getImage(1), directory + "/CERES1-LONGWAVE");
+                WRITE_IMAGE(ceres_fm3_reader.getImage(2), directory + "/CERES1-TOTAL");
                 ceres_fm3_status = DONE;
 
-                filename = directory + "/CERES2-SHORTWAVE";
-                WRITE_IMAGE(ceres_fm4_reader.getImage(0), filename);
-                filename = directory + "/CERES2-LONGWAVE";
-                WRITE_IMAGE(ceres_fm4_reader.getImage(1), filename);
-                filename = directory + "/CERES2-TOTAL";
-                WRITE_IMAGE(ceres_fm4_reader.getImage(2), filename);
+                WRITE_IMAGE(ceres_fm4_reader.getImage(0), directory + "/CERES2-SHORTWAVE");
+                WRITE_IMAGE(ceres_fm4_reader.getImage(1), directory + "/CERES2-LONGWAVE");
+                WRITE_IMAGE(ceres_fm4_reader.getImage(2), directory + "/CERES2-TOTAL");
                 ceres_fm4_status = DONE;
             }
 
@@ -353,24 +346,18 @@ namespace eos
                 logger->info("Lines (UV) : " + std::to_string(omi_1_reader.lines));
                 logger->info("Lines (VIS) : " + std::to_string(omi_2_reader.lines));
 
-                filename = directory + "/OMI-1";
-                WRITE_IMAGE(omi_1_reader.getImageRaw(), filename);
-                filename = directory + "/OMI-2";
-                WRITE_IMAGE(omi_2_reader.getImageRaw(), filename);
+                WRITE_IMAGE(omi_1_reader.getImageRaw(), directory + "/OMI-1");
+                WRITE_IMAGE(omi_2_reader.getImageRaw(), directory + "/OMI-2");
 
-                filename = directory + "/OMI-VIS-1";
-                WRITE_IMAGE(omi_1_reader.getImageVisible(), filename);
-                filename = directory + "/OMI-VIS-2";
-                WRITE_IMAGE(omi_2_reader.getImageVisible(), filename);
+                WRITE_IMAGE(omi_1_reader.getImageVisible(), directory + "/OMI-VIS-1");
+                WRITE_IMAGE(omi_2_reader.getImageVisible(), directory + "/OMI-VIS-2");
 
                 image::Image<uint16_t> imageAll1 = image::make_manyimg_composite<uint16_t>(33, 24, 792, [this](int c)
                                                                                            { return omi_1_reader.getChannel(c); });
                 image::Image<uint16_t> imageAll2 = image::make_manyimg_composite<uint16_t>(33, 24, 792, [this](int c)
                                                                                            { return omi_2_reader.getChannel(c); });
-                filename = directory + "/OMI-ALL-1";
-                WRITE_IMAGE(imageAll1, filename);
-                filename = directory + "/OMI-ALL-2";
-                WRITE_IMAGE(imageAll2, filename);
+                WRITE_IMAGE(imageAll1, directory + "/OMI-ALL-1");
+                WRITE_IMAGE(imageAll2, directory + "/OMI-ALL-2");
                 omi_status = DONE;
             }
 

--- a/plugins/eos_support/eos/module_eos_instruments.cpp
+++ b/plugins/eos_support/eos/module_eos_instruments.cpp
@@ -194,7 +194,7 @@ namespace eos
                     image::Image<uint16_t> image = modis_reader.getImage250m(i);
                     if (d_modis_bowtie)
                         image = image::bowtie::correctGenericBowTie(image, 1, scanHeight_250, alpha, beta);
-                    modis_products.images.push_back({"MODIS-" + std::to_string(i + 1) + ".png", std::to_string(i + 1), image});
+                    modis_products.images.push_back({"MODIS-" + std::to_string(i + 1), std::to_string(i + 1), image});
                 }
 
                 for (int i = 0; i < 5; i++)
@@ -202,7 +202,7 @@ namespace eos
                     image::Image<uint16_t> image = modis_reader.getImage500m(i);
                     if (d_modis_bowtie)
                         image = image::bowtie::correctGenericBowTie(image, 1, scanHeight_500, alpha, beta);
-                    modis_products.images.push_back({"MODIS-" + std::to_string(i + 3) + ".png", std::to_string(i + 3), image});
+                    modis_products.images.push_back({"MODIS-" + std::to_string(i + 3), std::to_string(i + 3), image});
                 }
 
                 for (int i = 0; i < 31; i++)
@@ -213,17 +213,17 @@ namespace eos
                         image = image::bowtie::correctGenericBowTie(image, 1, scanHeight_1000, alpha, beta);
 
                     if (i < 5)
-                        modis_products.images.push_back({"MODIS-" + std::to_string(i + 8) + ".png", std::to_string(i + 8), image});
+                        modis_products.images.push_back({"MODIS-" + std::to_string(i + 8), std::to_string(i + 8), image});
                     else if (i == 5)
-                        modis_products.images.push_back({"MODIS-13L.png", "13L", image});
+                        modis_products.images.push_back({"MODIS-13L", "13L", image});
                     else if (i == 6)
-                        modis_products.images.push_back({"MODIS-13H.png", "13H", image});
+                        modis_products.images.push_back({"MODIS-13H", "13H", image});
                     else if (i == 7)
-                        modis_products.images.push_back({"MODIS-14L.png", "13L", image});
+                        modis_products.images.push_back({"MODIS-14L", "13L", image});
                     else if (i == 8)
-                        modis_products.images.push_back({"MODIS-14H.png", "14H", image});
+                        modis_products.images.push_back({"MODIS-14H", "14H", image});
                     else
-                        modis_products.images.push_back({"MODIS-" + std::to_string(i + 6) + ".png", std::to_string(i + 6), image});
+                        modis_products.images.push_back({"MODIS-" + std::to_string(i + 6), std::to_string(i + 6), image});
                 }
 
                 modis_products.save(directory);
@@ -255,7 +255,7 @@ namespace eos
                 // airs_hd_products.set_timestamps(airs_reader.timestamps_ifov);
 
                 for (int i = 0; i < 4; i++)
-                    airs_hd_products.images.push_back({"AIRS-HD-" + std::to_string(i + 1) + ".png", std::to_string(i + 1), airs_reader.getHDChannel(i)});
+                    airs_hd_products.images.push_back({"AIRS-HD-" + std::to_string(i + 1), std::to_string(i + 1), airs_reader.getHDChannel(i)});
 
                 airs_hd_products.save(directory_hd);
                 dataset.products_list.push_back("AIRS/HD");
@@ -270,7 +270,7 @@ namespace eos
                 // airs_products.set_timestamps(airs_reader.timestamps_ifov);
 
                 for (int i = 0; i < 2666; i++)
-                    airs_products.images.push_back({"AIRS-" + std::to_string(i + 1) + ".png", std::to_string(i + 1), airs_reader.getChannel(i)});
+                    airs_products.images.push_back({"AIRS-" + std::to_string(i + 1), std::to_string(i + 1), airs_reader.getChannel(i)});
 
                 airs_products.save(directory);
                 dataset.products_list.push_back("AIRS");
@@ -300,10 +300,10 @@ namespace eos
                 amsu_products.set_proj_cfg(loadJsonFile(resources::getResourcePath("projections_settings/aqua_amsu.json")));
 
                 for (int i = 0; i < 2; i++)
-                    amsu_products.images.push_back({"AMSU-A2-" + std::to_string(i + 1) + ".png", std::to_string(i + 1), amsu_a2_reader.getChannel(i), amsu_a2_reader.timestamps});
+                    amsu_products.images.push_back({"AMSU-A2-" + std::to_string(i + 1), std::to_string(i + 1), amsu_a2_reader.getChannel(i), amsu_a2_reader.timestamps});
 
                 for (int i = 0; i < 13; i++)
-                    amsu_products.images.push_back({"AMSU-A1-" + std::to_string(i + 1) + ".png", std::to_string(i + 3), amsu_a1_reader.getChannel(i), amsu_a1_reader.timestamps});
+                    amsu_products.images.push_back({"AMSU-A1-" + std::to_string(i + 1), std::to_string(i + 3), amsu_a1_reader.getChannel(i), amsu_a1_reader.timestamps});
 
                 amsu_products.save(directory);
                 dataset.products_list.push_back("AMSU");

--- a/plugins/fengyun2_support/fengyun2/svissr/module_svissr_image_decoder.cpp
+++ b/plugins/fengyun2_support/fengyun2/svissr/module_svissr_image_decoder.cpp
@@ -46,20 +46,11 @@ namespace fengyun_svissr
 
         std::string disk_folder = buffer.directory + "/" + timestamp;
 
-        logger->info("Channel 1... " + getSvissrFilename(timeReadable, "1") + ".png");
-        buffer.image5.save_png(std::string(disk_folder + "/" + getSvissrFilename(timeReadable, "1") + ".png").c_str());
-
-        logger->info("Channel 2... " + getSvissrFilename(timeReadable, "2") + ".png");
-        buffer.image1.save_png(std::string(disk_folder + "/" + getSvissrFilename(timeReadable, "2") + ".png").c_str());
-
-        logger->info("Channel 3... " + getSvissrFilename(timeReadable, "3") + ".png");
-        buffer.image2.save_png(std::string(disk_folder + "/" + getSvissrFilename(timeReadable, "3") + ".png").c_str());
-
-        logger->info("Channel 4... " + getSvissrFilename(timeReadable, "4") + ".png");
-        buffer.image3.save_png(std::string(disk_folder + "/" + getSvissrFilename(timeReadable, "4") + ".png").c_str());
-
-        logger->info("Channel 5... " + getSvissrFilename(timeReadable, "5") + ".png");
-        buffer.image4.save_png(std::string(disk_folder + "/" + getSvissrFilename(timeReadable, "5") + ".png").c_str());
+        buffer.image5.save_img(std::string(disk_folder + "/" + getSvissrFilename(timeReadable, "1")).c_str());
+        buffer.image1.save_img(std::string(disk_folder + "/" + getSvissrFilename(timeReadable, "2")).c_str());
+        buffer.image2.save_img(std::string(disk_folder + "/" + getSvissrFilename(timeReadable, "3")).c_str());
+        buffer.image3.save_img(std::string(disk_folder + "/" + getSvissrFilename(timeReadable, "4")).c_str());
+        buffer.image4.save_img(std::string(disk_folder + "/" + getSvissrFilename(timeReadable, "5")).c_str());
 
         // We are done with all channels but 1 and 4. Clear others to free up memory!
         buffer.image1.clear();
@@ -101,8 +92,7 @@ namespace fengyun_svissr
                     compoImage[c * compoImage.width() * compoImage.height() + i] = lutImage[c * lutImage.width() * lutImage.height() + x * lutImage.width() + y];
             }
 
-            logger->info("False color... " + getSvissrFilename(timeReadable, "FC") + ".png");
-            compoImage.save_png(std::string(disk_folder + "/" + getSvissrFilename(timeReadable, "FC") + ".png").c_str());
+            compoImage.save_img(std::string(disk_folder + "/" + getSvissrFilename(timeReadable, "FC")).c_str());
         }
         else
         {

--- a/plugins/fengyun3_support/fengyun3/instruments/pmr/pmr_reader.cpp
+++ b/plugins/fengyun3_support/fengyun3/instruments/pmr/pmr_reader.cpp
@@ -16,10 +16,9 @@ namespace fengyun3
 
         void PMRReader::writeCurrent()
         {
-            logger->info("Saving PMR image to " + directory + "/PMR_" + std::to_string(images_count++ + 1) + ".png");
             // image.equalize();
             // image.normalize();
-            image.save_png(std::string(directory + "/PMR_" + std::to_string(images_count + 1) + ".png").c_str());
+            image.save_img(std::string(directory + "/PMR_" + std::to_string(images_count + 1)).c_str());
             image.fill(0);
         }
 

--- a/plugins/fengyun3_support/fengyun3/instruments/wai/wai_reader.cpp
+++ b/plugins/fengyun3_support/fengyun3/instruments/wai/wai_reader.cpp
@@ -17,8 +17,7 @@ namespace fengyun3
 
         void WAIReader::writeCurrent()
         {
-            image.save_png(std::string(directory + "/WAI_" + std::to_string(images_count++ + 1) + ".png").c_str());
-            logger->info("Saving WAI image to" + directory + "/WAI_" + std::to_string(images_count++ + 1) + ".png");
+            image.save_img(std::string(directory + "/WAI_" + std::to_string(images_count++ + 1)).c_str());
             image = image::Image<uint16_t>(832, 832, 1);
 
             lines = 0;

--- a/plugins/fengyun3_support/fengyun3/instruments/windrad/windrad_reader.cpp
+++ b/plugins/fengyun3_support/fengyun3/instruments/windrad/windrad_reader.cpp
@@ -34,20 +34,13 @@ namespace fengyun3
                 if (lastMarker2 == 21)
                 {
                     imgCount++;
-
-                    logger->info("Channel 1...");
-                    getChannel(0).save_png(std::string(directory + "/WindRAD-Pol1-" + band + "-" + std::to_string(imgCount) + ".png").c_str());
-
-                    logger->info("Channel 2...");
-                    getChannel(1).save_png(std::string(directory + "/WindRAD-Pol2-" + band + "-" + std::to_string(imgCount) + ".png").c_str());
+                    getChannel(0).save_img(std::string(directory + "/WindRAD-Pol1-" + band + "-" + std::to_string(imgCount)).c_str());
+                    getChannel(1).save_img(std::string(directory + "/WindRAD-Pol2-" + band + "-" + std::to_string(imgCount)).c_str());
                 }
                 else
                 {
-                    logger->info("Channel 1...");
-                    getChannel(0).save_png(std::string(directory + "/WindRAD-Pol3-" + band + "-" + std::to_string(imgCount) + ".png").c_str());
-
-                    logger->info("Channel 2...");
-                    getChannel(1).save_png(std::string(directory + "/WindRAD-Pol4-" + band + "-" + std::to_string(imgCount) + ".png").c_str());
+                    getChannel(0).save_img(std::string(directory + "/WindRAD-Pol3-" + band + "-" + std::to_string(imgCount)).c_str());
+                    getChannel(1).save_img(std::string(directory + "/WindRAD-Pol4-" + band + "-" + std::to_string(imgCount)).c_str());
                 }
 
                 lines = 0;

--- a/plugins/fengyun3_support/fengyun3/instruments/xeuvi/xeuvi_reader.cpp
+++ b/plugins/fengyun3_support/fengyun3/instruments/xeuvi/xeuvi_reader.cpp
@@ -16,8 +16,7 @@ namespace fengyun3
 
         void XEUVIReader::writeCurrent()
         {
-            logger->info("Saving XEUVI image to " + directory + "/XEUVI_" + std::to_string(images_count++ + 1) + ".png");
-            image.save_png(std::string(directory + "/XEUVI_" + std::to_string(images_count + 1) + ".png").c_str());
+            image.save_img(std::string(directory + "/XEUVI_" + std::to_string(images_count + 1)).c_str());
             image.fill(0);
         }
 

--- a/plugins/fengyun3_support/fengyun3/module_fy3_instruments.cpp
+++ b/plugins/fengyun3_support/fengyun3/module_fy3_instruments.cpp
@@ -491,7 +491,7 @@ namespace fengyun3
                 mwhs1_products.set_proj_cfg(loadJsonFile(resources::getResourcePath("projections_settings/fengyun_ab_mwhs1.json")));
 
                 for (int i = 0; i < 5; i++)
-                    mwhs1_products.images.push_back({"MWHS1-" + std::to_string(i + 1) + ".png", std::to_string(i + 1), mwhs1_reader.getChannel(i)});
+                    mwhs1_products.images.push_back({"MWHS1-" + std::to_string(i + 1), std::to_string(i + 1), mwhs1_reader.getChannel(i)});
 
                 mwhs1_products.set_timestamps(mwhs1_reader.timestamps);
 
@@ -521,7 +521,7 @@ namespace fengyun3
                 mwhs2_products.set_proj_cfg(loadJsonFile(resources::getResourcePath("projections_settings/fengyun_cde_mwhs2.json")));
 
                 for (int i = 0; i < 15; i++)
-                    mwhs2_products.images.push_back({"MWHS2-" + std::to_string(i + 1) + ".png", std::to_string(i + 1), mwhs2_reader.getChannel(i)});
+                    mwhs2_products.images.push_back({"MWHS2-" + std::to_string(i + 1), std::to_string(i + 1), mwhs2_reader.getChannel(i)});
 
                 mwhs2_products.set_timestamps(mwhs2_reader.timestamps);
 
@@ -551,7 +551,7 @@ namespace fengyun3
                 virr_products.set_proj_cfg(loadJsonFile(resources::getResourcePath("projections_settings/fengyun_abc_virr.json")));
 
                 for (int i = 0; i < 10; i++)
-                    virr_products.images.push_back({"VIRR-" + std::to_string(i + 1) + ".png", std::to_string(i + 1), virr_reader.getChannel(i)});
+                    virr_products.images.push_back({"VIRR-" + std::to_string(i + 1), std::to_string(i + 1), virr_reader.getChannel(i)});
 
                 int timestamp_offset = 0;
                 if (scid == FY3_A_SCID)
@@ -635,12 +635,12 @@ namespace fengyun3
                         mersi::mersi_match_detector_histograms(image, i < 5 ? 40 : 10);
                     if (d_mersi_bowtie)
                         image = image::bowtie::correctGenericBowTie(image, 1, i < 5 ? scanHeight_250 : scanHeight_1000, alpha, beta);
-                    mersi1_products.images.push_back({"MERSI1-" + std::to_string(i + 1) + ".png", std::to_string(i + 1), image, {}, -1, -1, offset[i]});
+                    mersi1_products.images.push_back({"MERSI1-" + std::to_string(i + 1), std::to_string(i + 1), image, {}, -1, -1, offset[i]});
                 }
 
                 // virr_products.set_timestamps(mwts2_reader.timestamps);
 
-                // mersi2_reader.getChannel(-1).save_png(directory + "/calib.png");
+                // mersi2_reader.getChannel(-1).save_img(directory + "/calib");
 
                 mersi1_status = SAVING;
 
@@ -714,10 +714,10 @@ namespace fengyun3
                         mersi::mersi_match_detector_histograms(image, (i == 4 || i == 5) ? 80 : (i < 6 ? 40 : 10));
                     if (d_mersi_bowtie)
                         image = image::bowtie::correctGenericBowTie(image, 1, i < 6 ? scanHeight_250 : scanHeight_1000, alpha, beta);
-                    mersi2_products.images.push_back({"MERSI2-" + std::to_string(i + 1) + ".png", std::to_string(i + 1), image, {}, -1, -1, offset[i]});
+                    mersi2_products.images.push_back({"MERSI2-" + std::to_string(i + 1), std::to_string(i + 1), image, {}, -1, -1, offset[i]});
                 }
 
-                // mersi2_reader.getChannel(-1).save_png(directory + "/calib.png");
+                // mersi2_reader.getChannel(-1).save_img(directory + "/calib");
 
                 mersi2_status = SAVING;
 
@@ -786,10 +786,10 @@ namespace fengyun3
                         mersi::mersi_offset_interleaved(image, 40, -3);
                     if (d_mersi_bowtie)
                         image = image::bowtie::correctGenericBowTie(image, 1, i < 2 ? scanHeight_250 : scanHeight_1000, alpha, beta);
-                    mersill_products.images.push_back({"MERSILL-" + std::to_string(i + 1) + ".png", std::to_string(i + 1), image, {}, -1, -1, offset[i]});
+                    mersill_products.images.push_back({"MERSILL-" + std::to_string(i + 1), std::to_string(i + 1), image, {}, -1, -1, offset[i]});
                 }
 
-                // mersill_reader.getChannel(-1).save_png(directory + "/calib.png");
+                // mersill_reader.getChannel(-1).save_img(directory + "/calib");
 
                 mersill_status = SAVING;
 
@@ -864,10 +864,10 @@ namespace fengyun3
                         image.mirror(true, false);
                     }
 
-                    mersirm_products.images.push_back({"MERSIRM-" + std::to_string(i + 1) + ".png", std::to_string(i + 1), image, {}, -1, -1, offset[i]});
+                    mersirm_products.images.push_back({"MERSIRM-" + std::to_string(i + 1), std::to_string(i + 1), image, {}, -1, -1, offset[i]});
                 }
 
-                // mersirm_reader.getChannel(-1).save_png(directory + "/calib.png");
+                // mersirm_reader.getChannel(-1).save_img(directory + "/calib");
 
                 mersirm_status = SAVING;
 
@@ -898,7 +898,7 @@ namespace fengyun3
                 mwri_products.set_proj_cfg(loadJsonFile(resources::getResourcePath("projections_settings/fengyun_abcd_mwri1.json")));
 
                 for (int i = 0; i < 10; i++)
-                    mwri_products.images.push_back({"MWRI-" + std::to_string(i + 1) + ".png", std::to_string(i + 1), mwri_reader.getChannel(i)});
+                    mwri_products.images.push_back({"MWRI-" + std::to_string(i + 1), std::to_string(i + 1), mwri_reader.getChannel(i)});
 
                 mwri_products.save(directory);
                 dataset.products_list.push_back("MWRI");
@@ -927,7 +927,7 @@ namespace fengyun3
                 mwrirm_produducts.set_proj_cfg(loadJsonFile(resources::getResourcePath("projections_settings/fengyun_g_mwrirm.json")));
 
                 for (int i = 0; i < 26; i++)
-                    mwrirm_produducts.images.push_back({"MWRIRM-" + std::to_string(i + 1) + ".png", std::to_string(i + 1), mwrirm_reader.getChannel(i)});
+                    mwrirm_produducts.images.push_back({"MWRIRM-" + std::to_string(i + 1), std::to_string(i + 1), mwrirm_reader.getChannel(i)});
 
                 mwrirm_produducts.save(directory);
                 dataset.products_list.push_back("MWRI-RM");
@@ -957,7 +957,7 @@ namespace fengyun3
                 logger->info("----------- GAS");
                 logger->info("Lines : " + std::to_string(gas_reader.lines));
 
-                gas_reader.getChannel().save_png(directory + "/GAS.png");
+                gas_reader.getChannel().save_img(directory + "/GAS");
 
                 gas_status = DONE;
             }
@@ -981,7 +981,7 @@ namespace fengyun3
                 erm_products.timestamp_type = satdump::ImageProducts::TIMESTAMP_LINE;
                 erm_products.set_proj_cfg(loadJsonFile(resources::getResourcePath("projections_settings/fengyun_abc_erm.json")));
 
-                erm_products.images.push_back({"ERM-1.png", "1", erm_reader.getChannel()});
+                erm_products.images.push_back({"ERM-1", "1", erm_reader.getChannel()});
 
                 erm_products.set_timestamps(erm_reader.timestamps);
 
@@ -1011,7 +1011,7 @@ namespace fengyun3
                 mwts1_products.set_proj_cfg(loadJsonFile(resources::getResourcePath("projections_settings/fengyun_ab_mwts1.json")));
 
                 for (int i = 0; i < 27; i++)
-                    mwts1_products.images.push_back({"MWTS1-" + std::to_string(i + 1) + ".png", std::to_string(i + 1), mwts1_reader.getChannel(i)});
+                    mwts1_products.images.push_back({"MWTS1-" + std::to_string(i + 1), std::to_string(i + 1), mwts1_reader.getChannel(i)});
 
                 mwts1_products.set_timestamps(mwts2_reader.timestamps);
 
@@ -1041,7 +1041,7 @@ namespace fengyun3
                 mwts2_products.set_proj_cfg(loadJsonFile(resources::getResourcePath("projections_settings/fengyun_d_mwts2.json")));
 
                 for (int i = 0; i < 18; i++)
-                    mwts2_products.images.push_back({"MWTS2-" + std::to_string(i + 1) + ".png", std::to_string(i + 1), mwts2_reader.getChannel(i)});
+                    mwts2_products.images.push_back({"MWTS2-" + std::to_string(i + 1), std::to_string(i + 1), mwts2_reader.getChannel(i)});
 
                 mwts2_products.set_timestamps(mwts2_reader.timestamps);
 
@@ -1071,7 +1071,7 @@ namespace fengyun3
                 mwts3_products.set_proj_cfg(loadJsonFile(resources::getResourcePath("projections_settings/fengyun_e_mwts3.json")));
 
                 for (int i = 0; i < 18; i++)
-                    mwts3_products.images.push_back({"MWTS3-" + std::to_string(i + 1) + ".png", std::to_string(i + 1), mwts3_reader.getChannel(i)});
+                    mwts3_products.images.push_back({"MWTS3-" + std::to_string(i + 1), std::to_string(i + 1), mwts3_reader.getChannel(i)});
 
                 mwts3_products.set_timestamps(mwts3_reader.timestamps);
 

--- a/plugins/fengyun4_support/fy4/module_fy4_lrit_data_decoder.cpp
+++ b/plugins/fengyun4_support/fy4/module_fy4_lrit_data_decoder.cpp
@@ -183,13 +183,8 @@ namespace fy4
             data_in.close();
 
             for (auto &segmentedDecoder : segmentedDecoders)
-            {
                 if (segmentedDecoder.second.image_id != "")
-                {
-                    logger->info("Writing image " + directory + "/IMAGES/" + segmentedDecoder.second.image_id + ".png" + "...");
-                    segmentedDecoder.second.image.save_png(std::string(directory + "/IMAGES/" + segmentedDecoder.second.image_id + ".png").c_str());
-                }
-            }
+                    segmentedDecoder.second.image.save_img(std::string(directory + "/IMAGES/" + segmentedDecoder.second.image_id).c_str());
         }
 
         void FY4LRITDataDecoderModule::drawUI(bool window)

--- a/plugins/fengyun4_support/fy4/module_fy4_lrit_data_decoder_proc.cpp
+++ b/plugins/fengyun4_support/fy4/module_fy4_lrit_data_decoder_proc.cpp
@@ -152,8 +152,7 @@ namespace fy4
                                 current_filename = image_id;
 
                                 wip_img->imageStatus = SAVING;
-                                logger->info("Writing image " + directory + "/IMAGES/" + current_filename + ".png" + "...");
-                                segmentedDecoder.image.save_png(directory + "/IMAGES/" + current_filename + ".png");
+                                segmentedDecoder.image.save_img(directory + "/IMAGES/" + current_filename);
                                 wip_img->imageStatus = RECEIVING;
                             }
 
@@ -182,8 +181,7 @@ namespace fy4
                             current_filename = image_id;
 
                             wip_img->imageStatus = SAVING;
-                            logger->info("Writing image " + directory + "/IMAGES/" + current_filename + ".png" + "...");
-                            segmentedDecoder.image.save_png(directory + "/IMAGES/" + current_filename + ".png");
+                            segmentedDecoder.image.save_img(directory + "/IMAGES/" + current_filename);
                             segmentedDecoder = SegmentedLRITImageDecoder();
                             wip_img->imageStatus = IDLE;
                         }
@@ -195,9 +193,8 @@ namespace fy4
                         if (!std::filesystem::exists(directory + "/IMAGES/" + img_type))
                             std::filesystem::create_directory(directory + "/IMAGES/" + img_type);
 
-                        logger->info("Writing image " + directory + "/IMAGES/" + img_type + "/" + image_id + ".png" + "...");
                         image::Image<uint8_t> image(&file.lrit_data[primary_header.total_header_length], image_structure_record.columns_count, image_structure_record.lines_count, 1);
-                        image.save_png(directory + "/IMAGES/" + img_type + "/" + image_id + ".png");
+                        image.save_img(directory + "/IMAGES/" + img_type + "/" + image_id);
                     }
                 }
                 else

--- a/plugins/gcom_support/gcom1/module_gcom1_instruments.cpp
+++ b/plugins/gcom_support/gcom1/module_gcom1_instruments.cpp
@@ -99,7 +99,7 @@ namespace gcom1
                 // amsr2_products.set_proj_cfg(loadJsonFile(resources::getResourcePath("projections_settings/metop_abc_mhs.json")));
 
                 for (int i = 0; i < 20; i++)
-                    amsr2_products.images.push_back({"AMSR2-" + std::to_string(i + 1) + ".png", std::to_string(i + 1), amsr2_reader.getChannel(i)});
+                    amsr2_products.images.push_back({"AMSR2-" + std::to_string(i + 1), std::to_string(i + 1), amsr2_reader.getChannel(i)});
 
                 amsr2_products.save(directory);
                 dataset.products_list.push_back("AMSR-2");

--- a/plugins/geonetcast_support/geonetcast/goes_abi.cpp
+++ b/plugins/geonetcast_support/geonetcast/goes_abi.cpp
@@ -88,7 +88,7 @@ namespace geonetcast
 
                 img_cnt_pos++;
 
-                // chunk_image.save_png("ABI/TEST_FULL_ABI" + std::to_string(img_cnt_pos) + ".png");
+                // chunk_image.save_img("ABI/TEST_FULL_ABI" + std::to_string(img_cnt_pos));
             }
             else
             {

--- a/plugins/geonetcast_support/geonetcast/module_geonetcast_decoder.cpp
+++ b/plugins/geonetcast_support/geonetcast/module_geonetcast_decoder.cpp
@@ -155,8 +155,7 @@ namespace geonetcast
 
                                         image::Image<uint16_t> final_image = parse_goesr_abi_netcdf_fulldisk_CMI(file.data, bit_depth);
 
-                                        logger->info("Saving complete " + file.name + ".png size " + filesize_str);
-                                        final_image.save_png(directory + "/PROCESSED/" + file.name + ".png");
+                                        final_image.save_img(directory + "/PROCESSED/" + file.name);
                                         // return;
                                     }
 #endif

--- a/plugins/gk2a_support/gk2a/module_gk2a_lrit_data_decoder.cpp
+++ b/plugins/gk2a_support/gk2a/module_gk2a_lrit_data_decoder.cpp
@@ -237,13 +237,8 @@ namespace gk2a
             data_in.close();
 
             for (auto &segmentedDecoder : segmentedDecoders)
-            {
                 if (segmentedDecoder.second.image_id != "")
-                {
-                    logger->info("Writing image " + directory + "/IMAGES/" + segmentedDecoder.second.image_id + ".png" + "...");
-                    segmentedDecoder.second.image.save_png(std::string(directory + "/IMAGES/" + segmentedDecoder.second.image_id + ".png").c_str());
-                }
-            }
+                    segmentedDecoder.second.image.save_img(std::string(directory + "/IMAGES/" + segmentedDecoder.second.image_id).c_str());
         }
 
         void GK2ALRITDataDecoderModule::drawUI(bool window)

--- a/plugins/gk2a_support/gk2a/module_gk2a_lrit_data_decoder_proc.cpp
+++ b/plugins/gk2a_support/gk2a/module_gk2a_lrit_data_decoder_proc.cpp
@@ -128,8 +128,7 @@ namespace gk2a
                                 current_filename = image_id;
 
                                 wip_img->imageStatus = SAVING;
-                                logger->info("Writing image " + directory + "/IMAGES/" + current_filename + ".png" + "...");
-                                segmentedDecoder.image.save_png(std::string(directory + "/IMAGES/" + current_filename + ".png").c_str());
+                                segmentedDecoder.image.save_img(std::string(directory + "/IMAGES/" + current_filename).c_str());
                                 wip_img->imageStatus = RECEIVING;
                             }
 
@@ -165,8 +164,7 @@ namespace gk2a
                             current_filename = image_id;
 
                             wip_img->imageStatus = SAVING;
-                            logger->info("Writing image " + directory + "/IMAGES/" + current_filename + ".png" + "...");
-                            segmentedDecoder.image.save_png(std::string(directory + "/IMAGES/" + current_filename + ".png").c_str());
+                            segmentedDecoder.image.save_img(std::string(directory + "/IMAGES/" + current_filename).c_str());
                             segmentedDecoder = SegmentedLRITImageDecoder();
                             wip_img->imageStatus = IDLE;
                         }
@@ -175,9 +173,8 @@ namespace gk2a
                     {
                         std::string clean_filename = current_filename.substr(0, current_filename.size() - 5); // Remove extensions
                         // Write raw image dats
-                        logger->info("Writing image " + directory + "/IMAGES/" + clean_filename + ".png" + "...");
                         image::Image<uint8_t> image(&file.lrit_data[primary_header.total_header_length], image_structure_record.columns_count, image_structure_record.lines_count, 1);
-                        image.save_png(std::string(directory + "/IMAGES/" + clean_filename + ".png").c_str());
+                        image.save_img(std::string(directory + "/IMAGES/" + clean_filename).c_str());
                     }
                 }
             }

--- a/plugins/goes_support/goes/grb/data/abi/abi_image_assembler.cpp
+++ b/plugins/goes_support/goes/grb/data/abi/abi_image_assembler.cpp
@@ -32,12 +32,11 @@ namespace goes
                                        (timeReadable->tm_min > 9 ? std::to_string(timeReadable->tm_min) : "0" + std::to_string(timeReadable->tm_min)) +             // Minutes mm
                                        (timeReadable->tm_sec > 9 ? std::to_string(timeReadable->tm_sec) : "0" + std::to_string(timeReadable->tm_sec)) + "Z";
 
-            std::string filename = "ABI_" + zone + "_" + std::to_string(abi_product.channel) + "_" + utc_filename + ".png";
+            std::string filename = "ABI_" + zone + "_" + std::to_string(abi_product.channel) + "_" + utc_filename;
             std::string directory = abi_directory + "/" + zone + "/" + utc_filename + "/";
             std::filesystem::create_directories(directory);
 
-            // logger->info("Saving " + directory + filename);
-            // full_image.save_png(std::string(directory + filename).c_str());
+            // full_image.save_img(std::string(directory + filename).c_str());
             saving_thread->push(full_image, std::string(directory + filename));
 
             image_composer->feed_channel(currentTimeStamp, abi_product.channel, full_image);

--- a/plugins/goes_support/goes/grb/data/abi/abi_image_composer.cpp
+++ b/plugins/goes_support/goes/grb/data/abi/abi_image_composer.cpp
@@ -71,12 +71,11 @@ namespace goes
                                        (timeReadable->tm_min > 9 ? std::to_string(timeReadable->tm_min) : "0" + std::to_string(timeReadable->tm_min)) +             // Minutes mm
                                        (timeReadable->tm_sec > 9 ? std::to_string(timeReadable->tm_sec) : "0" + std::to_string(timeReadable->tm_sec)) + "Z";
 
-            std::string filename = "ABI_" + zone + "_" + name + "_" + utc_filename + ".png";
+            std::string filename = "ABI_" + zone + "_" + name + "_" + utc_filename;
             std::string directory = abi_directory + "/" + zone + "/" + utc_filename + "/";
             std::filesystem::create_directories(directory);
 
-            // logger->info("Saving " + directory + filename);
-            // img.save_png(std::string(directory + filename).c_str());
+            // img.save_img(std::string(directory + filename).c_str());
             saving_thread->push(img, std::string(directory + filename));
         }
 

--- a/plugins/goes_support/goes/grb/data/suvi/suvi_image_assembler.cpp
+++ b/plugins/goes_support/goes/grb/data/suvi/suvi_image_assembler.cpp
@@ -31,12 +31,11 @@ namespace goes
                                        (timeReadable->tm_min > 9 ? std::to_string(timeReadable->tm_min) : "0" + std::to_string(timeReadable->tm_min)) +             // Minutes mm
                                        (timeReadable->tm_sec > 9 ? std::to_string(timeReadable->tm_sec) : "0" + std::to_string(timeReadable->tm_sec)) + "Z";
 
-            std::string filename = "SUVI_" + suvi_product.channel + "_" + utc_filename + ".png";
+            std::string filename = "SUVI_" + suvi_product.channel + "_" + utc_filename;
             std::string directory = suvi_directory + "/" + suvi_product.channel + "/";
             std::filesystem::create_directories(directory);
 
-            // logger->info("Saving " + directory + filename);
-            // full_image.save_png(std::string(directory + filename).c_str());
+            // full_image.save_img(std::string(directory + filename).c_str());
             saving_thread->push(full_image, std::string(directory + filename));
         }
 

--- a/plugins/goes_support/goes/gvar/module_gvar_image_decoder.cpp
+++ b/plugins/goes_support/goes/gvar/module_gvar_image_decoder.cpp
@@ -50,10 +50,8 @@ namespace goes
             std::string directory_d = directory_snd + "/" + timestamp;
 
             for (int i = 0; i < 19; i++)
-            {
-                logger->info("Saving Sounder_" + std::to_string(i + 1) + ".png");
-                sounderReader.getImage(i).save_png(directory_d + "/Sounder_" + std::to_string(i + 1) + ".png");
-            }
+                sounderReader.getImage(i).save_img(directory_d + "/Sounder_" + std::to_string(i + 1));
+
             sounderReader.clear();
         }
 
@@ -119,20 +117,11 @@ namespace goes
             images.image3.crop(0, 0, ir1_width, ir1_height);
             images.image4.crop(0, 0, ir1_width, ir1_height);
 
-            logger->info("Channel 1... " + getGvarFilename(sat_number, timeReadable, "1") + ".png");
-            images.image5.save_png(std::string(disk_folder + "/" + getGvarFilename(sat_number, timeReadable, "1") + ".png").c_str(), false);
-
-            logger->info("Channel 2... " + getGvarFilename(sat_number, timeReadable, "2") + ".png");
-            images.image1.save_png(std::string(disk_folder + "/" + getGvarFilename(sat_number, timeReadable, "2") + ".png").c_str());
-
-            logger->info("Channel 3... " + getGvarFilename(sat_number, timeReadable, "3") + ".png");
-            images.image2.save_png(std::string(disk_folder + "/" + getGvarFilename(sat_number, timeReadable, "3") + ".png").c_str());
-
-            logger->info("Channel 4... " + getGvarFilename(sat_number, timeReadable, "4") + ".png");
-            images.image3.save_png(std::string(disk_folder + "/" + getGvarFilename(sat_number, timeReadable, "4") + ".png").c_str());
-
-            logger->info("Channel 5... " + getGvarFilename(sat_number, timeReadable, "5") + ".png");
-            images.image4.save_png(std::string(disk_folder + "/" + getGvarFilename(sat_number, timeReadable, "5") + ".png").c_str());
+            images.image5.save_img(std::string(disk_folder + "/" + getGvarFilename(sat_number, timeReadable, "1")).c_str(), false);
+            images.image1.save_img(std::string(disk_folder + "/" + getGvarFilename(sat_number, timeReadable, "2")).c_str());
+            images.image2.save_img(std::string(disk_folder + "/" + getGvarFilename(sat_number, timeReadable, "3")).c_str());
+            images.image3.save_img(std::string(disk_folder + "/" + getGvarFilename(sat_number, timeReadable, "4")).c_str());
+            images.image4.save_img(std::string(disk_folder + "/" + getGvarFilename(sat_number, timeReadable, "5")).c_str());
 
             // Let plugins do something
             satdump::eventBus->fire_event<events::GVARSaveChannelImagesEvent>({images, timeReadable, timevalue, disk_folder});
@@ -189,9 +178,7 @@ namespace goes
                 hueTuning.hue[image::HUE_RANGE_MAGENTA] = 133.0 / 180.0;
                 hueTuning.overlap = 100.0 / 100.0;
                 image::hue_saturation(compoImage, hueTuning);
-
-                logger->info("False color... " + getGvarFilename(sat_number, timeReadable, "FC") + ".png");
-                compoImage.save_png(std::string(disk_folder + "/" + getGvarFilename(sat_number, timeReadable, "FC") + ".png").c_str());
+                compoImage.save_img(std::string(disk_folder + "/" + getGvarFilename(sat_number, timeReadable, "FC")).c_str());
 
                 // Let plugins do something
                 satdump::eventBus->fire_event<events::GVARSaveFCImageEvent>({compoImage, images.sat_number, timeReadable, timevalue, disk_folder});

--- a/plugins/goes_support/goes/hrit/data/goes_r_fc_composer.cpp
+++ b/plugins/goes_support/goes/hrit/data/goes_r_fc_composer.cpp
@@ -94,9 +94,8 @@ namespace goes
         void GOESRFalseColorComposer::save()
         {
             imageStatus = SAVING;
-            logger->info("Writing image " + directory + "/IMAGES/" + filename + ".png" + "...");
             logger->info("This false color LUT was made by Harry Dove-Robinson, see resources/goes/abi/wxstar/README.md for more infos.");
-            falsecolor.save_png(std::string(directory + "/IMAGES/" + filename + ".png").c_str());
+            falsecolor.save_img(std::string(directory + "/IMAGES/" + filename).c_str());
             hasData = false;
             time2 = time13 = 0;
             imageStatus = IDLE;

--- a/plugins/goes_support/goes/hrit/module_goes_lrit_data_decoder.cpp
+++ b/plugins/goes_support/goes/hrit/module_goes_lrit_data_decoder.cpp
@@ -189,10 +189,7 @@ namespace goes
             for (auto &segmentedDecoder : segmentedDecoders)
             {
                 if (segmentedDecoder.second.image.size())
-                {
-                    logger->info("Writing image " + directory + "/IMAGES/" + segmentedDecoder.second.filename + ".png" + "...");
-                    segmentedDecoder.second.image.save_png(std::string(directory + "/IMAGES/" + segmentedDecoder.second.filename + ".png").c_str());
-                }
+                    segmentedDecoder.second.image.save_img(std::string(directory + "/IMAGES/" + segmentedDecoder.second.filename).c_str());
             }
 
             if (goes_r_fc_composer_full_disk->hasData)

--- a/plugins/goes_support/goes/hrit/module_goes_lrit_data_decoder_proc.cpp
+++ b/plugins/goes_support/goes/hrit/module_goes_lrit_data_decoder_proc.cpp
@@ -393,15 +393,18 @@ namespace goes
                         //Sometimes, multiple different images can be sent down with the same name
                         //Do not overwrite files
                         std::string suffix = "";
+                        std::string extension = "";
                         int suffixInt = 1;
-                        while(std::filesystem::exists(directory + "/IMAGES/" + current_filename + suffix + ".png") || 
-                            std::filesystem::exists(directory + "/IMAGES/" + current_filename + suffix + ".jpg"))
+
+                        image::Image<uint8_t> image(&file.lrit_data[primary_header.total_header_length], image_structure_record.columns_count, image_structure_record.lines_count, 1);
+                        image.append_ext(&extension);
+
+                        while(std::filesystem::exists(directory + "/IMAGES/" + current_filename + suffix + extension))
                         {
                             suffixInt++;
                             suffix = "-" + std::to_string(suffixInt);
                         }
 
-                        image::Image<uint8_t> image(&file.lrit_data[primary_header.total_header_length], image_structure_record.columns_count, image_structure_record.lines_count, 1);
                         if (is_goesn)
                             image.resize(image.width(), image.height() * 1.75);
                         image.save_img(std::string(directory + "/IMAGES/" + current_filename + suffix).c_str());

--- a/plugins/goes_support/goes/hrit/module_goes_lrit_data_decoder_proc.cpp
+++ b/plugins/goes_support/goes/hrit/module_goes_lrit_data_decoder_proc.cpp
@@ -274,10 +274,9 @@ namespace goes
                         if (segmentedDecoder.image_id != -1)
                         {
                             wip_img->imageStatus = SAVING;
-                            logger->info("Writing image " + directory + "/IMAGES/" + segmentedDecoder.filename + ".png" + "...");
                             if (is_goesn)
                                 segmentedDecoder.image.resize(segmentedDecoder.image.width(), segmentedDecoder.image.height() * 1.75);
-                            segmentedDecoder.image.save_png(std::string(directory + "/IMAGES/" + segmentedDecoder.filename + ".png").c_str());
+                            segmentedDecoder.image.save_img(std::string(directory + "/IMAGES/" + segmentedDecoder.filename).c_str());
                             wip_img->imageStatus = RECEIVING;
                         }
 
@@ -350,10 +349,9 @@ namespace goes
                     if (segmentedDecoder.isComplete())
                     {
                         wip_img->imageStatus = SAVING;
-                        logger->info("Writing image " + directory + "/IMAGES/" + current_filename + ".png" + "...");
                         if (is_goesn)
                             segmentedDecoder.image.resize(segmentedDecoder.image.width(), segmentedDecoder.image.height() * 1.75);
-                        segmentedDecoder.image.save_png(std::string(directory + "/IMAGES/" + current_filename + ".png").c_str());
+                        segmentedDecoder.image.save_img(std::string(directory + "/IMAGES/" + current_filename).c_str());
                         segmentedDecoder = SegmentedLRITImageDecoder();
                         wip_img->imageStatus = IDLE;
 
@@ -396,17 +394,17 @@ namespace goes
                         //Do not overwrite files
                         std::string suffix = "";
                         int suffixInt = 1;
-                        while(std::filesystem::exists(directory + "/IMAGES/" + current_filename + suffix + ".png"))
+                        while(std::filesystem::exists(directory + "/IMAGES/" + current_filename + suffix + ".png") || 
+                            std::filesystem::exists(directory + "/IMAGES/" + current_filename + suffix + ".jpg"))
                         {
                             suffixInt++;
                             suffix = "-" + std::to_string(suffixInt);
                         }
 
-                        logger->info("Writing image " + directory + "/IMAGES/" + current_filename + suffix + ".png" + "...");
                         image::Image<uint8_t> image(&file.lrit_data[primary_header.total_header_length], image_structure_record.columns_count, image_structure_record.lines_count, 1);
                         if (is_goesn)
                             image.resize(image.width(), image.height() * 1.75);
-                        image.save_png(std::string(directory + "/IMAGES/" + current_filename + suffix + ".png").c_str());
+                        image.save_img(std::string(directory + "/IMAGES/" + current_filename + suffix).c_str());
 
                         // Check if this is GOES-R
                         if (primary_header.file_type_code == 0 && (noaa_header.product_id == 16 ||

--- a/plugins/goes_support/goes/sd/sd_imager_reader.cpp
+++ b/plugins/goes_support/goes/sd/sd_imager_reader.cpp
@@ -164,20 +164,11 @@ namespace goes
                 if (!std::filesystem::exists(dir))
                     std::filesystem::create_directories(dir);
 
-                logger->info("Saving VIS...");
-                getChannel(0).save_png(dir + "/VIS.png", false);
-
-                logger->info("Saving IR1...");
-                getChannel(1).save_png(dir + "/IR1.png", false);
-
-                logger->info("Saving IR2...");
-                getChannel(2).save_png(dir + "/IR2.png", false);
-
-                logger->info("Saving IR3...");
-                getChannel(3).save_png(dir + "/IR3.png", false);
-
-                logger->info("Saving IR4...");
-                getChannel(4).save_png(dir + "/IR4.png", false);
+                getChannel(0).save_img(dir + "/VIS", false);
+                getChannel(1).save_img(dir + "/IR1", false);
+                getChannel(2).save_img(dir + "/IR2", false);
+                getChannel(3).save_img(dir + "/IR3", false);
+                getChannel(4).save_img(dir + "/IR4", false);
 
                 lines = 0;
                 image_vis.clear();

--- a/plugins/gvar_extended/main.cpp
+++ b/plugins/gvar_extended/main.cpp
@@ -49,7 +49,7 @@ private:
 
     static void gvarSaveChannelImagesHandler(const goes::gvar::events::GVARSaveChannelImagesEvent &evt)
     {
-        logger->info("Preview... preview.png");
+        logger->info("Preview...");
         image::Image<uint8_t> preview(1300, 948, 1);
         image::Image<uint8_t> previewImage;
 
@@ -133,7 +133,7 @@ private:
             previewImage.draw_image(0, preview, 0, bar_height);
         }
 
-        previewImage.save_png(std::string(evt.directory + "/preview.png").c_str());
+        previewImage.save_img(std::string(evt.directory + "/preview").c_str());
 
         /*
                // calibrated temperature measurement based on NOAA LUTs (https://www.ospo.noaa.gov/Operations/GOES/calibration/gvar-conversion.html)
@@ -217,14 +217,14 @@ private:
                image::Image<uint16_t> mapProj = cropIR(evt.images.image3);
                drawMapOverlay(evt.images.sat_number, evt.timeUTC, mapProj);
                mapProj.crop(500, 50, 500 + 1560, 50 + 890);
-               logger->info("Europe IR crop.. europe_IR.png");
-               mapProj.to8bits().save_png(std::string(evt.directory + "/europe_IR.png").c_str());
+               logger->info("Europe IR crop..");
+               mapProj.to8bits().save_img(std::string(evt.directory + "/europe_IR").c_str());
 
                mapProj = cropVIS(evt.images.image5);
                drawMapOverlay(evt.images.sat_number, evt.timeUTC, mapProj);
                mapProj.crop(1348, 240, 1348 + 5928, 240 + 4120);
-               logger->info("Europe VIS crop.. europe_VIS.png");
-               mapProj.to8bits().save_png(std::string(evt.directory + "/europe_VIS.png").c_str());
+               logger->info("Europe VIS crop.. europe_VIS");
+               mapProj.to8bits().save_img(std::string(evt.directory + "/europe_VIS").c_str());
                mapProj.clear();
                */
     }
@@ -233,13 +233,13 @@ private:
     {
         if (evt.sat_number == 13)
         {
-            logger->info("Europe crop... europe.png");
+            logger->info("Europe crop...");
             image::Image<uint8_t> crop = evt.false_color_image;
             if (crop.width() == 20836)
                 crop.crop(3198, 240, 3198 + 5928, 240 + 4120);
             else
                 crop.crop(1348, 240, 1348 + 5928, 240 + 4120);
-            crop.save_png(std::string(evt.directory + "/europe.png").c_str());
+            crop.save_img(std::string(evt.directory + "/europe").c_str());
         }
     }
 

--- a/plugins/himawari_support/himawaricast/module_himawaricast_data_decoder.cpp
+++ b/plugins/himawari_support/himawaricast/module_himawaricast_data_decoder.cpp
@@ -39,8 +39,7 @@ namespace himawari
                 segmented_decoders[channel_name].image.normalize();
                 if (!std::filesystem::exists(directory + "/" + channel_name))
                     std::filesystem::create_directory(directory + "/" + channel_name);
-                logger->info("Saving " + (std::string)directory + "/" + channel_name + "/" + current_filename.substr(0, current_filename.size() - 4) + ".png");
-                segmented_decoders[channel_name].image.save_png(directory + "/" + channel_name + "/" + current_filename.substr(0, current_filename.size() - 4) + ".png");
+                segmented_decoders[channel_name].image.save_img(directory + "/" + channel_name + "/" + current_filename.substr(0, current_filename.size() - 4));
                 // segmented_decoders[channel_name].image.clear();
                 // segmented_decoders.erase(channel_name);
                 // segmented_decoders_filenames.erase(channel_name);
@@ -301,8 +300,7 @@ namespace himawari
                                                     segmented_decoders[channel_name].image.normalize();
                                                     if (!std::filesystem::exists(directory + "/" + channel_name))
                                                         std::filesystem::create_directory(directory + "/" + channel_name);
-                                                    logger->info("Saving " + (std::string)directory + "/" + channel_name + "/" + current_filename.substr(0, current_filename.size() - 4) + ".png");
-                                                    segmented_decoders[channel_name].image.save_png(directory + "/" + channel_name + "/" + current_filename.substr(0, current_filename.size() - 4) + ".png");
+                                                    segmented_decoders[channel_name].image.save_img(directory + "/" + channel_name + "/" + current_filename.substr(0, current_filename.size() - 4));
                                                     segmented_decoders[channel_name].image.clear();
                                                     segmented_decoders.erase(channel_name);
                                                     segmented_decoders_filenames.erase(channel_name);

--- a/plugins/jason3_support/jason3/module_jason3_instruments.cpp
+++ b/plugins/jason3_support/jason3/module_jason3_instruments.cpp
@@ -93,7 +93,7 @@ namespace jason3
                 for (int i = 0; i < 3; i++)
                 {
                     logger->info("Channel " + std::to_string(i + 1) + "...");
-                    WRITE_IMAGE(amr2_reader.getChannel(i), directory + "/AMR2-" + std::to_string(i + 1) + ".png");
+                    WRITE_IMAGE(amr2_reader.getChannel(i), directory + "/AMR2-" + std::to_string(i + 1));
                 }
                 amr2_status = DONE;
             }

--- a/plugins/jason3_support/jason3/module_jason3_instruments.cpp
+++ b/plugins/jason3_support/jason3/module_jason3_instruments.cpp
@@ -26,6 +26,7 @@ namespace jason3
             logger->info("Using input frames " + d_input_file);
 
             time_t lastTime = 0;
+            std::string filename;
             uint8_t cadu[1279];
 
             // Demuxers
@@ -92,8 +93,8 @@ namespace jason3
 
                 for (int i = 0; i < 3; i++)
                 {
-                    logger->info("Channel " + std::to_string(i + 1) + "...");
-                    WRITE_IMAGE(amr2_reader.getChannel(i), directory + "/AMR2-" + std::to_string(i + 1));
+                    filename = directory + "/AMR2-" + std::to_string(i + 1);
+                    WRITE_IMAGE(amr2_reader.getChannel(i), filename);
                 }
                 amr2_status = DONE;
             }

--- a/plugins/jason3_support/jason3/module_jason3_instruments.cpp
+++ b/plugins/jason3_support/jason3/module_jason3_instruments.cpp
@@ -26,7 +26,6 @@ namespace jason3
             logger->info("Using input frames " + d_input_file);
 
             time_t lastTime = 0;
-            std::string filename;
             uint8_t cadu[1279];
 
             // Demuxers
@@ -93,8 +92,7 @@ namespace jason3
 
                 for (int i = 0; i < 3; i++)
                 {
-                    filename = directory + "/AMR2-" + std::to_string(i + 1);
-                    WRITE_IMAGE(amr2_reader.getChannel(i), filename);
+                    WRITE_IMAGE(amr2_reader.getChannel(i), directory + "/AMR2-" + std::to_string(i + 1));
                 }
                 amr2_status = DONE;
             }

--- a/plugins/jpss_support/jpss/module_jpss_instruments.cpp
+++ b/plugins/jpss_support/jpss/module_jpss_instruments.cpp
@@ -179,7 +179,7 @@ namespace jpss
                 atms_products.set_proj_cfg(loadJsonFile(resources::getResourcePath("projections_settings/jpss_atms.json")));
 
                 for (int i = 0; i < 22; i++)
-                    atms_products.images.push_back({"ATMS-" + std::to_string(i + 1) + ".png", std::to_string(i + 1), atms_reader.getChannel(i)});
+                    atms_products.images.push_back({"ATMS-" + std::to_string(i + 1), std::to_string(i + 1), atms_reader.getChannel(i)});
 
                 atms_products.save(directory);
                 dataset.products_list.push_back("ATMS");
@@ -201,7 +201,7 @@ namespace jpss
                 for (int i = 0; i < 339; i++)
                 {
                     logger->info("Channel " + std::to_string(i + 1) + "...");
-                    WRITE_IMAGE(omps_nadir_reader.getChannel(i), directory + "/OMPS-NADIR-" + std::to_string(i + 1) + ".png");
+                    WRITE_IMAGE(omps_nadir_reader.getChannel(i), directory + "/OMPS-NADIR-" + std::to_string(i + 1));
                 }
                 omps_nadir_status = DONE;
             }
@@ -220,7 +220,7 @@ namespace jpss
                 for (int i = 0; i < 135; i++)
                 {
                     logger->info("Channel " + std::to_string(i + 1) + "...");
-                    WRITE_IMAGE(omps_limb_reader.getChannel(i), directory + "/OMPS-LIMB-" + std::to_string(i + 1) + ".png");
+                    WRITE_IMAGE(omps_limb_reader.getChannel(i), directory + "/OMPS-LIMB-" + std::to_string(i + 1));
                 }
                 omps_limb_status = DONE;
             }
@@ -271,7 +271,7 @@ namespace jpss
                         viirs_image = image::bowtie::correctGenericBowTie(viirs_image, 1, viirs_reader_moderate[i].channelSettings.zoneHeight, alpha, beta);
                         viirs_moderate_status[i] = SAVING;
 
-                        viirs_products.images.push_back({"VIIRS-M" + std::to_string(i + 1) + ".png",
+                        viirs_products.images.push_back({"VIIRS-M" + std::to_string(i + 1),
                                                          "m" + std::to_string(i + 1),
                                                          viirs_image,
                                                          viirs_reader_moderate[i].timestamps,
@@ -289,7 +289,7 @@ namespace jpss
                         viirs_image = image::bowtie::correctGenericBowTie(viirs_image, 1, viirs_reader_imaging[i].channelSettings.zoneHeight, alpha, beta);
                         viirs_imaging_status[i] = SAVING;
 
-                        viirs_products.images.push_back({"VIIRS-I" + std::to_string(i + 1) + ".png",
+                        viirs_products.images.push_back({"VIIRS-I" + std::to_string(i + 1),
                                                          "i" + std::to_string(i + 1),
                                                          viirs_image,
                                                          viirs_reader_imaging[i].timestamps,
@@ -303,7 +303,7 @@ namespace jpss
                 {
                     logger->info("DNB...");
 
-                    viirs_products.images.push_back({"VIIRS-DNB.png",
+                    viirs_products.images.push_back({"VIIRS-DNB",
                                                      "dnb",
                                                      viirs_reader_dnb[0].getImage(),
                                                      viirs_reader_dnb[0].timestamps,
@@ -314,7 +314,7 @@ namespace jpss
                 {
                     logger->info("DNB MGS...");
 
-                    viirs_products.images.push_back({"VIIRS-DNB-MGS.png",
+                    viirs_products.images.push_back({"VIIRS-DNB-MGS",
                                                      "dnbmgs",
                                                      viirs_reader_dnb[1].getImage(),
                                                      viirs_reader_dnb[1].timestamps,
@@ -325,7 +325,7 @@ namespace jpss
                 {
                     logger->info("DNB LGS...");
 
-                    viirs_products.images.push_back({"VIIRS-DNB-LGS.png",
+                    viirs_products.images.push_back({"VIIRS-DNB-LGS",
                                                      "dnblgs",
                                                      viirs_reader_dnb[2].getImage(),
                                                      viirs_reader_dnb[2].timestamps,

--- a/plugins/jpss_support/jpss/module_jpss_instruments.cpp
+++ b/plugins/jpss_support/jpss/module_jpss_instruments.cpp
@@ -31,6 +31,7 @@ namespace jpss
             logger->info("Using input frames " + d_input_file);
 
             time_t lastTime = 0;
+            std::string filename;
             uint8_t cadu[1279]; // Oversized for NPP, but not a big deal
 
             int mpdu_size = npp_mode ? 884 : 1094;
@@ -200,8 +201,8 @@ namespace jpss
 
                 for (int i = 0; i < 339; i++)
                 {
-                    logger->info("Channel " + std::to_string(i + 1) + "...");
-                    WRITE_IMAGE(omps_nadir_reader.getChannel(i), directory + "/OMPS-NADIR-" + std::to_string(i + 1));
+                    filename = directory + "/OMPS-NADIR-" + std::to_string(i + 1);
+                    WRITE_IMAGE(omps_nadir_reader.getChannel(i), filename);
                 }
                 omps_nadir_status = DONE;
             }
@@ -219,8 +220,8 @@ namespace jpss
 
                 for (int i = 0; i < 135; i++)
                 {
-                    logger->info("Channel " + std::to_string(i + 1) + "...");
-                    WRITE_IMAGE(omps_limb_reader.getChannel(i), directory + "/OMPS-LIMB-" + std::to_string(i + 1));
+                    filename = directory + "/OMPS-LIMB-" + std::to_string(i + 1);
+                    WRITE_IMAGE(omps_limb_reader.getChannel(i), filename);
                 }
                 omps_limb_status = DONE;
             }

--- a/plugins/jpss_support/jpss/module_jpss_instruments.cpp
+++ b/plugins/jpss_support/jpss/module_jpss_instruments.cpp
@@ -31,7 +31,6 @@ namespace jpss
             logger->info("Using input frames " + d_input_file);
 
             time_t lastTime = 0;
-            std::string filename;
             uint8_t cadu[1279]; // Oversized for NPP, but not a big deal
 
             int mpdu_size = npp_mode ? 884 : 1094;
@@ -201,8 +200,7 @@ namespace jpss
 
                 for (int i = 0; i < 339; i++)
                 {
-                    filename = directory + "/OMPS-NADIR-" + std::to_string(i + 1);
-                    WRITE_IMAGE(omps_nadir_reader.getChannel(i), filename);
+                    WRITE_IMAGE(omps_nadir_reader.getChannel(i), directory + "/OMPS-NADIR-" + std::to_string(i + 1));
                 }
                 omps_nadir_status = DONE;
             }
@@ -220,8 +218,7 @@ namespace jpss
 
                 for (int i = 0; i < 135; i++)
                 {
-                    filename = directory + "/OMPS-LIMB-" + std::to_string(i + 1);
-                    WRITE_IMAGE(omps_limb_reader.getChannel(i), filename);
+                    WRITE_IMAGE(omps_limb_reader.getChannel(i), directory + "/OMPS-LIMB-" + std::to_string(i + 1));
                 }
                 omps_limb_status = DONE;
             }

--- a/plugins/landsat_support/ldcm/module_ldcm_instruments.cpp
+++ b/plugins/landsat_support/ldcm/module_ldcm_instruments.cpp
@@ -138,11 +138,11 @@ namespace ldcm
                 // tirs_products.set_proj_cfg(loadJsonFile(resources::getResourcePath("projections_settings/metop_abc_mhs.json")));
 
                 for (int i = 0; i < 3; i++)
-                    tirs_products.images.push_back({"TIRS-" + std::to_string(i + 1) + ".png", std::to_string(i + 1), tirs_reader1.getChannel(i)});
+                    tirs_products.images.push_back({"TIRS-" + std::to_string(i + 1), std::to_string(i + 1), tirs_reader1.getChannel(i)});
                 for (int i = 0; i < 3; i++)
-                    tirs_products.images.push_back({"TIRS-" + std::to_string(i + 4) + ".png", std::to_string(i + 4), tirs_reader2.getChannel(i)});
+                    tirs_products.images.push_back({"TIRS-" + std::to_string(i + 4), std::to_string(i + 4), tirs_reader2.getChannel(i)});
                 for (int i = 0; i < 3; i++)
-                    tirs_products.images.push_back({"TIRS-" + std::to_string(i + 7) + ".png", std::to_string(i + 7), tirs_reader3.getChannel(i)});
+                    tirs_products.images.push_back({"TIRS-" + std::to_string(i + 7), std::to_string(i + 7), tirs_reader3.getChannel(i)});
 
                 tirs_products.save(directory);
                 dataset.products_list.push_back("TIRS");

--- a/plugins/mats_support/mats/instruments/mats/mats_reader.cpp
+++ b/plugins/mats_support/mats/instruments/mats/mats_reader.cpp
@@ -65,7 +65,7 @@ namespace mats
                                 std::string path = directory + "/Raw_Images/" + channel_names[channel_marker];
                                 if (!std::filesystem::exists(path))
                                     std::filesystem::create_directories(path);
-                                img.save_png(path + "/" + std::to_string(img_cnts[channel_marker]++) + ".png");
+                                img.save_img(path + "/" + std::to_string(img_cnts[channel_marker]++));
                             }
                         }
                     }

--- a/plugins/mats_support/mats/module_mats_instruments.cpp
+++ b/plugins/mats_support/mats/module_mats_instruments.cpp
@@ -92,7 +92,7 @@ namespace mats
                 // mats_nadir_products.set_timestamps(mhs_reader.timestamps);
                 // mats_nadir_products.set_proj_cfg(loadJsonFile(resources::getResourcePath("projections_settings/metop_abc_mhs.json")));
 
-                mats_nadir_products.images.push_back({"MATS-Nadir.png", "1", mats_reader.getNadirImage()});
+                mats_nadir_products.images.push_back({"MATS-Nadir", "1", mats_reader.getNadirImage()});
 
                 mats_nadir_products.save(directory);
                 dataset.products_list.push_back("Nadir");

--- a/plugins/meteor_support/meteor/instruments/msumr/module_meteor_msumr_lrpt.cpp
+++ b/plugins/meteor_support/meteor/instruments/msumr/module_meteor_msumr_lrpt.cpp
@@ -148,7 +148,7 @@ namespace meteor
             {
                 image::Image<uint16_t> img = msureader.getChannel(i).to16bits();
                 if (img.size() > 0)
-                    msumr_products.images.push_back({"MSU-MR-" + std::to_string(i + 1) + ".png", std::to_string(i + 1), img, msureader.timestamps, 8});
+                    msumr_products.images.push_back({"MSU-MR-" + std::to_string(i + 1), std::to_string(i + 1), img, msureader.timestamps, 8});
             }
 
             msumr_products.save(directory);

--- a/plugins/meteor_support/meteor/module_meteor_instruments.cpp
+++ b/plugins/meteor_support/meteor/module_meteor_instruments.cpp
@@ -201,7 +201,7 @@ namespace meteor
                     msumr_products.set_proj_cfg(loadJsonFile(resources::getResourcePath("projections_settings/meteor_m2-3_msumr.json")));
 
                 for (int i = 0; i < 6; i++)
-                    msumr_products.images.push_back({"MSU-MR-" + std::to_string(i + 1) + ".png", std::to_string(i + 1), msumr_reader.getChannel(i)});
+                    msumr_products.images.push_back({"MSU-MR-" + std::to_string(i + 1), std::to_string(i + 1), msumr_reader.getChannel(i)});
 
                 msumr_products.save(directory);
                 dataset.products_list.push_back("MSU-MR");
@@ -228,7 +228,7 @@ namespace meteor
                 mtvza_products.set_timestamps(mtvza_reader.timestamps);
 
                 for (int i = 0; i < 30; i++)
-                    mtvza_products.images.push_back({"MTVZA-" + std::to_string(i + 1) + ".png", std::to_string(i + 1), mtvza_reader.getChannel(i)});
+                    mtvza_products.images.push_back({"MTVZA-" + std::to_string(i + 1), std::to_string(i + 1), mtvza_reader.getChannel(i)});
 
                 mtvza_products.save(directory);
                 dataset.products_list.push_back("MTVZA");

--- a/plugins/noaa_metop_support/metop/module_metop_instruments.cpp
+++ b/plugins/noaa_metop_support/metop/module_metop_instruments.cpp
@@ -226,7 +226,7 @@ namespace metop
 
                 std::string names[6] = {"1", "2", "3a", "3b", "4", "5"};
                 for (int i = 0; i < 6; i++)
-                    avhrr_products.images.push_back({"AVHRR-" + names[i] + ".png", names[i], avhrr_reader.getChannel(i)});
+                    avhrr_products.images.push_back({"AVHRR-" + names[i], names[i], avhrr_reader.getChannel(i)});
 
                 avhrr_products.save(directory);
                 dataset.products_list.push_back("AVHRR");
@@ -255,7 +255,7 @@ namespace metop
                 mhs_products.set_proj_cfg(loadJsonFile(resources::getResourcePath("projections_settings/metop_abc_mhs.json")));
 
                 for (int i = 0; i < 5; i++)
-                    mhs_products.images.push_back({"MHS-" + std::to_string(i + 1) + ".png", std::to_string(i + 1), mhs_reader.getChannel(i)});
+                    mhs_products.images.push_back({"MHS-" + std::to_string(i + 1), std::to_string(i + 1), mhs_reader.getChannel(i)});
 
                 nlohmann::json calib_coefs = loadJsonFile(resources::getResourcePath("calibration/MHS.json"));
                 if (calib_coefs.contains(sat_name) && std::filesystem::exists(resources::getResourcePath("calibration/MHS.lua")))
@@ -331,7 +331,7 @@ namespace metop
                     imageAll.draw_image(0, image4, 256 * 0, height * 2);
                     imageAll.draw_image(0, image1, 256 * 1, height * 2);
                 }
-                WRITE_IMAGE(imageAll, directory + "/ASCAT-ALL.png");
+                WRITE_IMAGE(imageAll, directory + "/ASCAT-ALL");
 
                 ascat_products.save(directory);
                 dataset.products_list.push_back("ASCAT");
@@ -374,7 +374,7 @@ namespace metop
                     iasi_img_products.timestamp_type = satdump::ImageProducts::TIMESTAMP_IFOV;
                     iasi_img_products.set_timestamps(iasi_reader_img.timestamps_ifov);
                     iasi_img_products.set_proj_cfg(loadJsonFile(resources::getResourcePath("projections_settings/metop_abc_iasi_img.json")));
-                    iasi_img_products.images.push_back({"IASI-IMG.png", "1", iasi_imaging});
+                    iasi_img_products.images.push_back({"IASI-IMG", "1", iasi_imaging});
 
                     iasi_img_products.save(directory_img);
                     dataset.products_list.push_back("IASI-IMG");
@@ -391,7 +391,7 @@ namespace metop
                 iasi_products.save_as_matrix = true;
 
                 for (int i = 0; i < 8461; i++)
-                    iasi_products.images.push_back({"IASI-ALL.png", std::to_string(i + 1), iasi_reader.getChannel(i)});
+                    iasi_products.images.push_back({"IASI-ALL", std::to_string(i + 1), iasi_reader.getChannel(i)});
 
                 iasi_products.save(directory);
                 dataset.products_list.push_back("IASI");
@@ -422,10 +422,10 @@ namespace metop
                 amsu_products.set_proj_cfg(loadJsonFile(resources::getResourcePath("projections_settings/metop_abc_amsu.json")));
 
                 for (int i = 0; i < 2; i++)
-                    amsu_products.images.push_back({"AMSU-A2-" + std::to_string(i + 1) + ".png", std::to_string(i + 1), amsu_a2_reader.getChannel(i), amsu_a2_reader.timestamps});
+                    amsu_products.images.push_back({"AMSU-A2-" + std::to_string(i + 1), std::to_string(i + 1), amsu_a2_reader.getChannel(i), amsu_a2_reader.timestamps});
 
                 for (int i = 0; i < 13; i++)
-                    amsu_products.images.push_back({"AMSU-A1-" + std::to_string(i + 1) + ".png", std::to_string(i + 3), amsu_a1_reader.getChannel(i), amsu_a1_reader.timestamps});
+                    amsu_products.images.push_back({"AMSU-A1-" + std::to_string(i + 1), std::to_string(i + 3), amsu_a1_reader.getChannel(i), amsu_a1_reader.timestamps});
 
                 amsu_products.save(directory);
                 dataset.products_list.push_back("AMSU");
@@ -452,7 +452,7 @@ namespace metop
                 gome_products.save_as_matrix = true;
 
                 for (int i = 0; i < 6144; i++)
-                    gome_products.images.push_back({"GOME-ALL.png", std::to_string(i + 1), gome_reader.getChannel(i)});
+                    gome_products.images.push_back({"GOME-ALL", std::to_string(i + 1), gome_reader.getChannel(i)});
 
                 gome_products.save(directory);
                 dataset.products_list.push_back("GOME");

--- a/plugins/noaa_metop_support/metop/module_metop_instruments.cpp
+++ b/plugins/noaa_metop_support/metop/module_metop_instruments.cpp
@@ -33,6 +33,7 @@ namespace metop
             logger->info("Using input frames " + d_input_file);
 
             time_t lastTime = 0;
+            std::string filename;
             uint8_t cadu[1024];
 
             // Demuxers
@@ -331,7 +332,9 @@ namespace metop
                     imageAll.draw_image(0, image4, 256 * 0, height * 2);
                     imageAll.draw_image(0, image1, 256 * 1, height * 2);
                 }
-                WRITE_IMAGE(imageAll, directory + "/ASCAT-ALL");
+
+                filename = directory + "/ASCAT-ALL";
+                WRITE_IMAGE(imageAll, filename);
 
                 ascat_products.save(directory);
                 dataset.products_list.push_back("ASCAT");

--- a/plugins/noaa_metop_support/metop/module_metop_instruments.cpp
+++ b/plugins/noaa_metop_support/metop/module_metop_instruments.cpp
@@ -33,7 +33,6 @@ namespace metop
             logger->info("Using input frames " + d_input_file);
 
             time_t lastTime = 0;
-            std::string filename;
             uint8_t cadu[1024];
 
             // Demuxers
@@ -333,8 +332,7 @@ namespace metop
                     imageAll.draw_image(0, image1, 256 * 1, height * 2);
                 }
 
-                filename = directory + "/ASCAT-ALL";
-                WRITE_IMAGE(imageAll, filename);
+                WRITE_IMAGE(imageAll, directory + "/ASCAT-ALL");
 
                 ascat_products.save(directory);
                 dataset.products_list.push_back("ASCAT");

--- a/plugins/noaa_metop_support/noaa/module_noaa_instruments.cpp
+++ b/plugins/noaa_metop_support/noaa/module_noaa_instruments.cpp
@@ -208,7 +208,7 @@ namespace noaa
 
                     std::string names[6] = {"1", "2", "3a", "3b", "4", "5"};
                     for (int i = 0; i < 6; i++)
-                        avhrr_products.images.push_back({"AVHRR-" + names[i] + ".png", names[i], avhrr_reader.getChannel(i)});
+                        avhrr_products.images.push_back({"AVHRR-" + names[i], names[i], avhrr_reader.getChannel(i)});
 
                     avhrr_products.save(directory);
                     dataset.products_list.push_back("AVHRR");
@@ -240,7 +240,7 @@ namespace noaa
                     hirs_products.set_proj_cfg(loadJsonFile(resources::getResourcePath("projections_settings/noaa_hirs.json")));
 
                     for (int i = 0; i < 20; i++)
-                        hirs_products.images.push_back({"HIRS-" + std::to_string(i + 1) + ".png", std::to_string(i + 1), hirs_reader.getChannel(i)});
+                        hirs_products.images.push_back({"HIRS-" + std::to_string(i + 1), std::to_string(i + 1), hirs_reader.getChannel(i)});
 
                     hirs_products.save(directory);
                     dataset.products_list.push_back("HIRS");
@@ -299,7 +299,7 @@ namespace noaa
                     mhs_products.set_timestamps(mhs_reader.timestamps);
 
                     for (int i = 0; i < 5; i++)
-                        mhs_products.images.push_back({"MHS-" + std::to_string(i + 1) + ".png", std::to_string(i + 1), mhs_reader.getChannel(i)});
+                        mhs_products.images.push_back({"MHS-" + std::to_string(i + 1), std::to_string(i + 1), mhs_reader.getChannel(i)});
 
                     mhs_products.set_proj_cfg(loadJsonFile(resources::getResourcePath("projections_settings/noaa_19_mhs.json")));
 
@@ -348,7 +348,7 @@ namespace noaa
                     amsu_products.set_proj_cfg(loadJsonFile(resources::getResourcePath("projections_settings/noaa_amsu.json")));
 
                     for (int i = 0; i < 15; i++)
-                        amsu_products.images.push_back({"AMSU-" + std::to_string(i + 1) + ".png", std::to_string(i + 1), amsu_reader.getChannel(i), i < 2 ? amsu_reader.timestamps2 : amsu_reader.timestamps1});
+                        amsu_products.images.push_back({"AMSU-" + std::to_string(i + 1), std::to_string(i + 1), amsu_reader.getChannel(i), i < 2 ? amsu_reader.timestamps2 : amsu_reader.timestamps1});
 
                     amsu_products.save(directory);
                     dataset.products_list.push_back("AMSU");
@@ -433,7 +433,7 @@ namespace noaa
                     hirs_products.set_proj_cfg(loadJsonFile(resources::getResourcePath("projections_settings/noaa_hirs.json")));
 
                     for (int i = 0; i < 20; i++)
-                        hirs_products.images.push_back({"HIRS-" + std::to_string(i + 1) + ".png", std::to_string(i + 1), hirs_reader.getChannel(i)});
+                        hirs_products.images.push_back({"HIRS-" + std::to_string(i + 1), std::to_string(i + 1), hirs_reader.getChannel(i)});
 
                     hirs_products.save(directory);
                     dataset.products_list.push_back("HIRS");

--- a/plugins/oceansat_support/oceansat/instruments/ocm/module_oceansat_ocm.cpp
+++ b/plugins/oceansat_support/oceansat/instruments/ocm/module_oceansat_ocm.cpp
@@ -70,7 +70,7 @@ namespace oceansat
             ocm_products.bit_depth = 12;
 
             for (int i = 0; i < 8; i++)
-                ocm_products.images.push_back({"OCM-" + std::to_string(i + 1) + ".png", std::to_string(i + 1), ocm_reader.getChannel(i)});
+                ocm_products.images.push_back({"OCM-" + std::to_string(i + 1), std::to_string(i + 1), ocm_reader.getChannel(i)});
 
             ocm_products.save(directory);
             dataset.products_list.push_back("OCM");
@@ -88,15 +88,15 @@ namespace oceansat
                     image642.draw_image(1, image4);
                     image642.draw_image(2, image2);
                 }
-                WRITE_IMAGE(image642, directory + "/OCM-RGB-642.png");
+                WRITE_IMAGE(image642, directory + "/OCM-RGB-642");
                 image642.equalize();
                 image642.normalize();
-                WRITE_IMAGE(image642, directory + "/OCM-RGB-642-EQU.png");
+                WRITE_IMAGE(image642, directory + "/OCM-RGB-642-EQU");
                 image::Image<uint16_t> corrected642 = image::earth_curvature::correct_earth_curvature(image642,
                                                                                                       OCEANSAT2_ORBIT_HEIGHT,
                                                                                                       OCEANSAT2_OCM2_SWATH,
                                                                                                       OCEANSAT2_OCM2_RES);
-                WRITE_IMAGE(corrected642, directory + "/OCM-RGB-642-EQU-CORRECTED.png");
+                WRITE_IMAGE(corrected642, directory + "/OCM-RGB-642-EQU-CORRECTED");
             }
 
             logger->info("654 Composite...");
@@ -107,15 +107,15 @@ namespace oceansat
                     image654.draw_image(1, image5);
                     image654.draw_image(2, image4);
                 }
-                WRITE_IMAGE(image654, directory + "/OCM-RGB-654.png");
+                WRITE_IMAGE(image654, directory + "/OCM-RGB-654");
                 image654.equalize();
                 image654.normalize();
-                WRITE_IMAGE(image654, directory + "/OCM-RGB-654-EQU.png");
+                WRITE_IMAGE(image654, directory + "/OCM-RGB-654-EQU");
                 image::Image<uint16_t> corrected654 = image::earth_curvature::correct_earth_curvature(image654,
                                                                                                       OCEANSAT2_ORBIT_HEIGHT,
                                                                                                       OCEANSAT2_OCM2_SWATH,
                                                                                                       OCEANSAT2_OCM2_RES);
-                WRITE_IMAGE(corrected654, directory + "/OCM-RGB-654-EQU-CORRECTED.png");
+                WRITE_IMAGE(corrected654, directory + "/OCM-RGB-654-EQU-CORRECTED");
             }
 
             logger->info("754 Composite...");
@@ -126,15 +126,15 @@ namespace oceansat
                     image754.draw_image(1, image5);
                     image754.draw_image(2, image4);
                 }
-                WRITE_IMAGE(image754, directory + "/OCM-RGB-754.png");
+                WRITE_IMAGE(image754, directory + "/OCM-RGB-754");
                 image754.equalize();
                 image754.normalize();
-                WRITE_IMAGE(image754, directory + "/OCM-RGB-754-EQU.png");
+                WRITE_IMAGE(image754, directory + "/OCM-RGB-754-EQU");
                 image::Image<uint16_t> corrected754 = image::earth_curvature::correct_earth_curvature(image754,
                                                                                                       OCEANSAT2_ORBIT_HEIGHT,
                                                                                                       OCEANSAT2_OCM2_SWATH,
                                                                                                       OCEANSAT2_OCM2_RES);
-                WRITE_IMAGE(corrected754, directory + "/OCM-RGB-754-EQU-CORRECTED.png");
+                WRITE_IMAGE(corrected754, directory + "/OCM-RGB-754-EQU-CORRECTED");
             }
             logger->info("882 Composite...");
             {
@@ -144,15 +144,15 @@ namespace oceansat
                     image882.draw_image(1, image8);
                     image882.draw_image(2, image2);
                 }
-                WRITE_IMAGE(image882, directory + "/OCM-RGB-882.png");
+                WRITE_IMAGE(image882, directory + "/OCM-RGB-882");
                 image882.equalize();
                 image882.normalize();
-                WRITE_IMAGE(image882, directory + "/OCM-RGB-882-EQU.png");
+                WRITE_IMAGE(image882, directory + "/OCM-RGB-882-EQU");
                 image::Image<uint16_t> corrected882 = image::earth_curvature::correct_earth_curvature(image882,
                                                                                                       OCEANSAT2_ORBIT_HEIGHT,
                                                                                                       OCEANSAT2_OCM2_SWATH,
                                                                                                       OCEANSAT2_OCM2_RES);
-                WRITE_IMAGE(corrected882, directory + "/OCM-RGB-882-EQU-CORRECTED.png");
+                WRITE_IMAGE(corrected882, directory + "/OCM-RGB-882-EQU-CORRECTED");
             }
 
             logger->info("662 Composite...");
@@ -163,15 +163,15 @@ namespace oceansat
                     image662.draw_image(1, image6);
                     image662.draw_image(2, image2);
                 }
-                WRITE_IMAGE(image662, directory + "/OCM-RGB-662.png");
+                WRITE_IMAGE(image662, directory + "/OCM-RGB-662");
                 image662.equalize();
                 image662.normalize();
-                WRITE_IMAGE(image662, directory + "/OCM-RGB-662-EQU.png");
+                WRITE_IMAGE(image662, directory + "/OCM-RGB-662-EQU");
                 image::Image<uint16_t> corrected662 = image::earth_curvature::correct_earth_curvature(image662,
                                                                                                       OCEANSAT2_ORBIT_HEIGHT,
                                                                                                       OCEANSAT2_OCM2_SWATH,
                                                                                                       OCEANSAT2_OCM2_RES);
-                WRITE_IMAGE(corrected662, directory + "/OCM-RGB-662-EQU-CORRECTED.png");
+                WRITE_IMAGE(corrected662, directory + "/OCM-RGB-662-EQU-CORRECTED");
             }
             */
         }

--- a/plugins/others_support/angels/argos/module_angels_argos.cpp
+++ b/plugins/others_support/angels/argos/module_angels_argos.cpp
@@ -27,6 +27,7 @@ namespace angels
             std::ifstream data_in(d_input_file, std::ios::binary);
 
             std::string directory = d_output_file_hint.substr(0, d_output_file_hint.rfind('/'));
+            std::string filename;
 
             if (!std::filesystem::exists(directory))
                 std::filesystem::create_directory(directory);
@@ -84,7 +85,8 @@ namespace angels
             //frames_out.close();
 
             fft_image.crop(0, 0, 4096, lines);
-            WRITE_IMAGE(fft_image, directory + "/argos_fft");
+            filename = directory + "/argos_fft";
+            WRITE_IMAGE(fft_image, filename);
 
             logger->info("VCID 1 (ARGOS) Frames  : " + std::to_string(argos_cadu));
             logger->info("CCSDS Frames           : " + std::to_string(ccsds));

--- a/plugins/others_support/angels/argos/module_angels_argos.cpp
+++ b/plugins/others_support/angels/argos/module_angels_argos.cpp
@@ -27,7 +27,6 @@ namespace angels
             std::ifstream data_in(d_input_file, std::ios::binary);
 
             std::string directory = d_output_file_hint.substr(0, d_output_file_hint.rfind('/'));
-            std::string filename;
 
             if (!std::filesystem::exists(directory))
                 std::filesystem::create_directory(directory);
@@ -85,8 +84,7 @@ namespace angels
             //frames_out.close();
 
             fft_image.crop(0, 0, 4096, lines);
-            filename = directory + "/argos_fft";
-            WRITE_IMAGE(fft_image, filename);
+            WRITE_IMAGE(fft_image, directory + "/argos_fft");
 
             logger->info("VCID 1 (ARGOS) Frames  : " + std::to_string(argos_cadu));
             logger->info("CCSDS Frames           : " + std::to_string(ccsds));

--- a/plugins/others_support/angels/argos/module_angels_argos.cpp
+++ b/plugins/others_support/angels/argos/module_angels_argos.cpp
@@ -84,7 +84,7 @@ namespace angels
             //frames_out.close();
 
             fft_image.crop(0, 0, 4096, lines);
-            WRITE_IMAGE(fft_image, directory + "/argos_fft.png");
+            WRITE_IMAGE(fft_image, directory + "/argos_fft");
 
             logger->info("VCID 1 (ARGOS) Frames  : " + std::to_string(argos_cadu));
             logger->info("CCSDS Frames           : " + std::to_string(ccsds));

--- a/plugins/others_support/cloudsat/instruments/cpr/module_cloudsat_cpr.cpp
+++ b/plugins/others_support/cloudsat/instruments/cpr/module_cloudsat_cpr.cpp
@@ -31,6 +31,7 @@ namespace cloudsat
             time_t lastTime = 0;
 
             CPReader reader;
+            std::string filename;
             uint8_t buffer[402];
 
             logger->info("Demultiplexing and deframing...");
@@ -61,7 +62,8 @@ namespace cloudsat
                 std::filesystem::create_directory(directory);
 
             image::Image<uint16_t> image = reader.getChannel();
-            WRITE_IMAGE(image, directory + "/CPR");
+            filename = directory + "/CPR";
+            WRITE_IMAGE(image, filename);
 
             image::Image<uint8_t> clut = image::scale_lut<uint8_t>(65536, 0, 65536, image::LUT_jet<uint8_t>());
             image::Image<uint8_t> rain(image.width(), image.height(), 3);
@@ -75,7 +77,8 @@ namespace cloudsat
                 rain.channel(2)[i] = clut.channel(2)[index];
             }
 
-            WRITE_IMAGE(rain, directory + "/CPR-LUT");
+            filename = directory + "/CPR-LUT";
+            WRITE_IMAGE(rain, filename);
         }
 
         void CloudSatCPRDecoderModule::drawUI(bool window)

--- a/plugins/others_support/cloudsat/instruments/cpr/module_cloudsat_cpr.cpp
+++ b/plugins/others_support/cloudsat/instruments/cpr/module_cloudsat_cpr.cpp
@@ -31,7 +31,6 @@ namespace cloudsat
             time_t lastTime = 0;
 
             CPReader reader;
-            std::string filename;
             uint8_t buffer[402];
 
             logger->info("Demultiplexing and deframing...");
@@ -62,8 +61,7 @@ namespace cloudsat
                 std::filesystem::create_directory(directory);
 
             image::Image<uint16_t> image = reader.getChannel();
-            filename = directory + "/CPR";
-            WRITE_IMAGE(image, filename);
+            WRITE_IMAGE(image, directory + "/CPR");
 
             image::Image<uint8_t> clut = image::scale_lut<uint8_t>(65536, 0, 65536, image::LUT_jet<uint8_t>());
             image::Image<uint8_t> rain(image.width(), image.height(), 3);
@@ -77,8 +75,7 @@ namespace cloudsat
                 rain.channel(2)[i] = clut.channel(2)[index];
             }
 
-            filename = directory + "/CPR-LUT";
-            WRITE_IMAGE(rain, filename);
+            WRITE_IMAGE(rain, directory + "/CPR-LUT");
         }
 
         void CloudSatCPRDecoderModule::drawUI(bool window)

--- a/plugins/others_support/cloudsat/instruments/cpr/module_cloudsat_cpr.cpp
+++ b/plugins/others_support/cloudsat/instruments/cpr/module_cloudsat_cpr.cpp
@@ -61,9 +61,7 @@ namespace cloudsat
                 std::filesystem::create_directory(directory);
 
             image::Image<uint16_t> image = reader.getChannel();
-
-            logger->info("Image...");
-            WRITE_IMAGE(image, directory + "/CPR.png");
+            WRITE_IMAGE(image, directory + "/CPR");
 
             image::Image<uint8_t> clut = image::scale_lut<uint8_t>(65536, 0, 65536, image::LUT_jet<uint8_t>());
             image::Image<uint8_t> rain(image.width(), image.height(), 3);
@@ -77,7 +75,7 @@ namespace cloudsat
                 rain.channel(2)[i] = clut.channel(2)[index];
             }
 
-            WRITE_IMAGE(rain, directory + "/CPR-LUT.png");
+            WRITE_IMAGE(rain, directory + "/CPR-LUT");
         }
 
         void CloudSatCPRDecoderModule::drawUI(bool window)

--- a/plugins/others_support/coriolis/instruments/windsat/module_coriolis_windsat.cpp
+++ b/plugins/others_support/coriolis/instruments/windsat/module_coriolis_windsat.cpp
@@ -72,8 +72,8 @@ namespace coriolis
 
             for (int i = 0; i < 11; i++)
             {
-                WRITE_IMAGE(readers[i]->getImage1(), directory + "/WindSat-" + std::to_string(i + 1) + ".png");
-                WRITE_IMAGE(readers[i]->getImage2(), directory + "/WindSat-" + std::to_string(i + 12) + ".png");
+                WRITE_IMAGE(readers[i]->getImage1(), directory + "/WindSat-" + std::to_string(i + 1));
+                WRITE_IMAGE(readers[i]->getImage2(), directory + "/WindSat-" + std::to_string(i + 12));
             }
 
             data_in.close();

--- a/plugins/others_support/coriolis/instruments/windsat/module_coriolis_windsat.cpp
+++ b/plugins/others_support/coriolis/instruments/windsat/module_coriolis_windsat.cpp
@@ -31,7 +31,6 @@ namespace coriolis
             logger->info("Decoding to " + directory);
 
             time_t lastTime = 0;
-            std::string filename;
             uint8_t buffer[1024];
 
             logger->info("Demultiplexing and deframing...");
@@ -72,10 +71,8 @@ namespace coriolis
 
             for (int i = 0; i < 11; i++)
             {
-                filename = directory + "/WindSat-" + std::to_string(i + 1);
-                WRITE_IMAGE(readers[i]->getImage1(), filename);
-                filename = directory + "/WindSat-" + std::to_string(i + 12);
-                WRITE_IMAGE(readers[i]->getImage2(), filename);
+                WRITE_IMAGE(readers[i]->getImage1(), directory + "/WindSat-" + std::to_string(i + 1));
+                WRITE_IMAGE(readers[i]->getImage2(), directory + "/WindSat-" + std::to_string(i + 12));
             }
 
             data_in.close();

--- a/plugins/others_support/coriolis/instruments/windsat/module_coriolis_windsat.cpp
+++ b/plugins/others_support/coriolis/instruments/windsat/module_coriolis_windsat.cpp
@@ -31,7 +31,7 @@ namespace coriolis
             logger->info("Decoding to " + directory);
 
             time_t lastTime = 0;
-
+            std::string filename;
             uint8_t buffer[1024];
 
             logger->info("Demultiplexing and deframing...");
@@ -72,8 +72,10 @@ namespace coriolis
 
             for (int i = 0; i < 11; i++)
             {
-                WRITE_IMAGE(readers[i]->getImage1(), directory + "/WindSat-" + std::to_string(i + 1));
-                WRITE_IMAGE(readers[i]->getImage2(), directory + "/WindSat-" + std::to_string(i + 12));
+                filename = directory + "/WindSat-" + std::to_string(i + 1);
+                WRITE_IMAGE(readers[i]->getImage1(), filename);
+                filename = directory + "/WindSat-" + std::to_string(i + 12);
+                WRITE_IMAGE(readers[i]->getImage2(), filename);
             }
 
             data_in.close();

--- a/plugins/others_support/cryosat/instruments/siral/module_cryosat_siral.cpp
+++ b/plugins/others_support/cryosat/instruments/siral/module_cryosat_siral.cpp
@@ -28,7 +28,6 @@ namespace cryosat
             std::ifstream data_in(d_input_file, std::ios::binary);
 
             std::string directory = d_output_file_hint.substr(0, d_output_file_hint.rfind('/')) + "/SIRAL";
-            std::string filename;
 
             if (!std::filesystem::exists(directory))
                 std::filesystem::create_directory(directory);
@@ -126,8 +125,7 @@ namespace cryosat
 
             {
                 image::Image<uint8_t> outputImage(fftImage.buf, 243, lines, 1);
-                filename = directory + "/SIRAL";
-                WRITE_IMAGE(outputImage, filename);
+                WRITE_IMAGE(outputImage, directory + "/SIRAL");
             }
 
             fftImage.destroy();

--- a/plugins/others_support/cryosat/instruments/siral/module_cryosat_siral.cpp
+++ b/plugins/others_support/cryosat/instruments/siral/module_cryosat_siral.cpp
@@ -125,7 +125,7 @@ namespace cryosat
 
             {
                 image::Image<uint8_t> outputImage(fftImage.buf, 243, lines, 1);
-                WRITE_IMAGE(outputImage, directory + "/SIRAL.png");
+                WRITE_IMAGE(outputImage, directory + "/SIRAL");
             }
 
             fftImage.destroy();

--- a/plugins/others_support/cryosat/instruments/siral/module_cryosat_siral.cpp
+++ b/plugins/others_support/cryosat/instruments/siral/module_cryosat_siral.cpp
@@ -28,6 +28,7 @@ namespace cryosat
             std::ifstream data_in(d_input_file, std::ios::binary);
 
             std::string directory = d_output_file_hint.substr(0, d_output_file_hint.rfind('/')) + "/SIRAL";
+            std::string filename;
 
             if (!std::filesystem::exists(directory))
                 std::filesystem::create_directory(directory);
@@ -125,7 +126,8 @@ namespace cryosat
 
             {
                 image::Image<uint8_t> outputImage(fftImage.buf, 243, lines, 1);
-                WRITE_IMAGE(outputImage, directory + "/SIRAL");
+                filename = directory + "/SIRAL";
+                WRITE_IMAGE(outputImage, filename);
             }
 
             fftImage.destroy();

--- a/plugins/others_support/scisat1/module_scisat1_instruments.cpp
+++ b/plugins/others_support/scisat1/module_scisat1_instruments.cpp
@@ -96,11 +96,11 @@ namespace scisat1
                 if (!std::filesystem::exists(fts_directory))
                     std::filesystem::create_directory(fts_directory);
 
-                fts_reader.getImg().save_img(fts_directory + "/FTS.png");
+                fts_reader.getImg().save_img(fts_directory + "/FTS");
 
                 auto img = fts_reader.getImg();
                 img.resize_bilinear(img.width() / 10, img.height() * 10);
-                img.save_img(fts_directory + "/FTS_scaled.png");
+                img.save_img(fts_directory + "/FTS_scaled");
 
                 fts_status = DONE;
             }
@@ -118,8 +118,8 @@ namespace scisat1
                 if (!std::filesystem::exists(maestro_directory))
                     std::filesystem::create_directory(maestro_directory);
 
-                maestro_reader.getImg1().save_img(maestro_directory + "/MAESTRO_1.png");
-                maestro_reader.getImg2().save_img(maestro_directory + "/MAESTRO_2.png");
+                maestro_reader.getImg1().save_img(maestro_directory + "/MAESTRO_1");
+                maestro_reader.getImg2().save_img(maestro_directory + "/MAESTRO_2");
 
                 maestro_status = DONE;
             }

--- a/plugins/proba_support/proba/instruments/chris/chris_reader.cpp
+++ b/plugins/proba_support/proba/instruments/chris/chris_reader.cpp
@@ -183,14 +183,13 @@ namespace proba
 
                     // Save Half alone
                     std::string image_name = std::to_string(img_tag) + "_Half_" + (is_2nd_half ? "2" : "1");
-                    logger->info("Finished CHRIS image! Saving as CHRIS-" + image_name + ".png. Mode " + getModeName(chris_img.mode));
 
                     std::string dir_path = output_folder + "/CHRIS-" + image_name;
 
                     if (!std::filesystem::exists(dir_path))
                         std::filesystem::create_directories(dir_path);
 
-                    chris_img.raw.save_png(dir_path + "/RAW.png");
+                    chris_img.raw.save_img(dir_path + "/RAW");
 
                     satdump::ImageProducts chris_products;
                     chris_products.instrument_name = "chris";
@@ -201,7 +200,7 @@ namespace proba
                     {
                         image::Image<uint16_t> ch = chris_img.channels[i];
                         ch.resize(ch.width() * 2, ch.height());
-                        chris_products.images.push_back({"CHRIS-" + std::to_string(i + 1) + ".png", std::to_string(i + 1), ch});
+                        chris_products.images.push_back({"CHRIS-" + std::to_string(i + 1), std::to_string(i + 1), ch});
                     }
 
                     chris_products.save(dir_path);
@@ -234,14 +233,13 @@ namespace proba
 
                     // Save Full frame
                     std::string image_name = std::to_string(currentPair.first) + "_Full";
-                    logger->info("Got Full CHRIS image! Saving as CHRIS-" + image_name + ".png. Mode " + getModeName(chris_img.mode));
 
                     std::string dir_path = output_folder + "/CHRIS-" + image_name;
 
                     if (!std::filesystem::exists(dir_path))
                         std::filesystem::create_directories(dir_path);
 
-                    chris_img.raw.save_png(dir_path + "/RAW.png");
+                    chris_img.raw.save_img(dir_path + "/RAW");
 
                     satdump::ImageProducts chris_products;
                     chris_products.instrument_name = "chris";
@@ -251,7 +249,7 @@ namespace proba
                     for (int i = 0; i < (int)chris_img.channels.size(); i++)
                     {
                         image::Image<uint16_t> ch = chris_img.channels[i];
-                        chris_products.images.push_back({"CHRIS-" + std::to_string(i + 1) + ".png", std::to_string(i + 1), ch});
+                        chris_products.images.push_back({"CHRIS-" + std::to_string(i + 1), std::to_string(i + 1), ch});
                     }
 
                     chris_products.save(dir_path);

--- a/plugins/proba_support/proba/instruments/hrc/hrc_reader.cpp
+++ b/plugins/proba_support/proba/instruments/hrc/hrc_reader.cpp
@@ -75,12 +75,11 @@ namespace proba
         {
             for (auto &imgh : hrc_images)
             {
-                logger->info("Finished HRC image! Saving as HRC-" + std::to_string(imgh.first) + ".png");
                 image::Image<uint16_t> img = imgh.second->getImg();
-                img.save_png(output_folder + "/HRC-" + std::to_string(imgh.first) + ".png");
+                img.save_img(output_folder + "/HRC-" + std::to_string(imgh.first));
                 img.normalize();
                 img.equalize();
-                img.save_png(output_folder + "/HRC-" + std::to_string(imgh.first) + "-EQU.png");
+                img.save_img(output_folder + "/HRC-" + std::to_string(imgh.first) + "-EQU");
             }
         }
     } // namespace hrc

--- a/plugins/proba_support/proba/instruments/swap/swap_reader.cpp
+++ b/plugins/proba_support/proba/instruments/swap/swap_reader.cpp
@@ -87,6 +87,7 @@ namespace proba
 
             for (std::pair<const time_t, std::pair<int, std::pair<std::string, std::vector<uint8_t>>>> &currentPair : currentOuts)
             {
+                std::string extension = "";
                 std::string filename = currentPair.second.second.first;
                 std::vector<uint8_t> &currentOutVec = currentPair.second.second.second;
 
@@ -112,11 +113,11 @@ namespace proba
 
                 // Despeckle
                 img.simple_despeckle(20);
-                if (std::filesystem::exists(output_folder + "/" + filename + ".png") || std::filesystem::exists(output_folder + "/" + filename + ".jpg"))
+                img.append_ext(&extension);
+                if (std::filesystem::exists(output_folder + "/" + filename + extension))
                 {
                     int i = 0;
-                    while (std::filesystem::exists(output_folder + "/" + filename + "-" + std::to_string(i) + ".png") || 
-                        std::filesystem::exists(output_folder + "/" + filename + "-" + std::to_string(i) + ".jpg"))
+                    while (std::filesystem::exists(output_folder + "/" + filename + "-" + std::to_string(i) + extension))
                         i++;
                     filename = filename + "-" + std::to_string(i);
                 }

--- a/plugins/proba_support/proba/instruments/swap/swap_reader.cpp
+++ b/plugins/proba_support/proba/instruments/swap/swap_reader.cpp
@@ -10,10 +10,12 @@
 #include "common/ccsds/ccsds_time.h"
 
 #define WRITE_IMAGE_LOCAL(image, path)            \
+{                                                 \
     std::string newPath = path;                   \
     image.append_ext(&newPath);                   \
     image.save_img(std::string(newPath).c_str()); \
-    all_images.push_back(newPath);
+    all_images.push_back(newPath);                \
+}
 
 namespace proba
 {

--- a/plugins/proba_support/proba/instruments/swap/swap_reader.cpp
+++ b/plugins/proba_support/proba/instruments/swap/swap_reader.cpp
@@ -9,9 +9,11 @@
 #include "resources.h"
 #include "common/ccsds/ccsds_time.h"
 
-#define WRITE_IMAGE_LOCAL(image, path)         \
-    image.save_png(std::string(path).c_str()); \
-    all_images.push_back(path);
+#define WRITE_IMAGE_LOCAL(image, path)            \
+    std::string newPath = path;                   \
+    image.append_ext(&newPath);                   \
+    image.save_img(std::string(newPath).c_str()); \
+    all_images.push_back(newPath);
 
 namespace proba
 {
@@ -108,16 +110,15 @@ namespace proba
 
                 // Despeckle
                 img.simple_despeckle(20);
-
-                logger->info("Good! Saving as png... ");
-                if (std::filesystem::exists(output_folder + "/" + filename + ".png"))
+                if (std::filesystem::exists(output_folder + "/" + filename + ".png") || std::filesystem::exists(output_folder + "/" + filename + ".jpg"))
                 {
                     int i = 0;
-                    while (std::filesystem::exists(output_folder + "/" + filename + "-" + std::to_string(i) + ".png"))
+                    while (std::filesystem::exists(output_folder + "/" + filename + "-" + std::to_string(i) + ".png") || 
+                        std::filesystem::exists(output_folder + "/" + filename + "-" + std::to_string(i) + ".jpg"))
                         i++;
                     filename = filename + "-" + std::to_string(i);
                 }
-                WRITE_IMAGE_LOCAL(img, output_folder + "/" + filename + ".png");
+                WRITE_IMAGE_LOCAL(img, output_folder + "/" + filename);
             }
         }
     } // namespace swap

--- a/plugins/proba_support/proba/module_proba_instruments.cpp
+++ b/plugins/proba_support/proba/module_proba_instruments.cpp
@@ -303,15 +303,15 @@ namespace proba
 
                     std::string vegs_directory = d_output_file_hint.substr(0, d_output_file_hint.rfind('/')) + "/Vegetation";
 
-                    vegs_readers[i][0]->getImg().save_img(vegs_directory + "/Vegetation" + std::to_string(i + 1) + "_1.png");
-                    vegs_readers[i][1]->getImg().save_img(vegs_directory + "/Vegetation" + std::to_string(i + 1) + "_2.png");
+                    vegs_readers[i][0]->getImg().save_img(vegs_directory + "/Vegetation" + std::to_string(i + 1) + "_1");
+                    vegs_readers[i][1]->getImg().save_img(vegs_directory + "/Vegetation" + std::to_string(i + 1) + "_2");
                     auto img3 = vegs_readers[i][2]->getImg();
                     img3.mirror(true, false);
-                    img3.save_img(vegs_directory + "/Vegetation" + std::to_string(i + 1) + "_3.png");
+                    img3.save_img(vegs_directory + "/Vegetation" + std::to_string(i + 1) + "_3");
                     img3.clear();
-                    vegs_readers[i][3]->getImg().save_img(vegs_directory + "/Vegetation" + std::to_string(i + 1) + "_4.png");
-                    vegs_readers[i][4]->getImg().save_img(vegs_directory + "/Vegetation" + std::to_string(i + 1) + "_5.png");
-                    vegs_readers[i][5]->getImg().save_img(vegs_directory + "/Vegetation" + std::to_string(i + 1) + "_6.png");
+                    vegs_readers[i][3]->getImg().save_img(vegs_directory + "/Vegetation" + std::to_string(i + 1) + "_4");
+                    vegs_readers[i][4]->getImg().save_img(vegs_directory + "/Vegetation" + std::to_string(i + 1) + "_5");
+                    vegs_readers[i][5]->getImg().save_img(vegs_directory + "/Vegetation" + std::to_string(i + 1) + "_6");
 
                     for (int y = 0; y < 6; y++)
                         vegs_status[i][y] = DONE;

--- a/plugins/stereo_support/stereo/instruments/secchi/secchi_reader.cpp
+++ b/plugins/stereo_support/stereo/instruments/secchi/secchi_reader.cpp
@@ -81,9 +81,9 @@ namespace stereo
                         logger->info("Saving SECCHI " + channel_name + " Image");
 
                         if (last_timestamp_0 != 0)
-                            img.save_png(output_directory + "/" + channel_name + "/" + filename_timestamp(last_timestamp_0) + ".png");
+                            img.save_img(output_directory + "/" + channel_name + "/" + filename_timestamp(last_timestamp_0));
                         else
-                            img.save_png(output_directory + "/" + channel_name + "/" + std::to_string(unknown_cnt++) + ".png");
+                            img.save_img(output_directory + "/" + channel_name + "/" + std::to_string(unknown_cnt++));
 
                         if (last_filename_0.size() > 0)
                             decompression_status_out << channel_name << "     " << last_filename_0 << " " << timestamp_to_string(last_timestamp_0) << " " << ((img.size() > 0) ? "PASS" : "FAIL") << "\n";
@@ -125,9 +125,9 @@ namespace stereo
                         logger->info("Saving SECCHI " + channel_name + " Image");
 
                         // if (last_timestamp_1 != 0)
-                        //     img.save_png(output_directory + "/" + channel_name + "/" + filename_timestamp(last_timestamp_1) + ".png");
+                        //     img.save_img(output_directory + "/" + channel_name + "/" + filename_timestamp(last_timestamp_1));
                         // else
-                        img.save_png(output_directory + "/" + channel_name + "/" + std::to_string(unknown_cnt++) + ".png");
+                        img.save_img(output_directory + "/" + channel_name + "/" + std::to_string(unknown_cnt++));
 
                         if (last_filename_1.size() > 0)
                             decompression_status_out << channel_name << "      " << last_filename_1 << " " << timestamp_to_string(last_timestamp_1) << " " << ((img.size() > 0) ? "PASS" : "FAIL") << "\n";
@@ -166,9 +166,9 @@ namespace stereo
                         logger->info("Saving SECCHI " + channel_name + " Image");
 
                         // if (last_timestamp_2 != 0)
-                        //     img.save_png(output_directory + "/" + channel_name + "/" + filename_timestamp(last_timestamp_2) + ".png");
+                        //     img.save_img(output_directory + "/" + channel_name + "/" + filename_timestamp(last_timestamp_2));
                         // else
-                        img.save_png(output_directory + "/" + channel_name + "/" + std::to_string(unknown_cnt++) + ".png");
+                        img.save_img(output_directory + "/" + channel_name + "/" + std::to_string(unknown_cnt++));
 
                         if (last_filename_2.size() > 0)
                             decompression_status_out << channel_name << "      " << last_filename_2 << " " << timestamp_to_string(last_timestamp_2) << " " << ((img.size() > 0) ? "PASS" : "FAIL") << "\n";
@@ -221,9 +221,9 @@ namespace stereo
                         logger->info("Saving SECCHI " + channel_name + " Image");
 
                         if (last_timestamp_3 != 0)
-                            img.save_png(output_directory + "/" + channel_name + "/" + filename_timestamp(last_timestamp_3) + ".png");
+                            img.save_img(output_directory + "/" + channel_name + "/" + filename_timestamp(last_timestamp_3));
                         else
-                            img.save_png(output_directory + "/" + channel_name + "/" + std::to_string(unknown_cnt++) + ".png");
+                            img.save_img(output_directory + "/" + channel_name + "/" + std::to_string(unknown_cnt++) );
 
                         if (last_filename_3.size() > 0)
                             decompression_status_out << channel_name << " " << last_filename_3 << " " << timestamp_to_string(last_timestamp_3) << " " << ((img.size() > 0) ? "PASS" : "FAIL") << "\n";

--- a/plugins/stereo_support/stereo/module_stereo_instruments.cpp
+++ b/plugins/stereo_support/stereo/module_stereo_instruments.cpp
@@ -171,7 +171,7 @@ namespace stereo
             logger->info("Lines : " + std::to_string(s_waves_lines));
 
             image::Image<uint8_t> image_s_waves(s_waves_data.data(), 162, s_waves_lines, 1);
-            image_s_waves.save_png(directory + "/S_WAVES.png");
+            image_s_waves.save_img(directory + "/S_WAVES");
         }
     }
 

--- a/plugins/tubsat_support/tubin/module_tubin_decoder.cpp
+++ b/plugins/tubsat_support/tubin/module_tubin_decoder.cpp
@@ -170,10 +170,10 @@ namespace tubin
                 // tubin_products.set_timestamps(avhrr_reader.timestamps);
                 // tubin_products.set_proj_cfg(loadJsonFile(resources::getResourcePath("projections_settings/metop_abc_avhrr.json")));
 
-                tubin_products.images.push_back({"TUBIN-1.png", "1", image_ch1});
-                tubin_products.images.push_back({"TUBIN-2.png", "2", image_ch2});
-                tubin_products.images.push_back({"TUBIN-3.png", "3", image_ch3});
-                tubin_products.images.push_back({"TUBIN-4.png", "4", image_ch4});
+                tubin_products.images.push_back({"TUBIN-1", "1", image_ch1});
+                tubin_products.images.push_back({"TUBIN-2", "2", image_ch2});
+                tubin_products.images.push_back({"TUBIN-3", "3", image_ch3});
+                tubin_products.images.push_back({"TUBIN-4", "4", image_ch4});
 
                 tubin_products.save(directory);
                 dataset.products_list.push_back(product_name);

--- a/satdump_cfg.json
+++ b/satdump_cfg.json
@@ -111,15 +111,25 @@
             "name": "Save log file",
             "description": "Save ALL SatDump logs to a file.\nThis is useful to send in\nbug reports and such."
         },
-        "image_format": {
+        "product_format": {
             "type": "options",
             "value": "png",
-            "name": "Default Image Format",
+            "name": "Product Image Format",
             "options": [
                 "png",
                 "jpg"
             ],
-            "description": "Default format for processed images.\n\nDoes not apply to images transmitted in an already viewable\nformat, or grayscale images less than 200 pixels wide."
+            "description": "Image format for raw image products (PNG or JPEG)\n\nWARNING: Using JPEG for product images will degrade any\ncomposites or projections generated from them!"
+        },
+        "image_format": {
+            "type": "options",
+            "value": "png",
+            "name": "Processed Image Format",
+            "options": [
+                "png",
+                "jpg"
+            ],
+            "description": "Default format for processed images.\n\nDoes not apply to raw image products or images\ntransmitted in an already viewable format"
         },
         "opencl_device": {
             "platform": 0,

--- a/satdump_cfg.json
+++ b/satdump_cfg.json
@@ -117,9 +117,10 @@
             "name": "Product Image Format",
             "options": [
                 "png",
+                "j2k",
                 "jpg"
             ],
-            "description": "Image format for raw image products (PNG or JPEG)\n\nWARNING: Using JPEG for product images will degrade any\ncomposites or projections generated from them!"
+            "description": "Image format for raw image products\n\nPNG: PNG Image (recommended)\nj2k: JPEG 2000\njpg: JPEG Image (not recommended; may result\nin low-quality composites and projections)"
         },
         "image_format": {
             "type": "options",
@@ -127,9 +128,10 @@
             "name": "Processed Image Format",
             "options": [
                 "png",
+                "j2k",
                 "jpg"
             ],
-            "description": "Default format for processed images.\n\nDoes not apply to raw image products or images\ntransmitted in an already viewable format"
+            "description": "Default format for processed images\n\nDoes not apply to raw image products or images\ntransmitted in an already viewable format"
         },
         "opencl_device": {
             "platform": 0,

--- a/satdump_cfg.json
+++ b/satdump_cfg.json
@@ -119,7 +119,7 @@
                 "png",
                 "jpg"
             ],
-            "description": "Default format for processed images.\nDoes not apply to images transmitted\nin an already-viewable format."
+            "description": "Default format for processed images.\n\nDoes not apply to images transmitted in an already viewable\nformat, or grayscale images less than 200 pixels wide."
         },
         "opencl_device": {
             "platform": 0,

--- a/satdump_cfg.json
+++ b/satdump_cfg.json
@@ -111,6 +111,16 @@
             "name": "Save log file",
             "description": "Save ALL SatDump logs to a file.\nThis is useful to send in\nbug reports and such."
         },
+        "image_format": {
+            "type": "options",
+            "value": "png",
+            "name": "Default Image Format",
+            "options": [
+                "png",
+                "jpg"
+            ],
+            "description": "Default format for processed images.\nDoes not apply to images transmitted\nin an already-viewable format."
+        },
         "opencl_device": {
             "platform": 0,
             "device": 0

--- a/scripts/Configure-vcpkg.ps1
+++ b/scripts/Configure-vcpkg.ps1
@@ -14,7 +14,7 @@ if(Test-Path "$(Split-Path -Parent $MyInvocation.MyCommand.Path)\..\vcpkg" -Erro
 Write-Output "Configuing vcpkg..."
 cd "$(Split-Path -Parent $MyInvocation.MyCommand.Path)\.."
 mkdir vcpkg | Out-Null
-git clone -b debug --depth 1 https://github.com/JVital2013/vcpkg-satdump.git vcpkg
+git clone --depth 1 https://github.com/Aang23/vcpkg.git
 cd vcpkg
 
 #Install SDRPlay API into vcpkg

--- a/src-core/common/image/image.cpp
+++ b/src-core/common/image/image.cpp
@@ -264,6 +264,15 @@ namespace image
             file->find(".jpg") != std::string::npos)
             return true;
 
+		// Force PNG if the image is grayscale and less than
+		// 200px wide. Small grayscale jpegs don't save well
+		if(d_channels == 1 && d_width < 200)
+		{
+			*file += ".png";
+			return true;
+		}
+
+		//Otherwise, load the user setting
         std::string image_format;
         try
         {

--- a/src-core/common/image/image.cpp
+++ b/src-core/common/image/image.cpp
@@ -264,14 +264,6 @@ namespace image
             file->find(".jpg") != std::string::npos)
             return true;
 
-        // Force PNG if the image is grayscale and less than
-        // 200px wide. Small grayscale jpegs don't save well
-        if(d_channels == 1 && d_width < 200)
-        {
-            *file += ".png";
-            return true;
-        }
-
         //Otherwise, load the user setting
         std::string image_format;
         try

--- a/src-core/common/image/image.cpp
+++ b/src-core/common/image/image.cpp
@@ -264,15 +264,15 @@ namespace image
             file->find(".jpg") != std::string::npos)
             return true;
 
-		// Force PNG if the image is grayscale and less than
-		// 200px wide. Small grayscale jpegs don't save well
-		if(d_channels == 1 && d_width < 200)
-		{
-			*file += ".png";
-			return true;
-		}
+        // Force PNG if the image is grayscale and less than
+        // 200px wide. Small grayscale jpegs don't save well
+        if(d_channels == 1 && d_width < 200)
+        {
+            *file += ".png";
+            return true;
+        }
 
-		//Otherwise, load the user setting
+        //Otherwise, load the user setting
         std::string image_format;
         try
         {

--- a/src-core/common/image/image.cpp
+++ b/src-core/common/image/image.cpp
@@ -266,7 +266,8 @@ namespace image
         //Do nothing if there's already an extension
         if (file->find(".png") != std::string::npos ||
             file->find(".jpeg") != std::string::npos ||
-            file->find(".jpg") != std::string::npos)
+            file->find(".jpg") != std::string::npos || 
+            file->find(".j2k") != std::string::npos)
             return true;
 
         //Otherwise, load the user setting
@@ -281,7 +282,7 @@ namespace image
             return false;
         }
 
-        if (image_format != "png" && image_format != "jpg")
+        if (image_format != "png" && image_format != "jpg" && image_format != "j2k")
         {
             logger->error("Image format not specified, and default format is invalid!");
             return false;

--- a/src-core/common/image/image.cpp
+++ b/src-core/common/image/image.cpp
@@ -1,4 +1,6 @@
 #include "image.h"
+#include "logger.h"
+#include "core/config.h"
 #include <cstring>
 #include <limits>
 #include <fstream>
@@ -242,12 +244,45 @@ namespace image
     }
 
     template <typename T>
-    void Image<T>::save_img(std::string file)
+    void Image<T>::save_img(std::string file, bool fast)
     {
+        if(!append_ext(&file)) return;
+        logger->info("Saving " + file + "...");
         if (file.find(".png") != std::string::npos)
-            save_png(file);
+            save_png(file, fast);
         else if (file.find(".jpeg") != std::string::npos || file.find(".jpg") != std::string::npos)
             save_jpeg(file);
+    }
+
+    // Append selected file extension
+    template <typename T>
+    bool Image<T>::append_ext(std::string* file)
+    {
+        //Do nothing if there's already an extension
+        if (file->find(".png") != std::string::npos ||
+            file->find(".jpeg") != std::string::npos ||
+            file->find(".jpg") != std::string::npos)
+            return true;
+
+        std::string image_format;
+        try
+        {
+            image_format = satdump::config::main_cfg["satdump_general"]["image_format"]["value"];
+        }
+        catch (std::exception& e)
+        {
+            logger->error("Image format not specified, and default format cannot be found! %s", e.what());
+            return false;
+        }
+
+        if (image_format != "png" && image_format != "jpg")
+        {
+            logger->error("Image format not specified, and default format is invalid!");
+            return false;
+        }
+
+        *file += "." + image_format;
+        return true;
     }
 
     // Generate Images for uint16_t and uint8_t

--- a/src-core/common/image/image.h
+++ b/src-core/common/image/image.h
@@ -122,9 +122,10 @@ namespace image
         void load_jpeg(uint8_t *buffer, int size); // Load a JPEG from memory
 
         // Generic loading/saving interface
-        void load_img(std::string file);          // Load a file, auto-detecting type
-        void load_img(uint8_t *buffer, int size); // Load from memory, auto-detecting type
-        void save_img(std::string file);          // Save file, determine type based on extension
+        void load_img(std::string file);                            // Load a file, auto-detecting type
+        void load_img(uint8_t *buffer, int size);                   // Load from memory, auto-detecting type
+        void save_img(std::string file, bool fast = true);          // Save file, determine type based on extension or default setting
+        bool append_ext(std::string* file);                         // If the filename has no extension, use the default image format
     };
 
     // Others

--- a/src-core/common/image/image_jpegio.cpp
+++ b/src-core/common/image/image_jpegio.cpp
@@ -182,6 +182,7 @@ namespace image
         cinfo.input_components = jpeg_channels;
         cinfo.in_color_space = jpeg_channels == 3 ? JCS_RGB : JCS_GRAYSCALE;
         jpeg_set_defaults(&cinfo);
+        jpeg_set_quality(&cinfo, 90, true);
         jpeg_start_compress(&cinfo, true);
 
         // Init output buffer

--- a/src-core/common/image/image_saving_thread.h
+++ b/src-core/common/image/image_saving_thread.h
@@ -32,7 +32,7 @@ namespace image
 
                     // logger->debug("Queue length %d", queue.size());
                     logger->info("Saving " + img.second);
-                    img.first.save_png(img.second);
+                    img.first.save_img(img.second);
                     continue;
                 }
 
@@ -68,7 +68,7 @@ namespace image
             else
             {
                 logger->info("Saving " + path);
-                img.save_png(path);
+                img.save_img(path);
             }
         }
     };

--- a/src-core/core/module.h
+++ b/src-core/core/module.h
@@ -14,10 +14,13 @@
 #include "plugin.h"
 
 // Utils
-#define WRITE_IMAGE(image, path)               \
-    image.append_ext(&path);                   \
-    image.save_img(std::string(path).c_str()); \
-    d_output_files.push_back(path);
+#define WRITE_IMAGE(image, path)                  \
+{                                                 \
+    std::string newPath = path;                   \
+    image.append_ext(&newPath);                   \
+    image.save_img(std::string(newPath).c_str()); \
+    d_output_files.push_back(newPath);            \
+}
 #define UITO_C_STR(input) "%s", std::to_string(input).c_str()
 
 // Colors

--- a/src-core/core/module.h
+++ b/src-core/core/module.h
@@ -14,11 +14,10 @@
 #include "plugin.h"
 
 // Utils
-#define WRITE_IMAGE(image, path)                  \
-    std::string newPath = path;                   \
-    image.append_ext(&newPath);                   \
-    image.save_img(std::string(newPath).c_str()); \
-    d_output_files.push_back(newPath);
+#define WRITE_IMAGE(image, path)               \
+    image.append_ext(&path);                   \
+    image.save_img(std::string(path).c_str()); \
+    d_output_files.push_back(path);
 #define UITO_C_STR(input) "%s", std::to_string(input).c_str()
 
 // Colors

--- a/src-core/core/module.h
+++ b/src-core/core/module.h
@@ -14,9 +14,11 @@
 #include "plugin.h"
 
 // Utils
-#define WRITE_IMAGE(image, path)               \
-    image.save_png(std::string(path).c_str()); \
-    d_output_files.push_back(path);
+#define WRITE_IMAGE(image, path)                  \
+    std::string newPath = path;                   \
+    image.append_ext(&newPath);                   \
+    image.save_img(std::string(newPath).c_str()); \
+    d_output_files.push_back(newPath);
 #define UITO_C_STR(input) "%s", std::to_string(input).c_str()
 
 // Colors

--- a/src-core/imgui/pfd/portable-file-dialogs.h
+++ b/src-core/imgui/pfd/portable-file-dialogs.h
@@ -1055,6 +1055,9 @@ inline internal::file_dialog::file_dialog(type in_type,
 
         if (in_type == type::save)
         {
+            auto wextension = std::wstring(3, L'\0');
+            ofn.lpstrDefExt = (LPWSTR)wextension.data();
+
             if (!(options & opt::force_overwrite))
                 ofn.Flags |= OFN_OVERWRITEPROMPT;
 

--- a/src-core/products/image_products.cpp
+++ b/src-core/products/image_products.cpp
@@ -24,6 +24,8 @@ namespace satdump
 
         for (size_t c = 0; c < images.size(); c++)
         {
+            if (!images[c].image.append_ext(&images[c].filename))
+                return;
             contents["images"][c]["file"] = images[c].filename;
             contents["images"][c]["name"] = images[c].channel_name;
 
@@ -38,10 +40,7 @@ namespace satdump
                 contents["images"][c]["offset_x"] = images[c].offset_x;
 
             if (!save_as_matrix)
-            {
-                logger->info("Saving " + images[c].filename);
-                images[c].image.save_png(directory + "/" + images[c].filename);
-            }
+                images[c].image.save_img(directory + "/" + images[c].filename);
         }
 
         if (save_as_matrix)
@@ -50,8 +49,7 @@ namespace satdump
             logger->debug("Using size %d", size);
             image::Image<uint16_t> image_all = image::make_manyimg_composite<uint16_t>(size, size, images.size(), [this](int c)
                                                                                        { return images[c].image; });
-            logger->info("Saving " + images[0].filename);
-            image_all.save_png(directory + "/" + images[0].filename);
+            image_all.save_img(directory + "/" + images[0].filename);
             contents["img_matrix_size"] = size;
         }
 
@@ -76,7 +74,7 @@ namespace satdump
         if (save_as_matrix)
         {
             if (std::filesystem::exists(directory + "/" + contents["images"][0]["file"].get<std::string>()))
-                img_matrix.load_png(directory + "/" + contents["images"][0]["file"].get<std::string>());
+                img_matrix.load_img(directory + "/" + contents["images"][0]["file"].get<std::string>());
         }
 
         for (size_t c = 0; c < contents["images"].size(); c++)
@@ -91,7 +89,7 @@ namespace satdump
             if (!save_as_matrix)
             {
                 if (std::filesystem::exists(directory + "/" + contents["images"][c]["file"].get<std::string>()))
-                    img_holder.image.load_png(directory + "/" + contents["images"][c]["file"].get<std::string>());
+                    img_holder.image.load_img(directory + "/" + contents["images"][c]["file"].get<std::string>());
             }
             else
             {

--- a/src-core/products/image_products.cpp
+++ b/src-core/products/image_products.cpp
@@ -36,9 +36,14 @@ namespace satdump
 
         for (size_t c = 0; c < images.size(); c++)
         {
-            images[c].filename += "." + image_format;
-            contents["images"][c]["file"] = images[c].filename;
-            contents["images"][c]["name"] = images[c].channel_name;
+            if (images[c].filename.find(".png") == std::string::npos &&
+                images[c].filename.find(".jpeg") == std::string::npos &&
+                images[c].filename.find(".jpg") == std::string::npos)
+            {
+                images[c].filename += "." + image_format;
+                contents["images"][c]["file"] = images[c].filename;
+                contents["images"][c]["name"] = images[c].channel_name;
+            }
 
             if (images[c].timestamps.size() > 0)
             {

--- a/src-core/products/image_products.cpp
+++ b/src-core/products/image_products.cpp
@@ -1,5 +1,6 @@
 #include "image_products.h"
 #include "logger.h"
+#include "core/config.h"
 #include "common/image/composite.h"
 #include "resources.h"
 #include "common/image/earth_curvature.h"
@@ -22,10 +23,20 @@ namespace satdump
         if (save_as_matrix)
             contents["save_as_matrix"] = save_as_matrix;
 
+        std::string image_format;
+        try
+        {
+            image_format = satdump::config::main_cfg["satdump_general"]["product_format"]["value"];
+        }
+        catch (std::exception& e)
+        {
+            logger->error("Product format not specified, using PNG! %s", e.what());
+            image_format = "png";
+        }
+
         for (size_t c = 0; c < images.size(); c++)
         {
-            if (!images[c].image.append_ext(&images[c].filename))
-                return;
+            images[c].filename += "." + image_format;
             contents["images"][c]["file"] = images[c].filename;
             contents["images"][c]["name"] = images[c].channel_name;
 

--- a/src-core/products/image_products.cpp
+++ b/src-core/products/image_products.cpp
@@ -38,7 +38,8 @@ namespace satdump
         {
             if (images[c].filename.find(".png") == std::string::npos &&
                 images[c].filename.find(".jpeg") == std::string::npos &&
-                images[c].filename.find(".jpg") == std::string::npos)
+                images[c].filename.find(".jpg") == std::string::npos && 
+                images[c].filename.find(".j2k") == std::string::npos)
                 images[c].filename += "." + image_format;
 
             contents["images"][c]["file"] = images[c].filename;

--- a/src-core/products/image_products.cpp
+++ b/src-core/products/image_products.cpp
@@ -39,11 +39,10 @@ namespace satdump
             if (images[c].filename.find(".png") == std::string::npos &&
                 images[c].filename.find(".jpeg") == std::string::npos &&
                 images[c].filename.find(".jpg") == std::string::npos)
-            {
                 images[c].filename += "." + image_format;
-                contents["images"][c]["file"] = images[c].filename;
-                contents["images"][c]["name"] = images[c].channel_name;
-            }
+
+            contents["images"][c]["file"] = images[c].filename;
+            contents["images"][c]["name"] = images[c].channel_name;
 
             if (images[c].timestamps.size() > 0)
             {

--- a/src-core/products/processor/image_processor.cpp
+++ b/src-core/products/processor/image_processor.cpp
@@ -120,8 +120,7 @@ namespace satdump
                                                        100);
                     }
 
-                    logger->info("Saving " + product_path + "/" + name + ".png");
-                    rgb_image.save_png(product_path + "/" + name + ".png");
+                    rgb_image.save_img(product_path + "/" + name);
 
                     if (compo.value().contains("project") && img_products->has_proj_cfg())
                     {
@@ -131,7 +130,7 @@ namespace satdump
                                                                         rgb_image,
                                                                         final_timestamps,
                                                                         *img_products);
-                        ret.img.save_png(product_path + "/rgb_" + name + "_projected.png");
+                        ret.img.save_img(product_path + "/rgb_" + name + "_projected");
                     }
 
                     if ((compo.value().contains("geo_correct") ? compo.value()["geo_correct"].get<bool>() : false) && rgb_image.size() > 0)
@@ -141,8 +140,7 @@ namespace satdump
 
                         if (success)
                         {
-                            logger->info("Saving " + product_path + "/" + name + "_corrected.png");
-                            rgb_image.save_png(product_path + "/" + name + "_corrected.png");
+                            rgb_image.save_img(product_path + "/" + name + "_corrected");
                         }
                     }
                 }
@@ -188,7 +186,7 @@ namespace satdump
                                                                 img.image,
                                                                 img_products->get_timestamps(chanid),
                                                                 *img_products);
-                ret.img.save_png(product_path + "/channel_" + img.channel_name + "_projected.png");
+                ret.img.save_img(product_path + "/channel_" + img.channel_name + "_projected");
             }
         }
     }

--- a/src-core/products/processor/radiation_processor.cpp
+++ b/src-core/products/processor/radiation_processor.cpp
@@ -30,12 +30,9 @@ namespace satdump
                 RadiationMapCfg cfg = compo.value().get<RadiationMapCfg>();
                 image::Image<uint16_t> rad_map = satdump::make_radiation_map(*rad_products, cfg);
 
-                std::string name = products->instrument_name +
-                                   "_map_" +
-                                   initial_name + ".png";
+                std::string name = products->instrument_name + "_map_" + initial_name;
 
-                logger->info("Saving " + product_path + "/" + name);
-                rad_map.save_png(product_path + "/" + name);
+                rad_map.save_img(product_path + "/" + name);
             }
         }
     }

--- a/src-core/products/processor/scatterometer_processor.cpp
+++ b/src-core/products/processor/scatterometer_processor.cpp
@@ -33,12 +33,8 @@ namespace satdump
                 GrayScaleScatCfg cfg = compo.value().get<GrayScaleScatCfg>();
                 image::Image<uint16_t> grayscale = satdump::make_scatterometer_grayscale(*rad_products, cfg);
 
-                std::string name = products->instrument_name +
-                                   "_grayscale_" +
-                                   initial_name + ".png";
-
-                logger->info("Saving " + product_path + "/" + name);
-                grayscale.save_png(product_path + "/" + name);
+                std::string name = products->instrument_name + "_grayscale_" + initial_name;
+                grayscale.save_img(product_path + "/" + name);
             }
         }
 
@@ -70,12 +66,8 @@ namespace satdump
                     }
                 }
 
-                std::string name = products->instrument_name +
-                                   "_grayscale_proj_" +
-                                   initial_name + ".png";
-
-                logger->info("Saving " + product_path + "/" + name);
-                grayscale.save_png(product_path + "/" + name);
+                std::string name = products->instrument_name + "_grayscale_proj_" + initial_name;
+                grayscale.save_img(product_path + "/" + name);
             }
         }
     }

--- a/src-interface/viewer/image_handler.cpp
+++ b/src-interface/viewer/image_handler.cpp
@@ -553,7 +553,8 @@ namespace satdump
 #ifndef __ANDROID__
                 auto result = pfd::save_file("Save Image", default_name, {
                     "PNG Files", "*.png",
-                    "JPG Files", "*.jpg *.jpeg"
+                    "JPEG 2000 Files", "*.j2k",
+                    "JPEG Files", "*.jpg *.jpeg"
                     });
                 while (!result.ready(1000))
                     std::this_thread::sleep_for(std::chrono::milliseconds(1));

--- a/src-interface/viewer/image_handler.cpp
+++ b/src-interface/viewer/image_handler.cpp
@@ -551,7 +551,10 @@ namespace satdump
                                            products->instrument_name + "_" + (select_image_id == 0 ? "composite" : ("ch" + channel_numbers[select_image_id - 1])) + ".png";
 
 #ifndef __ANDROID__
-                auto result = pfd::save_file("Save Image", default_name, { "PNG Files", "*.png" });
+                auto result = pfd::save_file("Save Image", default_name, {
+                    "PNG Files", "*.png",
+                    "JPG Files", "*.jpg *.jpeg"
+                    });
                 while (!result.ready(1000))
                     std::this_thread::sleep_for(std::chrono::milliseconds(1));
 

--- a/src-interface/viewer/radiation_handler.cpp
+++ b/src-interface/viewer/radiation_handler.cpp
@@ -87,7 +87,10 @@ namespace satdump
                 std::string default_name = default_path + products->instrument_name + "_map.png";
 
 #ifndef __ANDROID__
-                auto result = pfd::save_file("Save Image", default_name, { "PNG Files", "*.png" });
+                auto result = pfd::save_file("Save Image", default_name, {
+                    "PNG Files", "*.png",
+                    "JPG Files", "*.jpg *.jpeg"
+                    });
                 while (!result.ready(1000))
                     std::this_thread::sleep_for(std::chrono::milliseconds(1));
 

--- a/src-interface/viewer/radiation_handler.cpp
+++ b/src-interface/viewer/radiation_handler.cpp
@@ -89,7 +89,8 @@ namespace satdump
 #ifndef __ANDROID__
                 auto result = pfd::save_file("Save Image", default_name, {
                     "PNG Files", "*.png",
-                    "JPG Files", "*.jpg *.jpeg"
+                    "JPEG 2000 Files", "*.j2k",
+                    "JPEG Files", "*.jpg *.jpeg"
                     });
                 while (!result.ready(1000))
                     std::this_thread::sleep_for(std::chrono::milliseconds(1));

--- a/src-interface/viewer/scatterometer_handler.cpp
+++ b/src-interface/viewer/scatterometer_handler.cpp
@@ -129,7 +129,10 @@ namespace satdump
                 std::string default_name = default_path + products->instrument_name + "_" + ((selected_visualization_id == 1 && current_scat_type == SCAT_ASCAT) ? ch_ascatp : ch_normal) + ".png";
 
 #ifndef __ANDROID__
-                auto result = pfd::save_file("Save Image", default_name, { "PNG Files", "*.png" });
+                auto result = pfd::save_file("Save Image", default_name, {
+                    "PNG Files", "*.png",
+                    "JPG Files", "*.jpg *.jpeg"
+                    });
                 while (!result.ready(1000))
                     std::this_thread::sleep_for(std::chrono::milliseconds(1));
 

--- a/src-interface/viewer/scatterometer_handler.cpp
+++ b/src-interface/viewer/scatterometer_handler.cpp
@@ -131,7 +131,8 @@ namespace satdump
 #ifndef __ANDROID__
                 auto result = pfd::save_file("Save Image", default_name, {
                     "PNG Files", "*.png",
-                    "JPG Files", "*.jpg *.jpeg"
+                    "JPEG 2000 Files", "*.j2k",
+                    "JPEG Files", "*.jpg *.jpeg"
                     });
                 while (!result.ready(1000))
                     std::this_thread::sleep_for(std::chrono::milliseconds(1));

--- a/src-interface/viewer/viewer_projection.cpp
+++ b/src-interface/viewer/viewer_projection.cpp
@@ -16,7 +16,7 @@
 
 namespace satdump
 {
-    re_t osm_url_regex = re_compile("https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,4}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)\\/\\{([xyz])\\}\\/\\{((?!\\3)[xyz])\\}\\/\\{((?!\\3)(?!\\4)[xyz])\\}(\\.png|\\.jpg|\\.jpeg|)");
+    re_t osm_url_regex = re_compile("https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,4}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)\\/\\{([xyz])\\}\\/\\{((?!\\3)[xyz])\\}\\/\\{((?!\\3)(?!\\4)[xyz])\\}(\\.png|\\.jpg|\\.jpeg|\\.j2k|)");
     int osm_url_regex_len = 0;
 
     void ViewerApplication::drawProjectionPanel()
@@ -126,7 +126,8 @@ namespace satdump
 #ifndef __ANDROID__
                 auto result = pfd::save_file("Save Image", default_name, {
                     "PNG Files", "*.png",
-                    "JPG Files", "*.jpg *.jpeg"
+                    "JPEG 2000 Files", "*.j2k",
+                    "JPEG Files", "*.jpg *.jpeg"
                     });
                 while (!result.ready(1000))
                     std::this_thread::sleep_for(std::chrono::milliseconds(1));

--- a/src-interface/viewer/viewer_projection.cpp
+++ b/src-interface/viewer/viewer_projection.cpp
@@ -124,7 +124,10 @@ namespace satdump
                 std::string default_name = default_path + "projection.png";
 
 #ifndef __ANDROID__
-                auto result = pfd::save_file("Save Image", default_name, { "PNG Files", "*.png" });
+                auto result = pfd::save_file("Save Image", default_name, {
+                    "PNG Files", "*.png",
+                    "JPG Files", "*.jpg *.jpeg"
+                    });
                 while (!result.ready(1000))
                     std::this_thread::sleep_for(std::chrono::milliseconds(1));
 

--- a/tools/imager_simulator/main.cpp
+++ b/tools/imager_simulator/main.cpp
@@ -147,9 +147,9 @@ int main(int argc, char *argv[])
 
     imager_products.set_proj_cfg(proj_settings);
 
-    imager_products.images.push_back({"IMAGER-1.png", "1", image_r});
-    imager_products.images.push_back({"IMAGER-2.png", "2", image_g});
-    imager_products.images.push_back({"IMAGER-3.png", "3", image_b});
+    imager_products.images.push_back({"IMAGER-1", "1", image_r});
+    imager_products.images.push_back({"IMAGER-2", "2", image_g});
+    imager_products.images.push_back({"IMAGER-3", "3", image_b});
 
     if (!std::filesystem::exists(output_folder))
         std::filesystem::create_directories(output_folder);

--- a/tools/msg_nat2img/main.cpp
+++ b/tools/msg_nat2img/main.cpp
@@ -167,22 +167,22 @@ int main(int argc, char *argv[])
         if (bandsel[channel] != 'X')
             continue;
 
-        std::string path = "SEVIRI_" + std::to_string(channel + 1) + ".png";
+        std::string path = "SEVIRI_" + std::to_string(channel + 1);
 
         vis_ir_imgs[channel].mirror(true, true);
 
         logger->info("Saving " + path);
-        vis_ir_imgs[channel].save_png(path);
+        vis_ir_imgs[channel].save_img(path);
     }
 
-    std::string path = "SEVIRI_321.png";
-
+    std::string path = "SEVIRI_321";
     image::Image<uint16_t> compo_321(vis_ir_x_size, vis_ir_y_size, 3);
+    compo_321.append_ext(&path);
 
     compo_321.draw_image(0, vis_ir_imgs[2]);
     compo_321.draw_image(1, vis_ir_imgs[1]);
     compo_321.draw_image(2, vis_ir_imgs[0]);
 
     logger->info("Saving " + path);
-    compo_321.save_png(path);
+    compo_321.save_img(path);
 }

--- a/tools/proj_test/main.cpp
+++ b/tools/proj_test/main.cpp
@@ -88,7 +88,5 @@ int main(int /*argc*/, char *argv[])
     }
 
     // img_map.crop(p_x_min, p_y_min, p_x_max, p_y_max);
-    logger->info("Saving...");
-
-    result.output_image.save_png("test.png");
+    result.output_image.save_img("test");
 }


### PR DESCRIPTION
## Image-Related changes in this PR: 
- Pulled this upstream PR: https://github.com/samhocevar/portable-file-dialogs/pull/86. Fixes the "save" dialog in the viewer/projector appending the file extension on Windows in all situations.
- Allows the user to interactively choose between jpg and png when saving imagery in the viewer/projector
- Adds a setting that allows users to choose between png and jpg for all automated processed image saves (defaults to png)
- Extends `save_img` to check if an extension was passed in the file name.
  - If no extension was passed, it will use the extension set in settings.
  - Grayscale images less than 200px across will still save as pngs. Small grayscale jpegs don't save well, and pngs of this size are tiny anyway
  - Also added the ability to pass along the fast parameter to save_png if necessary
- Modified `ImageProducts` to optionally accept images without a file extension, and use the extension configured in settings if unspecified.
- Moved `logger->info()` for saving an image into save_img to greatly reduce repeated logging code, and standardize the output across plugins
- Increased the quality of saved jpegs from 75 to 90
- **Updated all the plugins to use `save_img` instead of `save_png`, and pass the file without an extension to allow the system setting to take effect.**

## Other Changes
- Switched vcpkg in scripts/Configure-vcpkg.ps1 back to yours, now that the debug lib PR has been accepted

## Life Lessions
- If you leave an issue open long enough, the user that submitted it will implement a fix themselves 😄
- Fixes #171 