### PR TITLE
Ignore edges when calculating offline FFT Plot min/max

### DIFF
--- a/src-core/modules/demod/module_demod_base.cpp
+++ b/src-core/modules/demod/module_demod_base.cpp
@@ -208,14 +208,25 @@ namespace demod
             ImGui::SetNextWindowSize({400 * (float)ui_scale, (float)(showWaterfall ? 400 : 200) * (float)ui_scale});
             ImGui::Begin("Baseband FFT", NULL, ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoResize);
             fft_plot->draw({float(ImGui::GetWindowSize().x - 0), float(ImGui::GetWindowSize().y - 40 * ui_scale) * float(showWaterfall ? 0.5 : 1.0)});
+
+            //Find "actual" left edge of FFT, before frequency shift.
+            //Inset by 10% (819), then account for > 100% freq shifts via modulo
+            int pos = (abs((float)d_frequency_shift / (float)d_samplerate) * (float)8192) + 819;
+            pos %= 8192;
+
+            //Compute min and max of the middle 80% of original baseband
             float min = 1000;
-            for (int i = 0; i < 8192; i++)
-                if (fft_proc->output_stream->writeBuf[i] < min)
-                    min = fft_proc->output_stream->writeBuf[i];
             float max = -1000;
-            for (int i = 0; i < 8192; i++)
-                if (fft_proc->output_stream->writeBuf[i] > max)
-                    max = fft_proc->output_stream->writeBuf[i];
+            for (int i = 0; i < 6554; i++) //8192 * 80% = 6554
+            {
+                if (fft_proc->output_stream->writeBuf[pos] < min)
+                    min = fft_proc->output_stream->writeBuf[pos];
+                if (fft_proc->output_stream->writeBuf[pos] > max)
+                    max = fft_proc->output_stream->writeBuf[pos];
+                pos++;
+                if (pos >= 8192)
+                    pos = 0;
+            }
 
             waterfall_plot->scale_min = fft_plot->scale_min = fft_plot->scale_min * 0.99 + min * 0.01;
             waterfall_plot->scale_max = fft_plot->scale_max = fft_plot->scale_max * 0.99 + max * 0.01;


### PR DESCRIPTION
This PR changes the logic that sets the min/max of the offline FFT display. Instead of looking at the entire frequency range, it only looks at the "middle" 80%. The logic takes frequency shift into account, and the entire FFT is still shown.

**Reason:** I have a few SDRs with a rather extreme drop-off at the edges. With current logic, this results in poor scaling in the offline FFT since it takes the drop-off into account:

![Old](https://github.com/SatDump/SatDump/assets/24253715/da3cfde8-bee6-4ce5-a092-d9faf0552f66)

**After the changes, the FFT is much more useful:**
![New](https://github.com/SatDump/SatDump/assets/24253715/460ef371-8a8d-4654-a2fc-2f194277fe8a)

To be honest, I'm not sure how much this problem exists for others. It certainly depends on the SDR. If you feel my situation is an edge case, I'll be perfectly fine if this does not get merged.

Thanks!