### PR TITLE
Add Status Bar to UI

### DIFF
--- a/satdump_cfg.json
+++ b/satdump_cfg.json
@@ -86,6 +86,12 @@
             "value": false,
             "name": "Recorder Baseband Filename Milliseconds",
             "description": "Add milliseconds to the output filenames for basebands recorded in the recorder"
+        },
+         "status_bar": {
+            "type": "bool",
+            "value": true,
+            "name": "Show Status Bar",
+            "description": "Show status bar with last log at the bottom of the UI"
         }
     },
     // More generic SatDump settings

--- a/src-interface/main_ui.cpp
+++ b/src-interface/main_ui.cpp
@@ -13,6 +13,7 @@
 #include "common/audio/audio_sink.h"
 #include "imgui_notify/imgui_notify.h"
 #include "notify_logger_sink.h"
+#include "status_logger_sink.h"
 
 // #define ENABLE_DEBUG_MAP
 #ifdef ENABLE_DEBUG_MAP
@@ -33,6 +34,7 @@ namespace satdump
     widgets::MarkdownHelper credits_md;
 
     std::shared_ptr<NotifyLoggerSink> notify_logger_sink;
+    std::shared_ptr<StatusLoggerSink> status_logger_sink;
 
     void initMainUI()
     {
@@ -43,6 +45,7 @@ namespace satdump
 
         light_theme = config::main_cfg["user_interface"]["light_theme"]["value"].get<bool>();
         float manual_dpi_scaling = config::main_cfg["user_interface"]["manual_dpi_scaling"]["value"].get<float>();
+        status_bar = config::main_cfg["user_interface"]["status_bar"]["value"].get<float>();
 
 #ifdef __ANDROID__
         manual_dpi_scaling *= 3; // Otherwise it's just too small by default!
@@ -72,6 +75,13 @@ namespace satdump
         // Logger notify sink
         notify_logger_sink = std::make_shared<NotifyLoggerSink>();
         logger->add_sink(notify_logger_sink);
+
+        //Logger status bar sync
+        if (status_bar)
+        {
+            status_logger_sink = std::make_shared<StatusLoggerSink>();
+            logger->add_sink(status_logger_sink);
+        }
     }
 
     void exitMainUI()
@@ -111,6 +121,8 @@ namespace satdump
         }*/
         // else
         {
+            if(status_bar)
+                wheight -= status_logger_sink->draw();
             ImGui::SetNextWindowPos({0, 0});
             ImGui::SetNextWindowSize({(float)wwidth, (processing::is_processing & main_ui_is_processing_selected) ? -1.0f : (float)wheight});
             ImGui::Begin("Main", NULL, NOWINDOW_FLAGS | ImGuiWindowFlags_NoDecoration);
@@ -239,6 +251,7 @@ namespace satdump
     }
 
     bool light_theme;
+    bool status_bar;
 
     ctpl::thread_pool ui_thread_pool(8);
 }

--- a/src-interface/main_ui.h
+++ b/src-interface/main_ui.h
@@ -15,7 +15,6 @@ namespace satdump
     extern ctpl::thread_pool ui_thread_pool;
 
     extern bool light_theme;
-    extern bool status_bar;
 
     extern std::shared_ptr<RecorderApplication> recorder_app;
     extern std::shared_ptr<ViewerApplication> viewer_app;

--- a/src-interface/main_ui.h
+++ b/src-interface/main_ui.h
@@ -15,6 +15,7 @@ namespace satdump
     extern ctpl::thread_pool ui_thread_pool;
 
     extern bool light_theme;
+    extern bool status_bar;
 
     extern std::shared_ptr<RecorderApplication> recorder_app;
     extern std::shared_ptr<ViewerApplication> viewer_app;

--- a/src-interface/recorder/recorder.cpp
+++ b/src-interface/recorder/recorder.cpp
@@ -537,7 +537,7 @@ namespace satdump
                     {
                         ImVec2 mouse_pos = ImGui::GetMousePos();
                         float ratio = (mouse_pos.x - recorder_size.x * panel_ratio - 16 * ui_scale) / (recorder_size.x * (1.0 - panel_ratio) - 8 * ui_scale) - 0.5;
-                        ImGui::SetTooltip(((ratio >= 0 ? "" : "- ") + formatSamplerateToString(abs(ratio) * get_samplerate()) + "Hz\n" +
+                        ImGui::SetTooltip("%s", ((ratio >= 0 ? "" : "- ") + formatSamplerateToString(abs(ratio) * get_samplerate()) + "Hz\n" +
                                            formatSamplerateToString(source_ptr->get_frequency() + ratio * get_samplerate()) + "Hz")
                                               .c_str());
                     }

--- a/src-interface/status_logger_sink.cpp
+++ b/src-interface/status_logger_sink.cpp
@@ -3,6 +3,8 @@
 #include "imgui/imgui_internal.h"
 #include "core/config.h"
 
+SATDUMP_DLL extern float ui_scale;
+
 namespace satdump
 {
     StatusLoggerSink::StatusLoggerSink()
@@ -47,7 +49,7 @@ namespace satdump
             ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_MenuBar)) {
             if (ImGui::BeginMenuBar()) {
                 ImGui::TextUnformatted(lvl.c_str());
-                ImGui::SameLine(75);
+                ImGui::SameLine(75 * ui_scale);
                 ImGui::Separator();
                 ImGui::TextDisabled("%s", str.c_str());
                 height = ImGui::GetWindowHeight();

--- a/src-interface/status_logger_sink.cpp
+++ b/src-interface/status_logger_sink.cpp
@@ -1,0 +1,51 @@
+#include "status_logger_sink.h"
+#include "imgui/imgui.h"
+#include "imgui/imgui_internal.h"
+
+namespace satdump
+{
+    StatusLoggerSink::StatusLoggerSink()
+    {
+        str = "";
+        lvl = "Welcome to SatDump!";
+    }
+
+    StatusLoggerSink::~StatusLoggerSink()
+    {
+    }
+
+    void StatusLoggerSink::receive(slog::LogMsg log)
+    {
+        if (log.lvl >= slog::LOG_INFO)
+        {
+            if (log.lvl == slog::LOG_INFO)
+                lvl = "Info:";
+            else if (log.lvl == slog::LOG_WARN)
+                lvl = "Warning:";
+            else if (log.lvl == slog::LOG_ERROR)
+                lvl = "ERROR:";
+            else
+                lvl = "CRITICAL:";
+
+            str = log.str;
+        }
+    }
+
+    int StatusLoggerSink::draw()
+    {
+        int height = 0;
+        if (ImGui::BeginViewportSideBar("##MainStatusBar", ImGui::GetMainViewport(), ImGuiDir_Down, ImGui::GetFrameHeight(),
+            ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_MenuBar)) {
+            if (ImGui::BeginMenuBar()) {
+                ImGui::Text(lvl.c_str());
+                ImGui::SameLine();
+                ImGui::TextDisabled(str.c_str());
+                height = ImGui::GetWindowHeight();
+                ImGui::EndMenuBar();
+            }
+            ImGui::End();
+        }
+
+        return height;
+    }
+}

--- a/src-interface/status_logger_sink.cpp
+++ b/src-interface/status_logger_sink.cpp
@@ -1,17 +1,24 @@
 #include "status_logger_sink.h"
 #include "imgui/imgui.h"
 #include "imgui/imgui_internal.h"
+#include "core/config.h"
 
 namespace satdump
 {
     StatusLoggerSink::StatusLoggerSink()
     {
-        str = "";
-        lvl = "Welcome to SatDump!";
+        str = "Welcome to SatDump!";
+        lvl = "";
+        show = config::main_cfg["user_interface"]["status_bar"]["value"].get<bool>();
     }
 
     StatusLoggerSink::~StatusLoggerSink()
     {
+    }
+
+    bool StatusLoggerSink::is_shown()
+    {
+        return show;
     }
 
     void StatusLoggerSink::receive(slog::LogMsg log)
@@ -19,13 +26,15 @@ namespace satdump
         if (log.lvl >= slog::LOG_INFO)
         {
             if (log.lvl == slog::LOG_INFO)
-                lvl = "Info:";
+                lvl = "Info";
             else if (log.lvl == slog::LOG_WARN)
-                lvl = "Warning:";
+                lvl = "Warning";
             else if (log.lvl == slog::LOG_ERROR)
-                lvl = "ERROR:";
+                lvl = "Error";
+            else if (log.lvl == slog::LOG_CRIT)
+                lvl = "Critical";
             else
-                lvl = "CRITICAL:";
+                lvl = "";
 
             str = log.str;
         }
@@ -37,9 +46,10 @@ namespace satdump
         if (ImGui::BeginViewportSideBar("##MainStatusBar", ImGui::GetMainViewport(), ImGuiDir_Down, ImGui::GetFrameHeight(),
             ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_MenuBar)) {
             if (ImGui::BeginMenuBar()) {
-                ImGui::Text(lvl.c_str());
-                ImGui::SameLine();
-                ImGui::TextDisabled(str.c_str());
+                ImGui::TextUnformatted(lvl.c_str());
+                ImGui::SameLine(75);
+                ImGui::Separator();
+                ImGui::TextDisabled("%s", str.c_str());
                 height = ImGui::GetWindowHeight();
                 ImGui::EndMenuBar();
             }

--- a/src-interface/status_logger_sink.cpp
+++ b/src-interface/status_logger_sink.cpp
@@ -13,7 +13,6 @@ namespace satdump
         welcome_message.str = "Welcome to SatDump!";
         receive(welcome_message);
 
-        lastY = -1;
         show_bar = config::main_cfg["user_interface"]["status_bar"]["value"].get<bool>();
         show_log = false;
     }
@@ -68,9 +67,14 @@ namespace satdump
 
         if (show_log)
         {
+            static ImVec2 last_size;
+            static float lastY;
             ImVec2 display_size = ImGui::GetIO().DisplaySize;
-            ImGui::SetNextWindowSize(ImVec2(display_size.x, (display_size.y * 0.3) - height), ImGuiCond_Appearing);
-            ImGui::SetNextWindowPos(ImVec2(0, display_size.y * 0.7), ImGuiCond_Appearing, ImVec2(0, 0));
+            bool did_resize = display_size.x != last_size.x || display_size.y != last_size.y;
+            ImGui::SetNextWindowSize(ImVec2(display_size.x, (display_size.y * 0.3) - height), did_resize ? ImGuiCond_Always : ImGuiCond_Appearing);
+            ImGui::SetNextWindowPos(ImVec2(0, display_size.y * 0.7), did_resize ? ImGuiCond_Always : ImGuiCond_Appearing, ImVec2(0, 0));
+            last_size = display_size;
+
             ImGui::SetNextWindowBgAlpha(1.0);
             ImGui::Begin("SatDump Log", &show_log, ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoCollapse);
             if (ImGui::IsWindowFocused())

--- a/src-interface/status_logger_sink.h
+++ b/src-interface/status_logger_sink.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "logger.h"
+
+namespace satdump
+{
+    class StatusLoggerSink : public slog::LoggerSink
+    {
+    private:
+        std::string str;
+        std::string lvl;
+    public:
+        StatusLoggerSink();
+        ~StatusLoggerSink();
+        void receive(slog::LogMsg log);
+        int draw();
+    };
+}

--- a/src-interface/status_logger_sink.h
+++ b/src-interface/status_logger_sink.h
@@ -11,7 +11,6 @@ namespace satdump
         std::string lvl;
         bool show_bar;
         bool show_log;
-        float lastY;
     protected:
         void receive(slog::LogMsg log);
     public:

--- a/src-interface/status_logger_sink.h
+++ b/src-interface/status_logger_sink.h
@@ -10,10 +10,11 @@ namespace satdump
         std::string str;
         std::string lvl;
         bool show;
+    protected:
+        void receive(slog::LogMsg log);
     public:
         StatusLoggerSink();
         ~StatusLoggerSink();
-        void receive(slog::LogMsg log);
         int draw();
         bool is_shown();
     };

--- a/src-interface/status_logger_sink.h
+++ b/src-interface/status_logger_sink.h
@@ -9,10 +9,12 @@ namespace satdump
     private:
         std::string str;
         std::string lvl;
+        bool show;
     public:
         StatusLoggerSink();
         ~StatusLoggerSink();
         void receive(slog::LogMsg log);
         int draw();
+        bool is_shown();
     };
 }

--- a/src-interface/status_logger_sink.h
+++ b/src-interface/status_logger_sink.h
@@ -1,15 +1,17 @@
 #pragma once
 
-#include "logger.h"
+#include "common/widgets/logger_sink.h"
 
 namespace satdump
 {
-    class StatusLoggerSink : public slog::LoggerSink
+    class StatusLoggerSink : public widgets::LoggerSinkWidget
     {
     private:
         std::string str;
         std::string lvl;
-        bool show;
+        bool show_bar;
+        bool show_log;
+        float lastY;
     protected:
         void receive(slog::LogMsg log);
     public:

--- a/src-interface/viewer/viewer_projection.cpp
+++ b/src-interface/viewer/viewer_projection.cpp
@@ -304,7 +304,7 @@ namespace satdump
                     ImGui::Text("%s", label.c_str());
                     if (ImGui::IsItemHovered() && layer.type == 0)
                     {
-                        ImGui::SetTooltip(layer.viewer_prods->dataset_name.c_str());
+                        ImGui::SetTooltip("%s", layer.viewer_prods->dataset_name.c_str());
                     }
                     ImGui::SameLine(ImGui::GetWindowWidth() - 70 * ui_scale);
                     ImGui::SetCursorPosY(ImGui::GetCursorPos().y - 2 * ui_scale);

--- a/src-ui/CMakeLists.txt
+++ b/src-ui/CMakeLists.txt
@@ -41,4 +41,9 @@ else()
     target_link_libraries(satdump-ui PRIVATE glfw)
 endif()
 
+#Disable console on Windows builds
+if(MSVC)
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SUBSYSTEM:windows /ENTRY:mainCRTStartup")
+endif()
+
 install(TARGETS satdump-ui DESTINATION bin)


### PR DESCRIPTION
**Adds a status bar at the bottom of the UI**, which shows the last log item that is `LOG_INFO` or greater, regardless of log level setting. Can be turned off in settings.

It gives a nice indicator within the UI of background tasks - especially ones that were invisible before, like live mode product processing and TLE updating. It's especially useful on Android and Linux (when launched via the .desktop file) since the console is not available in these situations. It's also potentially a great vessel for Easter Eggs 😉.

**Info during live decode**

![Info during live decode](https://github.com/SatDump/SatDump/assets/24253715/39af65bc-66d3-4725-b5a1-b95e4a38e5c7)

**Info on live decode product processor**

![Info on live decode product processor](https://github.com/SatDump/SatDump/assets/24253715/312b4ba0-42f7-4115-b1c2-db3520889b39)

**TLE Updates**

![TLE Updates](https://github.com/SatDump/SatDump/assets/24253715/7241a6b7-6ff7-4e5b-9f0a-edf5844ab875)

<hr>

**As a related question, not addressed in this PR:** what are your thoughts on suppressing the console in release builds of satdump-ui on Windows?

This would more-or-less mirror the .desktop launch method on Linux. I tested a few ways of doing this (hiding/showing the console via Win32 API, or linking to the `windows` subsystem instead of the `console` subsystem) and it seems to work OK this way.