### PR TITLE
[Filename] Use HH-MM-SS-MSS instead of HH-MM-SS-Epoch.Ss in filename when millisecond precision activated

### DIFF
--- a/src-interface/recorder/recorder_proc.cpp
+++ b/src-interface/recorder/recorder_proc.cpp
@@ -241,13 +241,11 @@ namespace satdump
 
         if (config::main_cfg["user_interface"]["recorder_baseband_filename_millis_precision"]["value"].get<bool>())
         {
-            timestamp += "-";
+            std::ostringstream ss;
+
             double ms_val = fmod(timeValue_precise, 1.0) * 1e3;
-            if (ms_val < 10)
-                timestamp += "00";
-            else if (ms_val < 100)
-                timestamp += "0";
-            timestamp += std::to_string(timeValue_precise);
+            ss << "-" << std::fixed << std::setprecision(0) << std::setw(3) << std::setfill('0')  << ms_val;
+            timestamp += ss.str();
         }
 
         std::string filename = config::main_cfg["satdump_directories"]["recording_path"]["value"].get<std::string>() +


### PR DESCRIPTION
When milliseconds activated, this changes the filename for example from
`2023-08-05_18-02-45-1691258565.534000_16000000SPS_2284000000Hz.s16`
to
`2023-08-17_11-42-00-006_1000000SPS_100000000Hz.f32`
which seems the originally intended format.

(3 digits milliseconds instead of epoch float with microsecond resolution).

The shorter fix would have been to juste replace `timeValue_precise` with `ms_val` on line 250, but this way it is a little more C++ish in my view. I can also change to the simpler variant PR.