### PR TITLE
Add Loading screen

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -128,6 +128,7 @@ add_subdirectory(.. ${CMAKE_BINARY_DIR}/all_libs)
 
 add_library(android_imgui SHARED
   ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/loading_screen.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/imgui_image.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/imgui_backends/imgui_impl_android.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/imgui_backends/imgui_impl_opengl3.cpp

--- a/android/loading_screen.cpp
+++ b/android/loading_screen.cpp
@@ -1,16 +1,44 @@
-#include <GLES3/gl3.h>
-#include "core/style.h"
-#include "imgui/imgui_flags.h"
+#include "common/image/image.h"
 #include "imgui/imgui.h"
 #include "imgui_impl_android.h"
 #include "imgui_impl_opengl3.h"
 #include "loading_screen.h"
+#include "loader/loader.h"
+#include "resources.h"
 
 namespace satdump
 {
     LoadingScreenSink::LoadingScreenSink(EGLDisplay *g_EglDisplay, EGLSurface *g_EglSurface) : g_EglDisplay{g_EglDisplay}, g_EglSurface{g_EglSurface}
     {
-        draw_loader("Initializing");
+        image::Image<uint8_t> image;
+        image.load_png(resources::getResourcePath("icon.png"));
+        uint8_t *px = new uint8_t[image.width() * image.height() * 4];
+        memset(px, 255, image.width() * image.height() * 4);
+
+        if (image.channels() == 4)
+        {
+            for (int y = 0; y < (int)image.height(); y++)
+                for (int x = 0; x < (int)image.width(); x++)
+                    for (int c = 0; c < 4; c++)
+                        px[image.width() * 4 * y + x * 4 + c] = image.channel(c)[image.width() * y + x];
+        }
+        else if (image.channels() == 3)
+        {
+            for (int y = 0; y < (int)image.height(); y++)
+                for (int x = 0; x < (int)image.width(); x++)
+                    for (int c = 0; c < 3; c++)
+                        px[image.width() * 4 * y + x * 4 + c] = image.channel(c)[image.width() * y + x];
+        }
+
+        glGenTextures(1, &image_texture);
+        glBindTexture(GL_TEXTURE_2D, image_texture);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, image.width(), image.height(), 0, GL_RGBA, GL_UNSIGNED_BYTE, px);
+        image.clear();
+
+        push_frame("Initializing");
     }
 
     LoadingScreenSink::~LoadingScreenSink()
@@ -20,34 +48,20 @@ namespace satdump
     void LoadingScreenSink::receive(slog::LogMsg log)
     {
         if (log.lvl == slog::LOG_INFO)
-            draw_loader(log.str);
+            push_frame(log.str);
     }
 
-    void LoadingScreenSink::draw_loader(std::string str)
+    void LoadingScreenSink::push_frame(std::string str)
     {
-        ImGui_ImplOpenGL3_NewFrame();
-        ImGui_ImplAndroid_NewFrame();
-        ImGui::NewFrame();
-
         EGLint width, height;
         eglQuerySurface(*g_EglDisplay, *g_EglSurface, EGL_WIDTH, &width);
         eglQuerySurface(*g_EglDisplay, *g_EglSurface, EGL_HEIGHT, &height);
 
-        ImGui::SetNextWindowPos({ 0, 0 });
-        ImGui::SetNextWindowSize({(float)width, (float)height});
-        ImGui::Begin("Loading Screen", nullptr, NOWINDOW_FLAGS | ImGuiWindowFlags_NoDecoration);
-        ImGui::PushFont(style::bigFont);
-        ImVec2 text_size = ImGui::CalcTextSize("SatDump");
-        ImGui::SetCursorPos({((float)width / 2) - (text_size.x / 2), ((float)height / 2) - text_size.y});
-        ImGui::TextUnformatted("SatDump");
-        ImGui::PopFont();
-        ImGui::SetCursorPos({ ((float)width / 2) - (ImGui::CalcTextSize(str.c_str()).x / 2), ((float)height / 2) + 10 });
-        ImGui::TextUnformatted(str.c_str());
-        ImGui::End();
-
-        ImGui::Render();
-        ImGuiIO &io = ImGui::GetIO();
-        glViewport(0, 0, (int)io.DisplaySize.x, (int)io.DisplaySize.y);
+        ImGui_ImplOpenGL3_NewFrame();
+        ImGui_ImplAndroid_NewFrame();
+        draw_loader(width, height, &image_texture, str);
+        glViewport(0, 0, (int)width, (int)height);
+        glClearColor(0.0666f, 0.0666f, 0.0666f, 1.0f);
         glClear(GL_COLOR_BUFFER_BIT);
 
         ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());

--- a/android/loading_screen.cpp
+++ b/android/loading_screen.cpp
@@ -1,0 +1,56 @@
+#include <GLES3/gl3.h>
+#include "core/style.h"
+#include "imgui/imgui_flags.h"
+#include "imgui/imgui.h"
+#include "imgui_impl_android.h"
+#include "imgui_impl_opengl3.h"
+#include "loading_screen.h"
+
+namespace satdump
+{
+    LoadingScreenSink::LoadingScreenSink(EGLDisplay *g_EglDisplay, EGLSurface *g_EglSurface) : g_EglDisplay{g_EglDisplay}, g_EglSurface{g_EglSurface}
+    {
+        draw_loader("Initializing");
+    }
+
+    LoadingScreenSink::~LoadingScreenSink()
+    {
+    }
+
+    void LoadingScreenSink::receive(slog::LogMsg log)
+    {
+        if (log.lvl == slog::LOG_INFO)
+            draw_loader(log.str);
+    }
+
+    void LoadingScreenSink::draw_loader(std::string str)
+    {
+        ImGui_ImplOpenGL3_NewFrame();
+        ImGui_ImplAndroid_NewFrame();
+        ImGui::NewFrame();
+
+        EGLint width, height;
+        eglQuerySurface(*g_EglDisplay, *g_EglSurface, EGL_WIDTH, &width);
+        eglQuerySurface(*g_EglDisplay, *g_EglSurface, EGL_HEIGHT, &height);
+
+        ImGui::SetNextWindowPos({ 0, 0 });
+        ImGui::SetNextWindowSize({(float)width, (float)height});
+        ImGui::Begin("Loading Screen", nullptr, NOWINDOW_FLAGS | ImGuiWindowFlags_NoDecoration);
+        ImGui::PushFont(style::bigFont);
+        ImVec2 text_size = ImGui::CalcTextSize("SatDump");
+        ImGui::SetCursorPos({((float)width / 2) - (text_size.x / 2), ((float)height / 2) - text_size.y});
+        ImGui::TextUnformatted("SatDump");
+        ImGui::PopFont();
+        ImGui::SetCursorPos({ ((float)width / 2) - (ImGui::CalcTextSize(str.c_str()).x / 2), ((float)height / 2) + 10 });
+        ImGui::TextUnformatted(str.c_str());
+        ImGui::End();
+
+        ImGui::Render();
+        ImGuiIO &io = ImGui::GetIO();
+        glViewport(0, 0, (int)io.DisplaySize.x, (int)io.DisplaySize.y);
+        glClear(GL_COLOR_BUFFER_BIT);
+
+        ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+        eglSwapBuffers(*g_EglDisplay, *g_EglSurface);
+    }
+}

--- a/android/loading_screen.h
+++ b/android/loading_screen.h
@@ -2,6 +2,7 @@
 
 #include "logger.h"
 #include <EGL/egl.h>
+#include <GLES3/gl3.h>
 
 namespace satdump
 {
@@ -13,8 +14,9 @@ namespace satdump
     protected:
         void receive(slog::LogMsg log);
     private:
-        void draw_loader(std::string str);
+        void push_frame(std::string str);
         EGLDisplay *g_EglDisplay;
         EGLSurface *g_EglSurface;
+        GLuint image_texture;
     };
 }

--- a/android/loading_screen.h
+++ b/android/loading_screen.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "logger.h"
+#include <EGL/egl.h>
+
+namespace satdump
+{
+    class LoadingScreenSink : public slog::LoggerSink
+    {
+    public:
+        LoadingScreenSink(EGLDisplay *g_EglDisplay, EGLSurface *g_EglSurface);
+        ~LoadingScreenSink();
+    protected:
+        void receive(slog::LogMsg log);
+    private:
+        void draw_loader(std::string str);
+        EGLDisplay *g_EglDisplay;
+        EGLSurface *g_EglSurface;
+    };
+}

--- a/android/main.cpp
+++ b/android/main.cpp
@@ -95,6 +95,7 @@ void init(struct android_app *app)
         // ImGui::StyleColorsClassic();
 
         satdump::initMainUI();
+        style::setFonts();
         was_init = true;
     }
 

--- a/src-core/common/widgets/markdown_helper.cpp
+++ b/src-core/common/widgets/markdown_helper.cpp
@@ -25,14 +25,13 @@ namespace widgets
     void MarkdownHelper::init()
     {
         mdConfig.linkCallback = link_callback;
-
-        mdConfig.headingFormats[0] = {style::bigFont, true};
-        mdConfig.headingFormats[1] = {style::bigFont, true};
-        mdConfig.headingFormats[2] = {style::baseFont, true};
     };
 
     void MarkdownHelper::render()
     {
+        mdConfig.headingFormats[0] = { style::bigFont, true };
+        mdConfig.headingFormats[1] = { style::bigFont, true };
+        mdConfig.headingFormats[2] = { style::baseFont, true };
         ImGui::Markdown(markdown_.c_str(), markdown_.length(), mdConfig);
     }
 

--- a/src-core/core/style.cpp
+++ b/src-core/core/style.cpp
@@ -1,3 +1,5 @@
+#define SATDUMP_DLL_EXPORT 1
+
 #include "style.h"
 #include "imgui/imgui.h"
 #include "imgui/imgui_internal.h"
@@ -10,9 +12,9 @@
 
 namespace style
 {
-    ImFont *baseFont;
-    ImFont *bigFont;
-    ImFont *hugeFont;
+    SATDUMP_DLL ImFont *baseFont;
+    SATDUMP_DLL ImFont *bigFont;
+    SATDUMP_DLL ImFont *hugeFont;
 
     bool setDefaultStyle()
     {
@@ -23,8 +25,6 @@ namespace style
         ImGui::GetStyle().GrabRounding = round;
         ImGui::GetStyle().PopupRounding = round;
         ImGui::GetStyle().ScrollbarRounding = round;
-
-        setFonts();
 
         ImGui::StyleColorsDark();
         // ImGui::StyleColorsLight();
@@ -41,8 +41,6 @@ namespace style
         ImGui::GetStyle().GrabRounding = round;
         ImGui::GetStyle().PopupRounding = round;
         ImGui::GetStyle().ScrollbarRounding = round;
-
-        setFonts();
 
         ImGui::StyleColorsLight();
 
@@ -108,8 +106,6 @@ namespace style
         ImGui::GetStyle().GrabRounding = round;
         ImGui::GetStyle().PopupRounding = round;
         ImGui::GetStyle().ScrollbarRounding = round;
-
-        setFonts();
 
         ImGui::StyleColorsDark();
 

--- a/src-core/core/style.cpp
+++ b/src-core/core/style.cpp
@@ -178,7 +178,7 @@ namespace style
 
     void setFonts()
     {
-
+        ImGui::GetIO().Fonts->Clear();
         ImFontGlyphRangesBuilder builder;
         static const ImWchar def[] = {0x20, 0x2300, 0}; //default range
         static ImFontConfig config;
@@ -189,7 +189,9 @@ namespace style
         for (int i = 0; i < 6; i++)
             baseFont = ImGui::GetIO().Fonts->AddFontFromFileTTF(resources::getResourcePath("fonts/font.ttf").c_str(), 16.0f * ui_scale, &config, list[i]); 
 
+        config.MergeMode = false;
         bigFont = ImGui::GetIO().Fonts->AddFontFromFileTTF(resources::getResourcePath("fonts/Roboto-Medium.ttf").c_str(), 45.0f * ui_scale);   //, &config, ranges);
         //hugeFont = ImGui::GetIO().Fonts->AddFontFromFileTTF(resources::getResourcePath("fonts/Roboto-Medium.ttf").c_str(), 128.0f * ui_scale); //, &config, ranges);
+        ImGui::GetIO().Fonts->Build();
     }
 }

--- a/src-core/core/style.h
+++ b/src-core/core/style.h
@@ -1,13 +1,13 @@
 #pragma once
-
+#include "dll_export.h"
 #include "imgui/imgui.h"
 #include <string>
 
 namespace style
 {
-    extern ImFont *baseFont;
-    extern ImFont *bigFont;
-    extern ImFont *hugeFont;
+    SATDUMP_DLL extern ImFont *baseFont;
+    SATDUMP_DLL extern ImFont *bigFont;
+    SATDUMP_DLL extern ImFont *hugeFont;
 
     bool setDefaultStyle();
     bool setLightStyle(float dpi_scaling = 1.0f);

--- a/src-core/logger.cpp
+++ b/src-core/logger.cpp
@@ -232,9 +232,8 @@ namespace slog
     void Logger::del_sink(std::shared_ptr<LoggerSink> sink)
     {
         sink_mtx.lock();
-        auto it = std::find_if(sinks.rbegin(), sinks.rend(), [&sink](std::shared_ptr<LoggerSink> &c)
-                               { return sink.get() == c.get(); })
-                      .base();
+        auto it = std::find_if(sinks.begin(), sinks.end(), [&sink](std::shared_ptr<LoggerSink>& c)
+            { return sink.get() == c.get(); });
         if (it != sinks.end())
             sinks.erase(it);
         sink_mtx.unlock();

--- a/src-interface/loader/loader.cpp
+++ b/src-interface/loader/loader.cpp
@@ -1,0 +1,53 @@
+#include "imgui/imgui.h"
+#include "imgui/imgui_flags.h"
+#include "core/style.h"
+#include "loader.h"
+
+namespace satdump
+{
+    void draw_loader(int width, int height, GLuint *image_texture, std::string str)
+    {
+    	const std::string title = "SatDump";
+    	const std::string slogan = "General Purpose Satellite Data Processor";
+    	
+    	ImGui::NewFrame();
+        ImGui::SetNextWindowPos({ 0, 0 });
+        ImGui::SetNextWindowSize({(float)width, (float)height});
+        ImGui::Begin("Loading Screen", nullptr, NOWINDOW_FLAGS | ImGuiWindowFlags_NoDecoration);
+
+        if(width > height)
+        {
+            ImVec2 reference_pos = { (float)width * 0.2f, ((float)height * 0.5f) - 125 };
+            ImGui::SetCursorPos(reference_pos);
+            ImGui::Image((void*)(intptr_t)(*image_texture), ImVec2(200, 200));
+            ImGui::SetCursorPos({ reference_pos.x + 230, reference_pos.y + 40 });
+            ImGui::PushFont(style::bigFont);
+            ImGui::TextUnformatted(title.c_str());
+            ImGui::PopFont();
+            ImGui::SetCursorPos({ reference_pos.x + 230, reference_pos.y + 87 });
+            ImGui::TextUnformatted(slogan.c_str());
+            ImGui::GetWindowDrawList()->AddLine({reference_pos.x + 230, reference_pos.y + 112}, {reference_pos.x + 490, reference_pos.y + 112}, IM_COL32(155, 155, 155, 255));
+            ImGui::SetCursorPos({ reference_pos.x + 230, reference_pos.y + 120 });
+        }
+        else
+        {
+            ImGui::PushFont(style::bigFont);
+            ImVec2 title_size = ImGui::CalcTextSize(title.c_str());
+            ImGui::SetCursorPos({((float)width / 2) - 150, ((float)height / 2) - title_size.y - 315});
+            ImGui::Image((void*)(intptr_t)(*image_texture), ImVec2(300, 300));
+            ImGui::SetCursorPos({((float)width / 2) - (title_size.x / 2), ((float)height / 2) - title_size.y});
+            ImGui::TextUnformatted(title.c_str());
+            ImGui::PopFont();
+            ImVec2 slogan_size = ImGui::CalcTextSize(slogan.c_str());
+            ImGui::SetCursorPos({ ((float)width / 2) - (slogan_size.x / 2), ((float)height / 2) + 10 });
+            ImGui::TextUnformatted(slogan.c_str());
+            ImGui::GetWindowDrawList()->AddLine({((float)width / 2) - (slogan_size.x / 2), ((float)height / 2) + 20 + slogan_size.y}, 
+                {((float)width / 2) + (slogan_size.x / 2), ((float)height / 2) + 20 + slogan_size.y}, IM_COL32(155, 155, 155, 255));
+            ImGui::SetCursorPos({((float)width / 2) - (ImGui::CalcTextSize(str.c_str()).x / 2), ((float)height / 2) + 25 + slogan_size.y});
+        }
+
+        ImGui::TextDisabled("%s", str.c_str());
+        ImGui::End();
+        ImGui::Render();
+    }
+}

--- a/src-interface/loader/loader.h
+++ b/src-interface/loader/loader.h
@@ -1,0 +1,11 @@
+#pragma once
+#ifdef __ANDROID__
+#include <GLES3/gl3.h>
+#else
+#include <GLFW/glfw3.h>
+#endif
+
+namespace satdump
+{
+	void draw_loader(int width, int height, GLuint *image_texture, std::string str);
+}

--- a/src-ui/loading_screen.cpp
+++ b/src-ui/loading_screen.cpp
@@ -40,15 +40,31 @@ namespace satdump
         ImGui::SetNextWindowPos({ 0, 0 });
         ImGui::SetNextWindowSize({(float)display_w, (float)display_h});
         ImGui::Begin("Loading Screen", nullptr, NOWINDOW_FLAGS | ImGuiWindowFlags_NoDecoration);
-        ImVec2 reference_pos = { (float)display_w * 0.25f, ((float)display_h * 0.5f) - 125 };
-        ImGui::SetCursorPos(reference_pos);
-        ImGui::Image((void*)(intptr_t)image_texture, ImVec2(225, 225));
 
-        ImGui::SetCursorPos({ reference_pos.x + 275, reference_pos.y + 70 });
-        ImGui::PushFont(style::bigFont);
-        ImGui::TextUnformatted("SatDump");
-        ImGui::PopFont();
-        ImGui::SetCursorPos({ reference_pos.x + 275, reference_pos.y + 125 });
+        if(display_w > display_h)
+        {
+            ImVec2 reference_pos = { (float)display_w * 0.2f, ((float)display_h * 0.5f) - 125 };
+            ImGui::SetCursorPos(reference_pos);
+            ImGui::Image((void*)(intptr_t)image_texture, ImVec2(225, 225));
+            ImGui::SetCursorPos({ reference_pos.x + 260, reference_pos.y + 70 });
+            ImGui::PushFont(style::bigFont);
+            ImGui::TextUnformatted("SatDump");
+            ImGui::PopFont();
+            ImGui::SetCursorPos({ reference_pos.x + 260, reference_pos.y + 125 });
+        }
+        else
+        {
+            ImGui::SetCursorPos({ ((float)display_w / 2) - 112, ((float)display_h / 2) - 200 });
+            ImGui::Image((void*)(intptr_t)image_texture, ImVec2(225, 225));
+            ImVec2 reference_pos = ImGui::GetCursorPos();
+            ImGui::PushFont(style::bigFont);
+            ImGui::SetCursorPos({((float)display_w / 2) - (ImGui::CalcTextSize("SatDump").x / 2), reference_pos.y + 20});
+            ImGui::TextUnformatted("SatDump");
+            ImGui::PopFont();
+            reference_pos = ImGui::GetCursorPos();
+            ImGui::SetCursorPos({ ((float)display_w / 2) - (ImGui::CalcTextSize(str.c_str()).x) / 2, reference_pos.y + 10 });
+        }
+
         ImGui::TextUnformatted(str.c_str());
         ImGui::End();
 

--- a/src-ui/loading_screen.cpp
+++ b/src-ui/loading_screen.cpp
@@ -1,0 +1,62 @@
+#include "core/style.h"
+#include "imgui/imgui_flags.h"
+#include "imgui/imgui.h"
+#include "imgui/imgui_impl_glfw.h"
+#include "imgui/imgui_impl_opengl3.h"
+#include "loading_screen.h"
+
+namespace satdump
+{
+    LoadingScreenSink::LoadingScreenSink(GLFWwindow* window, GLFWimage* img) : window{window}
+    {
+        glGenTextures(1, &image_texture);
+        glBindTexture(GL_TEXTURE_2D, image_texture);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, img->width, img->height, 0, GL_RGBA, GL_UNSIGNED_BYTE, img->pixels);
+
+        draw_loader("Initializing");
+    }
+
+    LoadingScreenSink::~LoadingScreenSink()
+    {
+    }
+
+    void LoadingScreenSink::receive(slog::LogMsg log)
+    {
+        if (log.lvl == slog::LOG_INFO)
+            draw_loader(log.str);
+    }
+
+    void LoadingScreenSink::draw_loader(std::string str)
+    {
+        int display_w, display_h;
+        glfwGetFramebufferSize(window, &display_w, &display_h);
+        ImGui_ImplOpenGL3_NewFrame();
+        ImGui_ImplGlfw_NewFrame();
+        ImGui::NewFrame();
+
+        ImGui::SetNextWindowPos({ 0, 0 });
+        ImGui::SetNextWindowSize({(float)display_w, (float)display_h});
+        ImGui::Begin("Loading Screen", nullptr, NOWINDOW_FLAGS | ImGuiWindowFlags_NoDecoration);
+        ImVec2 reference_pos = { (float)display_w * 0.25f, ((float)display_h * 0.5f) - 125 };
+        ImGui::SetCursorPos(reference_pos);
+        ImGui::Image((void*)(intptr_t)image_texture, ImVec2(225, 225));
+
+        ImGui::SetCursorPos({ reference_pos.x + 275, reference_pos.y + 70 });
+        ImGui::PushFont(style::bigFont);
+        ImGui::TextUnformatted("SatDump");
+        ImGui::PopFont();
+        ImGui::SetCursorPos({ reference_pos.x + 275, reference_pos.y + 125 });
+        ImGui::TextUnformatted(str.c_str());
+        ImGui::End();
+
+        ImGui::Render();
+        glViewport(0, 0, display_w, display_h);
+        glClearColor(0.0666f, 0.0666f, 0.0666f, 1.0f);
+        glClear(GL_COLOR_BUFFER_BIT);
+        ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+        glfwSwapBuffers(window);
+    }
+}

--- a/src-ui/loading_screen.cpp
+++ b/src-ui/loading_screen.cpp
@@ -40,31 +40,14 @@ namespace satdump
         ImGui::SetNextWindowPos({ 0, 0 });
         ImGui::SetNextWindowSize({(float)display_w, (float)display_h});
         ImGui::Begin("Loading Screen", nullptr, NOWINDOW_FLAGS | ImGuiWindowFlags_NoDecoration);
-
-        if(display_w > display_h)
-        {
-            ImVec2 reference_pos = { (float)display_w * 0.2f, ((float)display_h * 0.5f) - 125 };
-            ImGui::SetCursorPos(reference_pos);
-            ImGui::Image((void*)(intptr_t)image_texture, ImVec2(225, 225));
-            ImGui::SetCursorPos({ reference_pos.x + 260, reference_pos.y + 70 });
-            ImGui::PushFont(style::bigFont);
-            ImGui::TextUnformatted("SatDump");
-            ImGui::PopFont();
-            ImGui::SetCursorPos({ reference_pos.x + 260, reference_pos.y + 125 });
-        }
-        else
-        {
-            ImGui::SetCursorPos({ ((float)display_w / 2) - 112, ((float)display_h / 2) - 200 });
-            ImGui::Image((void*)(intptr_t)image_texture, ImVec2(225, 225));
-            ImVec2 reference_pos = ImGui::GetCursorPos();
-            ImGui::PushFont(style::bigFont);
-            ImGui::SetCursorPos({((float)display_w / 2) - (ImGui::CalcTextSize("SatDump").x / 2), reference_pos.y + 20});
-            ImGui::TextUnformatted("SatDump");
-            ImGui::PopFont();
-            reference_pos = ImGui::GetCursorPos();
-            ImGui::SetCursorPos({ ((float)display_w / 2) - (ImGui::CalcTextSize(str.c_str()).x) / 2, reference_pos.y + 10 });
-        }
-
+        ImVec2 reference_pos = { (float)display_w * 0.2f, ((float)display_h * 0.5f) - 125 };
+        ImGui::SetCursorPos(reference_pos);
+        ImGui::Image((void*)(intptr_t)image_texture, ImVec2(225, 225));
+        ImGui::SetCursorPos({ reference_pos.x + 260, reference_pos.y + 70 });
+        ImGui::PushFont(style::bigFont);
+        ImGui::TextUnformatted("SatDump");
+        ImGui::PopFont();
+        ImGui::SetCursorPos({ reference_pos.x + 260, reference_pos.y + 125 });
         ImGui::TextUnformatted(str.c_str());
         ImGui::End();
 

--- a/src-ui/loading_screen.cpp
+++ b/src-ui/loading_screen.cpp
@@ -1,9 +1,8 @@
-#include "core/style.h"
-#include "imgui/imgui_flags.h"
 #include "imgui/imgui.h"
 #include "imgui/imgui_impl_glfw.h"
 #include "imgui/imgui_impl_opengl3.h"
 #include "loading_screen.h"
+#include "loader/loader.h"
 
 namespace satdump
 {
@@ -16,7 +15,7 @@ namespace satdump
         glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
         glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, img->width, img->height, 0, GL_RGBA, GL_UNSIGNED_BYTE, img->pixels);
 
-        draw_loader("Initializing");
+        push_frame("Initializing");
     }
 
     LoadingScreenSink::~LoadingScreenSink()
@@ -26,32 +25,18 @@ namespace satdump
     void LoadingScreenSink::receive(slog::LogMsg log)
     {
         if (log.lvl == slog::LOG_INFO)
-            draw_loader(log.str);
+            push_frame(log.str);
     }
 
-    void LoadingScreenSink::draw_loader(std::string str)
+    void LoadingScreenSink::push_frame(std::string str)
     {
         int display_w, display_h;
         glfwGetFramebufferSize(window, &display_w, &display_h);
         ImGui_ImplOpenGL3_NewFrame();
         ImGui_ImplGlfw_NewFrame();
-        ImGui::NewFrame();
 
-        ImGui::SetNextWindowPos({ 0, 0 });
-        ImGui::SetNextWindowSize({(float)display_w, (float)display_h});
-        ImGui::Begin("Loading Screen", nullptr, NOWINDOW_FLAGS | ImGuiWindowFlags_NoDecoration);
-        ImVec2 reference_pos = { (float)display_w * 0.2f, ((float)display_h * 0.5f) - 125 };
-        ImGui::SetCursorPos(reference_pos);
-        ImGui::Image((void*)(intptr_t)image_texture, ImVec2(225, 225));
-        ImGui::SetCursorPos({ reference_pos.x + 260, reference_pos.y + 70 });
-        ImGui::PushFont(style::bigFont);
-        ImGui::TextUnformatted("SatDump");
-        ImGui::PopFont();
-        ImGui::SetCursorPos({ reference_pos.x + 260, reference_pos.y + 125 });
-        ImGui::TextUnformatted(str.c_str());
-        ImGui::End();
+        draw_loader(display_w, display_h, &image_texture, str);
 
-        ImGui::Render();
         glViewport(0, 0, display_w, display_h);
         glClearColor(0.0666f, 0.0666f, 0.0666f, 1.0f);
         glClear(GL_COLOR_BUFFER_BIT);

--- a/src-ui/loading_screen.h
+++ b/src-ui/loading_screen.h
@@ -13,7 +13,7 @@ namespace satdump
     protected:
         void receive(slog::LogMsg log);
     private:
-        void draw_loader(std::string str);
+        void push_frame(std::string str);
         GLFWwindow* window;
         GLuint image_texture;
     };

--- a/src-ui/loading_screen.h
+++ b/src-ui/loading_screen.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <GLFW/glfw3.h>
+#include "logger.h"
+
+namespace satdump
+{
+    class LoadingScreenSink : public slog::LoggerSink
+    {
+    public:
+        LoadingScreenSink(GLFWwindow* window, GLFWimage* img);
+        ~LoadingScreenSink();
+    protected:
+        void receive(slog::LogMsg log);
+    private:
+        void draw_loader(std::string str);
+        GLFWwindow* window;
+        GLuint image_texture;
+    };
+}

--- a/src-ui/main.cpp
+++ b/src-ui/main.cpp
@@ -223,6 +223,15 @@ int main(int argc, char *argv[])
     // Init UI
     satdump::initMainUI();
 
+    //Shut down loading screen
+    logger->del_sink(loading_screen_sink);
+    loading_screen_sink.reset();
+
+    //Set font again to adjust for DPI
+    style::setFonts();
+    ImGui_ImplOpenGL3_DestroyFontsTexture();
+    ImGui_ImplOpenGL3_CreateFontsTexture();
+
     if (satdump::processing::is_processing)
     {
         satdump::ui_thread_pool.push([&](int)
@@ -234,10 +243,6 @@ int main(int argc, char *argv[])
         satdump::ui_thread_pool.push([&](int)
                                      {  satdump::updateTLEFile(satdump::user_path + "/satdump_tles.txt"); 
                                         satdump::loadTLEFileIntoRegistry(satdump::user_path + "/satdump_tles.txt"); });
-
-    //Shut down loading screen
-    logger->del_sink(loading_screen_sink);
-    loading_screen_sink.reset();
 
     // Main loop
     do


### PR DESCRIPTION
**Adds a loading screen to satdump-ui and SatDump for Android.** I also re-arranged the initialization process slightly to make the loading screen visible as soon as possible.

**Desktop**
![PC](https://github.com/SatDump/SatDump/assets/24253715/03e80f8e-104b-41aa-adb6-2d3299f97553)

**Android**
![mobile](https://github.com/SatDump/SatDump/assets/24253715/0e78cb76-2c4e-4094-bf86-3ef0b305a4e0)
