### PR TITLE
UI Crash fixes

### DIFF
--- a/src-core/common/tracking/tle.cpp
+++ b/src-core/common/tracking/tle.cpp
@@ -105,8 +105,8 @@ namespace satdump
                 norad = std::stoi(noradstr);
 
                 // Delete duplicates
-                std::remove_if(general_tle_registry.begin(), general_tle_registry.end(), [norad](TLE t)
-                               { return t.norad == norad; });
+                general_tle_registry.erase(std::remove_if(general_tle_registry.begin(), general_tle_registry.end(), [norad](TLE t)
+                               { return t.norad == norad; }), general_tle_registry.end());
 
                 logger->trace("Add satellite " + name);
                 general_tle_registry.push_back({norad, name, tle1, tle2});

--- a/src-interface/recorder/recorder.cpp
+++ b/src-interface/recorder/recorder.cpp
@@ -509,7 +509,8 @@ namespace satdump
                 {
                     if (constellation_debug == nullptr)
                         constellation_debug = new widgets::ConstellationViewer();
-                    constellation_debug->pushComplex(source_ptr->output_stream->readBuf, 256);
+                    if(is_started)
+                        constellation_debug->pushComplex(source_ptr->output_stream->readBuf, 256);
                     constellation_debug->draw();
                 }
             }


### PR DESCRIPTION
This PR fixes 2 crashes:

- **Fixed a crash when opening the Recorder Debug widget,** when no source is currently started.
- **Fixed a crash when opening the satellite list in the tracker widget after updating TLEs,** if SatDump already had TLEs loaded. Technically this was due to the in-memory TLE list getting empty vector items on update.