### PR TITLE
Various fixes

### DIFF
--- a/plugins/noaa_metop_support/noaa/module_noaa_gac_decoder.cpp
+++ b/plugins/noaa_metop_support/noaa/module_noaa_gac_decoder.cpp
@@ -119,7 +119,7 @@ namespace noaa
             if (time(NULL) % 10 == 0 && lastTime != time(NULL))
             {
                 lastTime = time(NULL);
-                logger->info("Progress " + std::to_string(round(((float)progress / (float)filesize) * 1000.0f) / 10.0f) + "%%, Frames : " + std::to_string(frame_count / 11090));
+                logger->info("Progress " + std::to_string(round(((float)progress / (float)filesize) * 1000.0f) / 10.0f) + "%%, Frames : " + std::to_string(frame_count));
             }
         }
 

--- a/src-core/common/dsp_source_sink/file_source.h
+++ b/src-core/common/dsp_source_sink/file_source.h
@@ -23,7 +23,7 @@ protected:
     std::string file_path;
     bool iq_swap = false;
 
-    long total_samples = 0;
+    long long total_samples = 0;
 
     FileSelectWidget file_input = FileSelectWidget("Select", "Select Input Baseband");
 

--- a/src-core/common/dsp_source_sink/file_source.h
+++ b/src-core/common/dsp_source_sink/file_source.h
@@ -23,7 +23,7 @@ protected:
     std::string file_path;
     bool iq_swap = false;
 
-    long long total_samples = 0;
+    unsigned long long total_samples = 0;
 
     FileSelectWidget file_input = FileSelectWidget("Select", "Select Input Baseband");
 

--- a/src-core/common/widgets/logger_sink.cpp
+++ b/src-core/common/widgets/logger_sink.cpp
@@ -1,0 +1,47 @@
+#include "imgui/imgui.h"
+#include "logger_sink.h"
+
+namespace widgets
+{
+    void LoggerSinkWidget::receive(slog::LogMsg log)
+    {
+        if (log.lvl >= sink_lvl)
+        {
+            mtx.lock();
+            all_lines.push_back({ log.lvl, format_log(log, false) });
+            if (all_lines.size() == max_lines)
+                all_lines.pop_front();
+            mtx.unlock();
+        }
+    }
+
+    void LoggerSinkWidget::draw()
+    {
+        mtx.lock();
+        for (LogLine& ll : all_lines)
+        {
+            std::string timestamp = ll.str.substr(0, 24);
+            std::string text = ll.str.substr(24, ll.str.size());
+
+            ImGui::Text("%s", timestamp.c_str());
+            ImGui::SameLine();
+
+            if (ll.lvl == slog::LOG_TRACE)
+                ImGui::TextColored(ImColor(255, 255, 255), "%s", text.c_str());
+            else if (ll.lvl == slog::LOG_DEBUG)
+                ImGui::TextColored(ImColor(0, 255, 255), "%s", text.c_str());
+            else if (ll.lvl == slog::LOG_INFO)
+                ImGui::TextColored(ImColor(0, 255, 0), "%s", text.c_str());
+            else if (ll.lvl == slog::LOG_WARN)
+                ImGui::TextColored(ImColor(255, 255, 0), "%s", text.c_str());
+            else if (ll.lvl == slog::LOG_ERROR)
+                ImGui::TextColored(ImColor(255, 0, 0), "%s", text.c_str());
+            else if (ll.lvl == slog::LOG_CRIT)
+                ImGui::TextColored(ImColor(255, 0, 255), "%s", text.c_str());
+
+
+        }
+        mtx.unlock();
+        ImGui::SetScrollY(ImGui::GetScrollMaxY());
+    }
+}

--- a/src-core/common/widgets/logger_sink.h
+++ b/src-core/common/widgets/logger_sink.h
@@ -1,9 +1,7 @@
 #pragma once
 
-#include <vector>
-#include <iostream>
+#include <deque>
 #include "logger.h"
-#include "imgui/imgui.h"
 
 namespace widgets
 {
@@ -16,44 +14,14 @@ namespace widgets
             std::string str;
         };
 
-        std::vector<LogLine> all_lines;
+        std::deque<LogLine> all_lines;
+        std::mutex mtx;
 
     protected:
-        void receive(slog::LogMsg log)
-        {
-            if (log.lvl >= sink_lvl)
-                all_lines.push_back({log.lvl, format_log(log, false)});
-        }
+        void receive(slog::LogMsg log);
 
     public:
-        void draw()
-        {
-            if (all_lines.size() > max_lines)
-                all_lines.erase(all_lines.end() - max_lines, all_lines.end());
-
-            for (LogLine &ll : all_lines)
-            {
-                std::string timestamp = ll.str.substr(0, 24);
-                std::string text = ll.str.substr(24, ll.str.size());
-
-                ImGui::Text("%s", timestamp.c_str());
-                ImGui::SameLine();
-
-                if (ll.lvl == slog::LOG_TRACE)
-                    ImGui::TextColored(ImColor(255, 255, 255), "%s", text.c_str());
-                else if (ll.lvl == slog::LOG_DEBUG)
-                    ImGui::TextColored(ImColor(0, 255, 255), "%s", text.c_str());
-                else if (ll.lvl == slog::LOG_INFO)
-                    ImGui::TextColored(ImColor(0, 255, 0), "%s", text.c_str());
-                else if (ll.lvl == slog::LOG_WARN)
-                    ImGui::TextColored(ImColor(255, 255, 0), "%s", text.c_str());
-                else if (ll.lvl == slog::LOG_ERROR)
-                    ImGui::TextColored(ImColor(255, 0, 0), "%s", text.c_str());
-                else if (ll.lvl == slog::LOG_CRIT)
-                    ImGui::TextColored(ImColor(255, 0, 255), "%s", text.c_str());
-            }
-        }
-
         size_t max_lines = 1e3;
+        void draw();
     };
 }

--- a/src-core/modules/products/module_products_processor.cpp
+++ b/src-core/modules/products/module_products_processor.cpp
@@ -38,7 +38,6 @@ namespace products
     {
         ImGui::Begin("Products Processor", NULL, (window ? 0 : NOWINDOW_FLAGS) | ImGuiWindowFlags_NoScrollbar);
         logger_sink->draw();
-        ImGui::SetScrollY(ImGui::GetScrollMaxY());
         ImGui::End();
     }
 

--- a/src-interface/status_logger_sink.cpp
+++ b/src-interface/status_logger_sink.cpp
@@ -78,15 +78,7 @@ namespace satdump
             ImGui::SetNextWindowBgAlpha(1.0);
             ImGui::Begin("SatDump Log", &show_log, ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoCollapse);
             if (ImGui::IsWindowFocused())
-            {
                 widgets::LoggerSinkWidget::draw();
-                if (lastY != ImGui::GetScrollMaxY())
-                {
-                    lastY = ImGui::GetScrollMaxY();
-                    ImGui::SetScrollY(lastY);
-                }
-
-            }
             else
                 show_log = false;
 

--- a/src-interface/status_logger_sink.cpp
+++ b/src-interface/status_logger_sink.cpp
@@ -68,7 +68,6 @@ namespace satdump
         if (show_log)
         {
             static ImVec2 last_size;
-            static float lastY;
             ImVec2 display_size = ImGui::GetIO().DisplaySize;
             bool did_resize = display_size.x != last_size.x || display_size.y != last_size.y;
             ImGui::SetNextWindowSize(ImVec2(display_size.x, (display_size.y * 0.3) - height), did_resize ? ImGuiCond_Always : ImGuiCond_Appearing);


### PR DESCRIPTION
This PR has 3 fixes:

- **Don't reset the log in the GUI once there are more than 1000 log items.** Instead, pop the first item off the top of the buffer once the max is reached. I also implemented mutex locking within this widget - I saw this change cause some crashes otherwise.
- **Fix GAC frame count in log.** It always displayed 0 before
- **Fix file source playback "fast-forward" bug in the recorder section on Windows.** High-samplerate file playbacks would play as fast as the computer could handle it, after playing for a few minutes on Windows (probably on 32-bit Linux, too). After some debugging, it looks like it's because of the `total_samples` variable within `dsp::DSPSampleSource`.

    On Windows, `long` is only a 32-bit integer - regardless of OS architecture - which is way too small. We need a 64-bit integer, like 64-bit Linux gives us with a `long`. Specifying `long long` fixes the issue.

    I also made it unsigned because I can, and now we can handle even more absurdly large basebands 😄.