### PR TITLE
fix out of bound in deinterleaver for meteor lrpt decoder

### DIFF
--- a/plugins/meteor_support/meteor/deint.cpp
+++ b/plugins/meteor_support/meteor/deint.cpp
@@ -22,18 +22,12 @@ namespace meteor
     {
         int i, j, k;
         uint8_t tmp, _xor, window;
-        std::vector<int> ones_count(8 * period);
-        std::vector<int> average_bit(8 * period);
+        std::vector<int> ones_count(8 * period, 0);
+        std::vector<int> average_bit(8 * period + 8, 0);
         int corr, best_corr, best_idx;
 
         /* Make len a multiple of the period */
         len -= len % period;
-
-        for (i = 0; i < (int)ones_count.size(); i++)
-        {
-            ones_count[i] = 0;
-            average_bit[i] = 0;
-        }
 
         /* XOR the bitstream with a delayed version of itself */
         for (i = 0; i < period; i++)

--- a/plugins/meteor_support/meteor/module_meteor_lrpt_decoder.cpp
+++ b/plugins/meteor_support/meteor/module_meteor_lrpt_decoder.cpp
@@ -22,7 +22,8 @@ namespace meteor
                                                                                                                                         diff_decode(parameters["diff_decode"].get<bool>())
     {
         m2x_mode = d_parameters.contains("m2x_mode") ? d_parameters["m2x_mode"].get<bool>() : false;
-        buffer = new int8_t[ENCODED_FRAME_SIZE];
+        _buffer = new int8_t[ENCODED_FRAME_SIZE + INTER_MARKER_STRIDE];
+        buffer = &_buffer[INTER_MARKER_STRIDE];
 
         if (m2x_mode)
         {
@@ -50,7 +51,7 @@ namespace meteor
 
     METEORLRPTDecoderModule::~METEORLRPTDecoderModule()
     {
-        delete[] buffer;
+        delete[] _buffer;
     }
 
     void METEORLRPTDecoderModule::process()

--- a/plugins/meteor_support/meteor/module_meteor_lrpt_decoder.h
+++ b/plugins/meteor_support/meteor/module_meteor_lrpt_decoder.h
@@ -14,6 +14,7 @@ namespace meteor
     protected:
         bool diff_decode;
 
+        int8_t *_buffer;
         int8_t *buffer;
 
         std::ifstream data_in;


### PR DESCRIPTION
* First:
   ```diff
   - std::vector<int> average_bit(8 * period);
   + std::vector<int> average_bit(8 * period + 8, 0);
   ```
   this needs because out of bound is possible here:
   ```c++
   tmp |= (average_bit[best_idx + i] > 0 ? 1 << i : 0);
   ```
   when `best_idx` is greather than `8 * period - 8`
   I also removed manual filling of vectors with zeros, because it is available using the constructor.


* Second:
   ```diff
   - buffer = new int8_t[ENCODED_FRAME_SIZE];
   + _buffer = new int8_t[ENCODED_FRAME_SIZE + INTER_MARKER_STRIDE];
   + buffer = &_buffer[INTER_MARKER_STRIDE];
   ```
   `buffer` indented because out of bounds is possible here:
   ```c++
   deinterleave(dst, dst + offset, len);
   ```
   when `offset < 0`
   The indent of `INTER_MARKER_STRIDE` is due to this expression:
   ```c++
   offset = offset > INTER_MARKER_STRIDE / 2 ? offset - INTER_MARKER_STRIDE : offset;
   ```
