### PR TITLE
File source fast mode and other fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,8 +74,19 @@ else()
 endif()
 
 if(MSVC OR BUILD_MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP8 /EHsc /wd4305 /wd4267 /wd4244") # Speed up this to object-level
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /MP8 /EHsc /wd4305 /wd4267 /wd4244") # Speed up this to object-level
+    add_definitions(-D_CRT_SECURE_NO_WARNINGS -D_WINSOCK_DEPRECATED_NO_WARNINGS)
+
+    # Speed up this to object-level, Suppress type conversion warnings, suppress
+    # POSIX function warnings, suppress warnings about DLL-exported functions, and
+    # Suppress warnings about template methods defined in another C++ file
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP8 /EHsc /wd4305 /wd4267 /wd4244 /wd4273 /wd4996 /wd4661")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /MP8 /EHsc /wd4305 /wd4267 /wd4244 /wd4273 /wd4996 /wd4661")
+
+    #Suppress pointless (to us) warnings about DLL-exported functions
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /ignore:4286,4217")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /ignore:4286,4217")
+    set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} /ignore:4286,4217")
+
     set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
     include_directories(vcpkg/installed/x64-windows/include)
     link_directories(vcpkg/installed/x64-windows/lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,13 +74,13 @@ else()
 endif()
 
 if(MSVC OR BUILD_MSVC)
-    add_definitions(-D_CRT_SECURE_NO_WARNINGS -D_WINSOCK_DEPRECATED_NO_WARNINGS)
+    add_definitions(-D_CRT_SECURE_NO_WARNINGS -D_WINSOCK_DEPRECATED_NO_WARNINGS -D_CRT_NONSTDC_NO_WARNINGS)
 
     # Speed up this to object-level, Suppress type conversion warnings, suppress
     # POSIX function warnings, suppress warnings about DLL-exported functions, and
     # Suppress warnings about template methods defined in another C++ file
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP8 /EHsc /wd4305 /wd4267 /wd4244 /wd4273 /wd4996 /wd4661")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /MP8 /EHsc /wd4305 /wd4267 /wd4244 /wd4273 /wd4996 /wd4661")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP8 /EHsc /wd4305 /wd4267 /wd4244 /wd4273 /wd4661")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /MP8 /EHsc /wd4305 /wd4267 /wd4244 /wd4273 /wd4661")
 
     #Suppress pointless (to us) warnings about DLL-exported functions
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /ignore:4286,4217")

--- a/plugins/analog_support/noaa_apt/module_noaa_apt_decoder.cpp
+++ b/plugins/analog_support/noaa_apt/module_noaa_apt_decoder.cpp
@@ -325,7 +325,7 @@ namespace noaa_apt
                 {
                     number = d_parameters["satellite_number"];
                 }
-                catch (std::exception)
+                catch (std::exception&)
                 {
                     number = std::stoi(d_parameters["satellite_number"].get<std::string>());
                 }

--- a/plugins/analog_support/noaa_apt/module_noaa_apt_decoder.cpp
+++ b/plugins/analog_support/noaa_apt/module_noaa_apt_decoder.cpp
@@ -325,7 +325,7 @@ namespace noaa_apt
                 {
                     number = d_parameters["satellite_number"];
                 }
-                catch (std::exception &e)
+                catch (std::exception)
                 {
                     number = std::stoi(d_parameters["satellite_number"].get<std::string>());
                 }

--- a/plugins/dmsp_support/dmsp/module_dmsp_rtd_instruments.cpp
+++ b/plugins/dmsp_support/dmsp/module_dmsp_rtd_instruments.cpp
@@ -39,7 +39,7 @@ namespace dmsp
         {
             sat_num = d_parameters["satellite_number"];
         }
-        catch (std::exception &e)
+        catch (std::exception)
         {
             sat_num = std::stoi(d_parameters["satellite_number"].get<std::string>());
         }

--- a/plugins/dmsp_support/dmsp/module_dmsp_rtd_instruments.cpp
+++ b/plugins/dmsp_support/dmsp/module_dmsp_rtd_instruments.cpp
@@ -39,7 +39,7 @@ namespace dmsp
         {
             sat_num = d_parameters["satellite_number"];
         }
-        catch (std::exception)
+        catch (std::exception&)
         {
             sat_num = std::stoi(d_parameters["satellite_number"].get<std::string>());
         }

--- a/plugins/goes_support/goes/grb/data/payload_assembler.cpp
+++ b/plugins/goes_support/goes/grb/data/payload_assembler.cpp
@@ -93,7 +93,7 @@ namespace goes
                 fullPkt.insert(fullPkt.end(), &pkt.header.raw[0], &pkt.header.raw[6]);
                 fullPkt.insert(fullPkt.end(), &pkt.payload[0], &pkt.payload[pkt.payload.size() - 4]);
             }
-            catch (std::exception &e)
+            catch (std::exception)
             {
                 return false;
             }

--- a/plugins/goes_support/goes/grb/data/payload_assembler.cpp
+++ b/plugins/goes_support/goes/grb/data/payload_assembler.cpp
@@ -93,7 +93,7 @@ namespace goes
                 fullPkt.insert(fullPkt.end(), &pkt.header.raw[0], &pkt.header.raw[6]);
                 fullPkt.insert(fullPkt.end(), &pkt.payload[0], &pkt.payload[pkt.payload.size() - 4]);
             }
-            catch (std::exception)
+            catch (std::exception&)
             {
                 return false;
             }

--- a/plugins/inmarsat_support/aero/module_aero_parser.cpp
+++ b/plugins/inmarsat_support/aero/module_aero_parser.cpp
@@ -378,7 +378,7 @@ namespace inmarsat
                             ImGui::TableSetColumnIndex(2);
                             ImGui::TextColored(ImColor(0, 255, 0), "%s", msg["message"].get<std::string>().c_str());
                         }
-                        catch (std::exception &e)
+                        catch (std::exception)
                         {
                         }
                     }
@@ -406,7 +406,7 @@ namespace inmarsat
                             ImGui::TableSetColumnIndex(2);
                             ImGui::TextColored(ImColor(0, 255, 0), "%s", msg.dump().c_str());
                         }
-                        catch (std::exception &e)
+                        catch (std::exception)
                         {
                         }
                     }

--- a/plugins/inmarsat_support/aero/module_aero_parser.cpp
+++ b/plugins/inmarsat_support/aero/module_aero_parser.cpp
@@ -378,7 +378,7 @@ namespace inmarsat
                             ImGui::TableSetColumnIndex(2);
                             ImGui::TextColored(ImColor(0, 255, 0), "%s", msg["message"].get<std::string>().c_str());
                         }
-                        catch (std::exception)
+                        catch (std::exception&)
                         {
                         }
                     }
@@ -406,7 +406,7 @@ namespace inmarsat
                             ImGui::TableSetColumnIndex(2);
                             ImGui::TextColored(ImColor(0, 255, 0), "%s", msg.dump().c_str());
                         }
-                        catch (std::exception)
+                        catch (std::exception&)
                         {
                         }
                     }

--- a/plugins/inmarsat_support/stdc/module_stdc_parser.cpp
+++ b/plugins/inmarsat_support/stdc/module_stdc_parser.cpp
@@ -293,7 +293,7 @@ namespace inmarsat
                             ImGui::TableSetColumnIndex(2);
                             ImGui::TextColored(ImColor(0, 255, 0), "%s", msg["message"].get<std::string>().c_str());
                         }
-                        catch (std::exception &e)
+                        catch (std::exception)
                         {
                         }
                     }
@@ -322,7 +322,7 @@ namespace inmarsat
                             ImGui::TableSetColumnIndex(2);
                             ImGui::TextColored(ImColor(0, 255, 0), "%s", msg["message"].get<std::string>().c_str());
                         }
-                        catch (std::exception &e)
+                        catch (std::exception)
                         {
                         }
                     }
@@ -374,7 +374,7 @@ namespace inmarsat
                                 ImGui::TextColored(ImColor(255, 255, 255), "%s", msg.dump().c_str());
                             }
                         }
-                        catch (std::exception &e)
+                        catch (std::exception)
                         {
                         }
                     }

--- a/plugins/inmarsat_support/stdc/module_stdc_parser.cpp
+++ b/plugins/inmarsat_support/stdc/module_stdc_parser.cpp
@@ -293,7 +293,7 @@ namespace inmarsat
                             ImGui::TableSetColumnIndex(2);
                             ImGui::TextColored(ImColor(0, 255, 0), "%s", msg["message"].get<std::string>().c_str());
                         }
-                        catch (std::exception)
+                        catch (std::exception&)
                         {
                         }
                     }
@@ -322,7 +322,7 @@ namespace inmarsat
                             ImGui::TableSetColumnIndex(2);
                             ImGui::TextColored(ImColor(0, 255, 0), "%s", msg["message"].get<std::string>().c_str());
                         }
-                        catch (std::exception)
+                        catch (std::exception&)
                         {
                         }
                     }
@@ -374,7 +374,7 @@ namespace inmarsat
                                 ImGui::TextColored(ImColor(255, 255, 255), "%s", msg.dump().c_str());
                             }
                         }
-                        catch (std::exception)
+                        catch (std::exception&)
                         {
                         }
                     }

--- a/plugins/sdr_sources/sdrpp_server_support/sdrpp_server/networking.cpp
+++ b/plugins/sdr_sources/sdrpp_server_support/sdrpp_server/networking.cpp
@@ -319,7 +319,7 @@ namespace net {
                 }
                 entry.handler(std::move(client), entry.ctx);
             }
-            catch (std::exception &e) {
+            catch (std::exception) {
                 listening = false;
                 return;
             }

--- a/plugins/sdr_sources/sdrpp_server_support/sdrpp_server/networking.cpp
+++ b/plugins/sdr_sources/sdrpp_server_support/sdrpp_server/networking.cpp
@@ -319,7 +319,7 @@ namespace net {
                 }
                 entry.handler(std::move(client), entry.ctx);
             }
-            catch (std::exception) {
+            catch (std::exception&) {
                 listening = false;
                 return;
             }

--- a/plugins/sdr_sources/spyserver_support/spyserver/networking.cpp
+++ b/plugins/sdr_sources/spyserver_support/spyserver/networking.cpp
@@ -364,7 +364,7 @@ namespace net
                 }
                 entry.handler(std::move(client), entry.ctx);
             }
-            catch (std::exception)
+            catch (std::exception&)
             {
                 listening = false;
                 return;

--- a/plugins/sdr_sources/spyserver_support/spyserver/networking.cpp
+++ b/plugins/sdr_sources/spyserver_support/spyserver/networking.cpp
@@ -364,7 +364,7 @@ namespace net
                 }
                 entry.handler(std::move(client), entry.ctx);
             }
-            catch (std::exception &e)
+            catch (std::exception)
             {
                 listening = false;
                 return;

--- a/plugins/stereo_support/stereo/instruments/secchi/rice_decomp.cpp
+++ b/plugins/stereo_support/stereo/instruments/secchi/rice_decomp.cpp
@@ -52,9 +52,12 @@ must also match.*/
 #include <stdlib.h>
 #include "rice_decomp.h"
 
+#ifndef _MSC_VER
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-variable"
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#endif
+
 namespace soho_compression
 {
     /*      =======================Form of Call=======================
@@ -877,4 +880,7 @@ namespace soho_compression
         return 1; /*For this example we always send.    */
     }
 }
+
+#ifndef _MSC_VER
 #pragma GCC diagnostic pop
+#endif

--- a/src-core/common/cli_utils.cpp
+++ b/src-core/common/cli_utils.cpp
@@ -55,7 +55,7 @@ nlohmann::json parse_common_flags(int argc, char *argv[])
                         else // Otherwse, cast to an integer
                             parameters[flag] = (long long)integral;
                     }
-                    catch (std::exception) // If it fails, parse to a string
+                    catch (std::exception&) // If it fails, parse to a string
                     {
                         parameters[flag] = value;
                     }

--- a/src-core/common/cli_utils.cpp
+++ b/src-core/common/cli_utils.cpp
@@ -55,7 +55,7 @@ nlohmann::json parse_common_flags(int argc, char *argv[])
                         else // Otherwse, cast to an integer
                             parameters[flag] = (long long)integral;
                     }
-                    catch (std::exception &e) // If it fails, parse to a string
+                    catch (std::exception) // If it fails, parse to a string
                     {
                         parameters[flag] = value;
                     }

--- a/src-core/common/dsp_source_sink/file_source.h
+++ b/src-core/common/dsp_source_sink/file_source.h
@@ -21,7 +21,7 @@ protected:
     std::chrono::duration<double> sample_time_period;
     int buffer_size = 8192;
     std::string file_path;
-    bool iq_swap = false;
+    bool iq_swap = false, fast_playback = false;
 
     unsigned long long total_samples = 0;
 

--- a/src-core/common/image/image_drawing.cpp
+++ b/src-core/common/image/image_drawing.cpp
@@ -8,9 +8,15 @@
 #define STB_TRUETYPE_IMPLEMENTATION // force following include to generate implementation
 #include "common/image/font/imstb_truetype.h"
 
+#ifndef _MSC_VER
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 #include "font/utf8.h"
+
+#ifndef _MSC_VER
 #pragma GCC diagnostic pop
+#endif
 #include <iostream>
 #include <fstream>
 

--- a/src-core/common/lua/lua_utils.cpp
+++ b/src-core/common/lua/lua_utils.cpp
@@ -25,7 +25,7 @@ namespace lua_utils
                     else
                         l[index] = mapJsonToLua(lua, el.value());
                 }
-                catch (std::exception &e)
+                catch (std::exception)
                 {
                     if (el.value().is_number_integer())
                         l[el.key()] = el.value().get<int>();
@@ -37,7 +37,7 @@ namespace lua_utils
                         l[el.key()] = mapJsonToLua(lua, el.value());
                 }
             }
-            catch (std::exception &e)
+            catch (std::exception)
             {
             }
         }

--- a/src-core/common/lua/lua_utils.cpp
+++ b/src-core/common/lua/lua_utils.cpp
@@ -25,7 +25,7 @@ namespace lua_utils
                     else
                         l[index] = mapJsonToLua(lua, el.value());
                 }
-                catch (std::exception)
+                catch (std::exception&)
                 {
                     if (el.value().is_number_integer())
                         l[el.key()] = el.value().get<int>();
@@ -37,7 +37,7 @@ namespace lua_utils
                         l[el.key()] = mapJsonToLua(lua, el.value());
                 }
             }
-            catch (std::exception)
+            catch (std::exception&)
             {
             }
         }

--- a/src-core/common/wav.cpp
+++ b/src-core/common/wav.cpp
@@ -60,7 +60,7 @@ namespace wav
         {
             // SDR++ Audio filename
             if (sscanf(filename.c_str(),
-                       "audio_%luHz_%d-%d-%d_%d-%d-%d",
+                       "audio_%lluHz_%d-%d-%d_%d-%d-%d",
                        &freq,
                        &timeS.tm_hour, &timeS.tm_min, &timeS.tm_sec,
                        &timeS.tm_mday, &timeS.tm_mon, &timeS.tm_year) == 7)
@@ -73,7 +73,7 @@ namespace wav
 
             // HDSDR Audio filename
             if (sscanf(filename.c_str(),
-                       "HDSDR_%4d%2d%2d_%2d%2d%2dZ_%lukHz_AF",
+                       "HDSDR_%4d%2d%2d_%2d%2d%2dZ_%llukHz_AF",
                        &timeS.tm_year, &timeS.tm_mon, &timeS.tm_mday,
                        &timeS.tm_hour, &timeS.tm_min, &timeS.tm_sec,
                        &freq) == 7)
@@ -86,7 +86,7 @@ namespace wav
 
             // SDRSharp Audio filename
             if (sscanf(filename.c_str(),
-                       "SDRSharp_%4d%2d%2d_%2d%2d%2dZ_%luHz_AF",
+                       "SDRSharp_%4d%2d%2d_%2d%2d%2dZ_%lluHz_AF",
                        &timeS.tm_year, &timeS.tm_mon, &timeS.tm_mday,
                        &timeS.tm_hour, &timeS.tm_min, &timeS.tm_sec,
                        &freq) == 7)
@@ -99,7 +99,7 @@ namespace wav
 
             // SDRUno Audio filename
             if (sscanf(filename.c_str(),
-                       "SDRUno_%4d%2d%2d_%2d%2d%2d_%luHz",
+                       "SDRUno_%4d%2d%2d_%2d%2d%2d_%lluHz",
                        &timeS.tm_year, &timeS.tm_mon, &timeS.tm_mday,
                        &timeS.tm_hour, &timeS.tm_min, &timeS.tm_sec,
                        &freq) == 7)
@@ -123,7 +123,7 @@ namespace wav
 
             // GQRX Audio filename (UTC)
             if (sscanf(filename.c_str(),
-                       "gqrx_%4d%2d%2d_%2d%2d%2d_%lu",
+                       "gqrx_%4d%2d%2d_%2d%2d%2d_%llu",
                        &timeS.tm_year, &timeS.tm_mon, &timeS.tm_mday,
                        &timeS.tm_hour, &timeS.tm_min, &timeS.tm_sec,
                        &freq) == 7)
@@ -175,7 +175,7 @@ namespace wav
         {
             // SDR++ Baseband filename
             if (sscanf(filename.c_str(),
-                       "baseband_%luHz_%d-%d-%d_%d-%d-%d",
+                       "baseband_%lluHz_%d-%d-%d_%d-%d-%d",
                        &freq,
                        &timeS.tm_hour, &timeS.tm_min, &timeS.tm_sec,
                        &timeS.tm_mday, &timeS.tm_mon, &timeS.tm_year) == 7)

--- a/src-core/core/pipeline.cpp
+++ b/src-core/core/pipeline.cpp
@@ -316,7 +316,7 @@ namespace satdump
                 {
                     newPipeline.live_cfg.normal_live = pipelineConfig.value()["live_cfg"].get<std::vector<std::pair<int, int>>>();
                 }
-                catch (std::exception)
+                catch (std::exception&)
                 {
                     newPipeline.live_cfg.normal_live = pipelineConfig.value()["live_cfg"]["default"].get<std::vector<std::pair<int, int>>>();
                     if (pipelineConfig.value()["live_cfg"].contains("server"))

--- a/src-core/core/pipeline.cpp
+++ b/src-core/core/pipeline.cpp
@@ -316,7 +316,7 @@ namespace satdump
                 {
                     newPipeline.live_cfg.normal_live = pipelineConfig.value()["live_cfg"].get<std::vector<std::pair<int, int>>>();
                 }
-                catch (std::exception &e)
+                catch (std::exception)
                 {
                     newPipeline.live_cfg.normal_live = pipelineConfig.value()["live_cfg"]["default"].get<std::vector<std::pair<int, int>>>();
                     if (pipelineConfig.value()["live_cfg"].contains("server"))

--- a/src-core/nlohmann/json_utils.h
+++ b/src-core/nlohmann/json_utils.h
@@ -18,7 +18,7 @@ T getValueOrDefault(nlohmann::json obj, T v)
     {
         return obj.get<T>();
     }
-    catch (std::exception &e)
+    catch (std::exception)
     {
         return v;
     }
@@ -31,7 +31,7 @@ void setValueIfExists(nlohmann::json obj, T &v)
     {
         v = obj.get<T>();
     }
-    catch (std::exception &e)
+    catch (std::exception)
     {
     }
 }

--- a/src-core/nlohmann/json_utils.h
+++ b/src-core/nlohmann/json_utils.h
@@ -18,7 +18,7 @@ T getValueOrDefault(nlohmann::json obj, T v)
     {
         return obj.get<T>();
     }
-    catch (std::exception)
+    catch (std::exception&)
     {
         return v;
     }
@@ -31,7 +31,7 @@ void setValueIfExists(nlohmann::json obj, T &v)
     {
         v = obj.get<T>();
     }
-    catch (std::exception)
+    catch (std::exception&)
     {
     }
 }

--- a/src-core/products/image_products.h
+++ b/src-core/products/image_products.h
@@ -64,7 +64,7 @@ namespace satdump
                 else
                     return contents["timestamps"].get<std::vector<double>>();
             }
-            catch (std::exception)
+            catch (std::exception&)
             {
                 return {};
             }

--- a/src-core/products/image_products.h
+++ b/src-core/products/image_products.h
@@ -64,7 +64,7 @@ namespace satdump
                 else
                     return contents["timestamps"].get<std::vector<double>>();
             }
-            catch (std::exception &e)
+            catch (std::exception)
             {
                 return {};
             }

--- a/src-core/products/radiation_products.h
+++ b/src-core/products/radiation_products.h
@@ -36,12 +36,12 @@ namespace satdump
                 {
                     timestamps = contents["timestamps"][channel].get<std::vector<double>>();
                 }
-                catch (std::exception &e)
+                catch (std::exception)
                 {
                     timestamps = contents["timestamps"].get<std::vector<double>>();
                 }
             }
-            catch (std::exception &e)
+            catch (std::exception)
             {
                 logger->trace("This radiation product has no timestamps!");
             }

--- a/src-core/products/radiation_products.h
+++ b/src-core/products/radiation_products.h
@@ -36,12 +36,12 @@ namespace satdump
                 {
                     timestamps = contents["timestamps"][channel].get<std::vector<double>>();
                 }
-                catch (std::exception)
+                catch (std::exception&)
                 {
                     timestamps = contents["timestamps"].get<std::vector<double>>();
                 }
             }
-            catch (std::exception)
+            catch (std::exception&)
             {
                 logger->trace("This radiation product has no timestamps!");
             }

--- a/src-core/products/scatterometer_products.h
+++ b/src-core/products/scatterometer_products.h
@@ -62,7 +62,7 @@ namespace satdump
             {
                 timestamps = contents["timestamps"][channel].get<std::vector<double>>();
             }
-            catch (std::exception)
+            catch (std::exception&)
             {
                 timestamps = contents["timestamps"].get<std::vector<double>>();
             }

--- a/src-core/products/scatterometer_products.h
+++ b/src-core/products/scatterometer_products.h
@@ -62,7 +62,7 @@ namespace satdump
             {
                 timestamps = contents["timestamps"][channel].get<std::vector<double>>();
             }
-            catch (std::exception &e)
+            catch (std::exception)
             {
                 timestamps = contents["timestamps"].get<std::vector<double>>();
             }

--- a/src-interface/pipeline_selector.h
+++ b/src-interface/pipeline_selector.h
@@ -68,7 +68,7 @@ namespace satdump
                                     favourite.push_back(i);
                         }
                     }
-                    catch (std::exception)
+                    catch (std::exception&)
                     {
                     }
                 }

--- a/src-interface/pipeline_selector.h
+++ b/src-interface/pipeline_selector.h
@@ -68,7 +68,7 @@ namespace satdump
                                     favourite.push_back(i);
                         }
                     }
-                    catch (std::exception &e)
+                    catch (std::exception)
                     {
                     }
                 }

--- a/src-interface/recorder/recorder_proc.cpp
+++ b/src-interface/recorder/recorder_proc.cpp
@@ -121,7 +121,7 @@ namespace satdump
                     {
                         source_ptr->set_samplerate(cfg["samplerate"]);
                     }
-                    catch (std::exception &e)
+                    catch (std::exception)
                     {
                     }
                 }

--- a/src-interface/recorder/recorder_proc.cpp
+++ b/src-interface/recorder/recorder_proc.cpp
@@ -121,7 +121,7 @@ namespace satdump
                     {
                         source_ptr->set_samplerate(cfg["samplerate"]);
                     }
-                    catch (std::exception)
+                    catch (std::exception&)
                     {
                     }
                 }

--- a/src-interface/recorder/tracking/tracking_widget_backend.cpp
+++ b/src-interface/recorder/tracking/tracking_widget_backend.cpp
@@ -358,7 +358,7 @@ namespace satdump
                 if (is_valid && name.find("simulation") == std::string::npos)
                     vv.push_back({id, name});
             }
-            catch (std::exception)
+            catch (std::exception&)
             {
             }
         }

--- a/src-interface/recorder/tracking/tracking_widget_backend.cpp
+++ b/src-interface/recorder/tracking/tracking_widget_backend.cpp
@@ -358,7 +358,7 @@ namespace satdump
                 if (is_valid && name.find("simulation") == std::string::npos)
                     vv.push_back({id, name});
             }
-            catch (std::exception &e)
+            catch (std::exception)
             {
             }
         }


### PR DESCRIPTION
**This PR makes a few changes** - not the ones I was going to make, mind you. The first change I intended on making, and the rest just ended up happening on the way 😎. Everything else will have to be in a later PR.

- **Adds "fast mode" to the GUI recorder tab when playing back from a file source.** This lets the file play back/process as fast as possible. I found myself needing to decode just part of a file, or use the screen as a poor man's way to convert a ziq to s8/s16. The ability to run through it at full speed is helpful in both situations. I tested the change with a few decoding pipelines and it seems to work OK - I assume this is safe to do, but I'm sure you have more insight.

    ![image](https://github.com/SatDump/SatDump/assets/24253715/207a75da-3c79-460d-b1f1-a2ba87e659e8)

- **Cleaned up compiler warnings on Windows** to make the log more useful in finding problems. This included several changes:
    - **Suppress warnings about using "unsafe" POSIX functions** since I highly doubt you'd like to convert to Windows-specific APIs anytime soon.
    - **Suppress warnings about using functions marked for DLL export/import** since I think these are unavoidable in the way SatDump is written (and seem harmless, from my research).
    - **Suppress warnings about "no suitable definition provided for explicit template instantiation request"**. This seems to happen because the `Image` class has template functions declared in the header, and defined in a .cpp file. Visual Studio doesn't seem to be a fan of this, but it's valid and works, so I see no point in keeping the warning.
    - **Guard GCC pragmas**
    - **Remove unused `std::exception` variables** - honestly, I'm with Microsoft on this one. Don't worry, that won't happen too much - but an unused variable is an unused variable 🤷 . GCC actually has a bug report about not detecting unused exceptions at https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90353.
    - **When using formatted strings, use `%llu` for uint64_t:** before `%lu` was used in wav.cpp, which is only 32 bit on Windows.
 
There are a few remaining warnings, but it's much more manageable. Remaining warnings are in libraries or effectively harmless. There is one I'm going to comment on below because I'm not sure about it.