### PR TITLE
Auto Display scaling

### DIFF
--- a/android/app/src/main/java/MainActivity.kt
+++ b/android/app/src/main/java/MainActivity.kt
@@ -155,7 +155,7 @@ class MainActivity : NativeActivity(), TextWatcher {
         return getApplicationInfo().nativeLibraryDir;
     }
 
-    public fun get_dpi() : float {
+    public fun get_dpi() : Float {
         return getResources().getDisplayMetrics().density;
     }
 

--- a/android/app/src/main/java/MainActivity.kt
+++ b/android/app/src/main/java/MainActivity.kt
@@ -155,6 +155,10 @@ class MainActivity : NativeActivity(), TextWatcher {
         return getApplicationInfo().nativeLibraryDir;
     }
 
+    public fun get_dpi() : float {
+        return getResources().getDisplayMetrics().density;
+    }
+
     fun showSoftInput() {
         val inputMethodManager = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
         inputMethodManager.showSoftInput(editText, 0)

--- a/android/loading_screen.cpp
+++ b/android/loading_screen.cpp
@@ -8,7 +8,9 @@
 
 namespace satdump
 {
-    LoadingScreenSink::LoadingScreenSink(EGLDisplay *g_EglDisplay, EGLSurface *g_EglSurface) : g_EglDisplay{g_EglDisplay}, g_EglSurface{g_EglSurface}
+    LoadingScreenSink::LoadingScreenSink(EGLDisplay *g_EglDisplay, EGLSurface *g_EglSurface, float scale) : g_EglDisplay{g_EglDisplay},
+                                                                                                            g_EglSurface{g_EglSurface},
+                                                                                                            scale{scale}
     {
         image::Image<uint8_t> image;
         image.load_png(resources::getResourcePath("icon.png"));
@@ -59,7 +61,7 @@ namespace satdump
 
         ImGui_ImplOpenGL3_NewFrame();
         ImGui_ImplAndroid_NewFrame();
-        draw_loader(width, height, &image_texture, str);
+        draw_loader(width, height, scale, &image_texture, str);
         glViewport(0, 0, (int)width, (int)height);
         glClearColor(0.0666f, 0.0666f, 0.0666f, 1.0f);
         glClear(GL_COLOR_BUFFER_BIT);

--- a/android/loading_screen.h
+++ b/android/loading_screen.h
@@ -9,7 +9,7 @@ namespace satdump
     class LoadingScreenSink : public slog::LoggerSink
     {
     public:
-        LoadingScreenSink(EGLDisplay *g_EglDisplay, EGLSurface *g_EglSurface);
+        LoadingScreenSink(EGLDisplay *g_EglDisplay, EGLSurface *g_EglSurface, float scale);
         ~LoadingScreenSink();
     protected:
         void receive(slog::LogMsg log);
@@ -18,5 +18,6 @@ namespace satdump
         EGLDisplay *g_EglDisplay;
         EGLSurface *g_EglSurface;
         GLuint image_texture;
+        float scale;
     };
 }

--- a/android/main.cpp
+++ b/android/main.cpp
@@ -31,6 +31,36 @@ static int GetAssetData(const char *filename, void **out_data);
 
 bool was_init = false;
 
+float get_dpi(struct android_app* app)
+{
+    JavaVM* java_vm = app->activity->vm;
+    JNIEnv* java_env = NULL;
+
+    jint jni_return = java_vm->GetEnv((void**)&java_env, JNI_VERSION_1_6);
+    if (jni_return == JNI_ERR)
+        throw std::runtime_error("Could not get JNI environement");
+
+    jni_return = java_vm->AttachCurrentThread(&java_env, NULL);
+    if (jni_return != JNI_OK)
+        throw std::runtime_error("Could not attach to thread");
+
+    jclass native_activity_clazz = java_env->GetObjectClass(app->activity->clazz);
+    if (native_activity_clazz == NULL)
+        throw std::runtime_error("Could not get MainActivity class");
+
+    jmethodID method_id = java_env->GetMethodID(native_activity_clazz, "get_dpi", "()F");
+    if (method_id == NULL)
+        throw std::runtime_error("Could not get methode ID");
+
+    jfloat jflt = java_env->CallFloatMethod(app->activity->clazz, method_id);
+
+    jni_return = java_vm->DetachCurrentThread();
+    if (jni_return != JNI_OK)
+        throw std::runtime_error("Could not detach from thread");
+
+    return jflt;
+}
+
 void init(struct android_app *app)
 {
     if (g_Initialized)
@@ -294,36 +324,6 @@ std::string getPluginsDir(struct android_app *app)
         throw std::runtime_error("Could not detach from thread");
 
     return str;
-}
-
-float get_dpi(struct android_app* app)
-{
-    JavaVM* java_vm = app->activity->vm;
-    JNIEnv* java_env = NULL;
-
-    jint jni_return = java_vm->GetEnv((void**)&java_env, JNI_VERSION_1_6);
-    if (jni_return == JNI_ERR)
-        throw std::runtime_error("Could not get JNI environement");
-
-    jni_return = java_vm->AttachCurrentThread(&java_env, NULL);
-    if (jni_return != JNI_OK)
-        throw std::runtime_error("Could not attach to thread");
-
-    jclass native_activity_clazz = java_env->GetObjectClass(app->activity->clazz);
-    if (native_activity_clazz == NULL)
-        throw std::runtime_error("Could not get MainActivity class");
-
-    jmethodID method_id = java_env->GetMethodID(native_activity_clazz, "get_dpi", "()Ljava/lang/float;");
-    if (method_id == NULL)
-        throw std::runtime_error("Could not get methode ID");
-
-    float jflt = (float)java_env->CallFloatMethod(app->activity->clazz, method_id);
-
-    jni_return = java_vm->DetachCurrentThread();
-    if (jni_return != JNI_OK)
-        throw std::runtime_error("Could not detach from thread");
-
-    return jflt;
 }
 
 #include <unistd.h>

--- a/android/main.cpp
+++ b/android/main.cpp
@@ -28,7 +28,6 @@ static int GetAssetData(const char *filename, void **out_data);
 #include "main_ui.h"
 #include "loading_screen.h"
 #include "core/style.h"
-#include "core/module.h"
 
 bool was_init = false;
 
@@ -97,15 +96,15 @@ void init(struct android_app *app)
         // ImGui::StyleColorsDark();
         // ImGui::StyleColorsClassic();
 
-        ui_scale = 2.0;
+        float display_scale = get_dpi(app);
         initLogger();
-        style::setFonts();
-        std::shared_ptr<satdump::LoadingScreenSink> loading_screen_sink = std::make_shared<satdump::LoadingScreenSink>(&g_EglDisplay, &g_EglSurface);
+        style::setFonts(display_scale);
+        std::shared_ptr<satdump::LoadingScreenSink> loading_screen_sink = std::make_shared<satdump::LoadingScreenSink>(&g_EglDisplay, &g_EglSurface, display_scale);
         logger->add_sink(loading_screen_sink);
 
         satdump::tle_do_update_on_init = false;
         satdump::initSatdump();
-        satdump::initMainUI();
+        satdump::initMainUI(display_scale);
 
         //Shut down loading screen
         logger->del_sink(loading_screen_sink);
@@ -295,6 +294,36 @@ std::string getPluginsDir(struct android_app *app)
         throw std::runtime_error("Could not detach from thread");
 
     return str;
+}
+
+float get_dpi(struct android_app* app)
+{
+    JavaVM* java_vm = app->activity->vm;
+    JNIEnv* java_env = NULL;
+
+    jint jni_return = java_vm->GetEnv((void**)&java_env, JNI_VERSION_1_6);
+    if (jni_return == JNI_ERR)
+        throw std::runtime_error("Could not get JNI environement");
+
+    jni_return = java_vm->AttachCurrentThread(&java_env, NULL);
+    if (jni_return != JNI_OK)
+        throw std::runtime_error("Could not attach to thread");
+
+    jclass native_activity_clazz = java_env->GetObjectClass(app->activity->clazz);
+    if (native_activity_clazz == NULL)
+        throw std::runtime_error("Could not get MainActivity class");
+
+    jmethodID method_id = java_env->GetMethodID(native_activity_clazz, "get_dpi", "()Ljava/lang/float;");
+    if (method_id == NULL)
+        throw std::runtime_error("Could not get methode ID");
+
+    float jflt = (float)java_env->CallFloatMethod(app->activity->clazz, method_id);
+
+    jni_return = java_vm->DetachCurrentThread();
+    if (jni_return != JNI_OK)
+        throw std::runtime_error("Could not detach from thread");
+
+    return jflt;
 }
 
 #include <unistd.h>

--- a/satdump_cfg.json
+++ b/satdump_cfg.json
@@ -54,8 +54,8 @@
         "manual_dpi_scaling": {
             "type": "float",
             "value": 1.0,
-            "name": "DPI Scaling",
-            "description": "DPI Scaling defines the overall UI scale. This can be used to make it bigger or smaller depending on your display's pixel density."
+            "name": "UI Scaling",
+            "description": "Defines the overall UI scale. This can be used to make UI elements bigger or smaller\n\n1.0 = normal\n0.5 = half size\n2.0 = double size"
         },
         "finish_processing_after_live": {
             "type": "bool",

--- a/src-core/core/style.cpp
+++ b/src-core/core/style.cpp
@@ -18,7 +18,7 @@ namespace style
 
     bool setDefaultStyle()
     {
-        float round = 2.0f;
+        float round = pow(2.0f, ui_scale);
         ImGui::GetStyle().WindowRounding = round;
         ImGui::GetStyle().ChildRounding = round;
         ImGui::GetStyle().FrameRounding = round;
@@ -32,9 +32,9 @@ namespace style
         return true;
     }
 
-    bool setLightStyle(float dpi_scaling)
+    bool setLightStyle()
     {
-        float round = 2.0f;
+        float round = pow(2.0f, ui_scale);
         ImGui::GetStyle().WindowRounding = round;
         ImGui::GetStyle().ChildRounding = round;
         ImGui::GetStyle().FrameRounding = round;
@@ -91,15 +91,12 @@ namespace style
         colors[ImGuiCol_NavHighlight] = ImVec4(0.60f, 0.60f, 0.60f, 1.00f);
         colors[ImGuiCol_NavWindowingHighlight] = ImVec4(1.00f, 1.00f, 1.00f, 0.70f);*/
 
-        ImGui::GetStyle().ScaleAllSizes(dpi_scaling);
-        ui_scale = dpi_scaling;
-
         return true;
     }
 
-    bool setDarkStyle(float dpi_scaling)
+    bool setDarkStyle()
     {
-        float round = 2.0f;
+        float round = pow(2.0f, ui_scale);
         ImGui::GetStyle().WindowRounding = round;
         ImGui::GetStyle().ChildRounding = round;
         ImGui::GetStyle().FrameRounding = round;
@@ -156,9 +153,6 @@ namespace style
         colors[ImGuiCol_NavHighlight] = ImVec4(0.60f, 0.60f, 0.60f, 1.00f);
         colors[ImGuiCol_NavWindowingHighlight] = ImVec4(1.00f, 1.00f, 1.00f, 0.70f);
 
-        ImGui::GetStyle().ScaleAllSizes(dpi_scaling);
-        ui_scale = dpi_scaling;
-
         return true;
     }
 
@@ -178,20 +172,25 @@ namespace style
 
     void setFonts()
     {
+        setFonts(ui_scale);
+    }
+
+    void setFonts(float dpi_scaling)
+    {
         ImGui::GetIO().Fonts->Clear();
         ImFontGlyphRangesBuilder builder;
         static const ImWchar def[] = {0x20, 0x2300, 0}; //default range
         static ImFontConfig config;
-        baseFont = ImGui::GetIO().Fonts->AddFontFromFileTTF(resources::getResourcePath("fonts/Roboto-Medium.ttf").c_str(), 16.0f * ui_scale, &config, def);
+        baseFont = ImGui::GetIO().Fonts->AddFontFromFileTTF(resources::getResourcePath("fonts/Roboto-Medium.ttf").c_str(), 16.0f * dpi_scaling, &config, def);
         config.MergeMode = true;
         static const ImWchar list[6][3] = {{0xf000, 0xf0ff, 0}, {0xf400, 0xf4ff, 0}, {0xf800, 0xf8ff, 0}, {0xfc00, 0xfcff, 0}, {0xea00, 0xeaff, 0}, {0xf200, 0xf2ff, 0}};   
 
         for (int i = 0; i < 6; i++)
-            baseFont = ImGui::GetIO().Fonts->AddFontFromFileTTF(resources::getResourcePath("fonts/font.ttf").c_str(), 16.0f * ui_scale, &config, list[i]); 
+            baseFont = ImGui::GetIO().Fonts->AddFontFromFileTTF(resources::getResourcePath("fonts/font.ttf").c_str(), 16.0f * dpi_scaling, &config, list[i]);
 
         config.MergeMode = false;
-        bigFont = ImGui::GetIO().Fonts->AddFontFromFileTTF(resources::getResourcePath("fonts/Roboto-Medium.ttf").c_str(), 45.0f * ui_scale);   //, &config, ranges);
-        //hugeFont = ImGui::GetIO().Fonts->AddFontFromFileTTF(resources::getResourcePath("fonts/Roboto-Medium.ttf").c_str(), 128.0f * ui_scale); //, &config, ranges);
+        bigFont = ImGui::GetIO().Fonts->AddFontFromFileTTF(resources::getResourcePath("fonts/Roboto-Medium.ttf").c_str(), 45.0f * dpi_scaling);   //, &config, ranges);
+        //hugeFont = ImGui::GetIO().Fonts->AddFontFromFileTTF(resources::getResourcePath("fonts/Roboto-Medium.ttf").c_str(), 128.0f * dpi_scaling); //, &config, ranges);
         ImGui::GetIO().Fonts->Build();
     }
 }

--- a/src-core/core/style.h
+++ b/src-core/core/style.h
@@ -10,9 +10,10 @@ namespace style
     SATDUMP_DLL extern ImFont *hugeFont;
 
     bool setDefaultStyle();
-    bool setLightStyle(float dpi_scaling = 1.0f);
-    bool setDarkStyle(float dpi_scaling = 1.0f);
+    bool setLightStyle();
+    bool setDarkStyle();
     void beginDisabled();
     void endDisabled();
     void setFonts();
+    void setFonts(float dpi_scaling);
 }

--- a/src-interface/loader/loader.cpp
+++ b/src-interface/loader/loader.cpp
@@ -5,7 +5,7 @@
 
 namespace satdump
 {
-    void draw_loader(int width, int height, GLuint *image_texture, std::string str)
+    void draw_loader(int width, int height, float scale, GLuint *image_texture, std::string str)
     {
     	const std::string title = "SatDump";
     	const std::string slogan = "General Purpose Satellite Data Processor";
@@ -17,33 +17,33 @@ namespace satdump
 
         if(width > height)
         {
-            ImVec2 reference_pos = { (float)width * 0.2f, ((float)height * 0.5f) - 125 };
+            ImVec2 reference_pos = { (float)width * 0.2f, ((float)height * 0.5f) - (125 * scale)};
             ImGui::SetCursorPos(reference_pos);
-            ImGui::Image((void*)(intptr_t)(*image_texture), ImVec2(200, 200));
-            ImGui::SetCursorPos({ reference_pos.x + 230, reference_pos.y + 40 });
+            ImGui::Image((void*)(intptr_t)(*image_texture), ImVec2(200 * scale, 200 * scale));
+            ImGui::SetCursorPos({ reference_pos.x + (230 * scale), reference_pos.y + (40 * scale) });
             ImGui::PushFont(style::bigFont);
             ImGui::TextUnformatted(title.c_str());
             ImGui::PopFont();
-            ImGui::SetCursorPos({ reference_pos.x + 230, reference_pos.y + 87 });
+            ImGui::SetCursorPos({ reference_pos.x + (230 * scale), reference_pos.y + (87 * scale) });
             ImGui::TextUnformatted(slogan.c_str());
-            ImGui::GetWindowDrawList()->AddLine({reference_pos.x + 230, reference_pos.y + 112}, {reference_pos.x + 490, reference_pos.y + 112}, IM_COL32(155, 155, 155, 255));
-            ImGui::SetCursorPos({ reference_pos.x + 230, reference_pos.y + 120 });
+            ImGui::GetWindowDrawList()->AddLine({reference_pos.x + (230 * scale), reference_pos.y + (112 * scale)}, {reference_pos.x + (490 * scale), reference_pos.y + (112 * scale)}, IM_COL32(155, 155, 155, 255));
+            ImGui::SetCursorPos({ reference_pos.x + (230 * scale), reference_pos.y + (120 * scale) });
         }
         else
         {
             ImGui::PushFont(style::bigFont);
             ImVec2 title_size = ImGui::CalcTextSize(title.c_str());
-            ImGui::SetCursorPos({((float)width / 2) - 150, ((float)height / 2) - title_size.y - 315});
-            ImGui::Image((void*)(intptr_t)(*image_texture), ImVec2(300, 300));
+            ImGui::SetCursorPos({((float)width / 2) - (150 * scale), ((float)height / 2) - title_size.y - (315 * scale)});
+            ImGui::Image((void*)(intptr_t)(*image_texture), ImVec2(300 * scale, 300 * scale));
             ImGui::SetCursorPos({((float)width / 2) - (title_size.x / 2), ((float)height / 2) - title_size.y});
             ImGui::TextUnformatted(title.c_str());
             ImGui::PopFont();
             ImVec2 slogan_size = ImGui::CalcTextSize(slogan.c_str());
-            ImGui::SetCursorPos({ ((float)width / 2) - (slogan_size.x / 2), ((float)height / 2) + 10 });
+            ImGui::SetCursorPos({ ((float)width / 2) - (slogan_size.x / 2), ((float)height / 2) + (10 * scale) });
             ImGui::TextUnformatted(slogan.c_str());
-            ImGui::GetWindowDrawList()->AddLine({((float)width / 2) - (slogan_size.x / 2), ((float)height / 2) + 20 + slogan_size.y}, 
-                {((float)width / 2) + (slogan_size.x / 2), ((float)height / 2) + 20 + slogan_size.y}, IM_COL32(155, 155, 155, 255));
-            ImGui::SetCursorPos({((float)width / 2) - (ImGui::CalcTextSize(str.c_str()).x / 2), ((float)height / 2) + 25 + slogan_size.y});
+            ImGui::GetWindowDrawList()->AddLine({((float)width / 2) - (slogan_size.x / 2), ((float)height / 2) + (20 * scale) + slogan_size.y}, 
+                {((float)width / 2) + (slogan_size.x / 2), ((float)height / 2) + (20 * scale) + slogan_size.y}, IM_COL32(155, 155, 155, 255));
+            ImGui::SetCursorPos({((float)width / 2) - (ImGui::CalcTextSize(str.c_str()).x / 2), ((float)height / 2) + (25 * scale) + slogan_size.y});
         }
 
         ImGui::TextDisabled("%s", str.c_str());

--- a/src-interface/loader/loader.cpp
+++ b/src-interface/loader/loader.cpp
@@ -33,8 +33,8 @@ namespace satdump
         {
             ImGui::PushFont(style::bigFont);
             ImVec2 title_size = ImGui::CalcTextSize(title.c_str());
-            ImGui::SetCursorPos({((float)width / 2) - (150 * scale), ((float)height / 2) - title_size.y - (315 * scale)});
-            ImGui::Image((void*)(intptr_t)(*image_texture), ImVec2(300 * scale, 300 * scale));
+            ImGui::SetCursorPos({((float)width / 2) - (100 * scale), ((float)height / 2) - title_size.y - (215 * scale)});
+            ImGui::Image((void*)(intptr_t)(*image_texture), ImVec2(200 * scale, 200 * scale));
             ImGui::SetCursorPos({((float)width / 2) - (title_size.x / 2), ((float)height / 2) - title_size.y});
             ImGui::TextUnformatted(title.c_str());
             ImGui::PopFont();

--- a/src-interface/loader/loader.h
+++ b/src-interface/loader/loader.h
@@ -7,5 +7,5 @@
 
 namespace satdump
 {
-	void draw_loader(int width, int height, GLuint *image_texture, std::string str);
+	void draw_loader(int width, int height, float scale, GLuint *image_texture, std::string str);
 }

--- a/src-interface/main_ui.cpp
+++ b/src-interface/main_ui.cpp
@@ -36,28 +36,14 @@ namespace satdump
     std::shared_ptr<NotifyLoggerSink> notify_logger_sink;
     std::shared_ptr<StatusLoggerSink> status_logger_sink;
 
-    void initMainUI()
+    void initMainUI(float device_scale)
     {
         audio::registerSinks();
-
         offline::setup();
         settings::setup();
 
-        light_theme = config::main_cfg["user_interface"]["light_theme"]["value"].get<bool>();
-        float manual_dpi_scaling = config::main_cfg["user_interface"]["manual_dpi_scaling"]["value"].get<float>();
-
-#ifdef __ANDROID__
-        manual_dpi_scaling *= 3; // Otherwise it's just too small by default!
-#endif
-
-        ui_scale = manual_dpi_scaling;
-
-        // Setup Theme
-
-        if (light_theme)
-            style::setLightStyle(manual_dpi_scaling);
-        else
-            style::setDarkStyle(manual_dpi_scaling);
+        // Setup DPI/Theme
+        updateUI(device_scale);
 
         // Load credits MD
         std::ifstream ifs(resources::getResourcePath("credits.md"));
@@ -79,6 +65,20 @@ namespace satdump
         status_logger_sink = std::make_shared<StatusLoggerSink>();
         if(status_logger_sink->is_shown())
             logger->add_sink(status_logger_sink);
+    }
+
+    void updateUI(float device_scale)
+    {
+        light_theme = config::main_cfg["user_interface"]["light_theme"]["value"].get<bool>();
+        float manual_dpi_scaling = config::main_cfg["user_interface"]["manual_dpi_scaling"]["value"].get<float>();
+        ui_scale = device_scale * manual_dpi_scaling;
+        ImGui::GetStyle() = ImGuiStyle::ImGuiStyle();
+        ImGui::GetStyle().ScaleAllSizes(ui_scale);
+
+        if (light_theme)
+            style::setLightStyle();
+        else
+            style::setDarkStyle();
     }
 
     void exitMainUI()

--- a/src-interface/main_ui.cpp
+++ b/src-interface/main_ui.cpp
@@ -72,7 +72,7 @@ namespace satdump
         light_theme = config::main_cfg["user_interface"]["light_theme"]["value"].get<bool>();
         float manual_dpi_scaling = config::main_cfg["user_interface"]["manual_dpi_scaling"]["value"].get<float>();
         ui_scale = device_scale * manual_dpi_scaling;
-        ImGui::GetStyle() = ImGuiStyle::ImGuiStyle();
+        ImGui::GetStyle() = ImGuiStyle();
         ImGui::GetStyle().ScaleAllSizes(ui_scale);
 
         if (light_theme)

--- a/src-interface/main_ui.h
+++ b/src-interface/main_ui.h
@@ -19,7 +19,8 @@ namespace satdump
     extern std::shared_ptr<RecorderApplication> recorder_app;
     extern std::shared_ptr<ViewerApplication> viewer_app;
 
-    void initMainUI();
+    void initMainUI(float device_scale);
+    void updateUI(float device_scale);
     void exitMainUI();
     void renderMainUI(int wwidth, int wheight);
 }

--- a/src-interface/pipeline_selector.h
+++ b/src-interface/pipeline_selector.h
@@ -287,8 +287,8 @@ namespace satdump
         {
             pipeline_mtx.lock();
             ImGui::BeginTable("##pipelinesmainoptions", 2);
-            ImGui::TableSetupColumn("##pipelinesmaincolumn1", ImGuiTableColumnFlags_WidthFixed, 100);
-            ImGui::TableSetupColumn("##pipelinesmaincolumn2", ImGuiTableColumnFlags_WidthStretch, 100);
+            ImGui::TableSetupColumn("##pipelinesmaincolumn1", ImGuiTableColumnFlags_WidthFixed, 100 * ui_scale);
+            ImGui::TableSetupColumn("##pipelinesmaincolumn2", ImGuiTableColumnFlags_WidthStretch, 100 * ui_scale);
 
             ImGui::TableNextRow();
             ImGui::TableSetColumnIndex(0);

--- a/src-ui/loading_screen.cpp
+++ b/src-ui/loading_screen.cpp
@@ -6,7 +6,8 @@
 
 namespace satdump
 {
-    LoadingScreenSink::LoadingScreenSink(GLFWwindow* window, GLFWimage* img) : window{window}
+    LoadingScreenSink::LoadingScreenSink(GLFWwindow* window, float scale, GLFWimage* img) : window{window},
+                                                                                            scale{scale}
     {
         glGenTextures(1, &image_texture);
         glBindTexture(GL_TEXTURE_2D, image_texture);
@@ -35,7 +36,7 @@ namespace satdump
         ImGui_ImplOpenGL3_NewFrame();
         ImGui_ImplGlfw_NewFrame();
 
-        draw_loader(display_w, display_h, &image_texture, str);
+        draw_loader(display_w, display_h, scale, &image_texture, str);
 
         glViewport(0, 0, display_w, display_h);
         glClearColor(0.0666f, 0.0666f, 0.0666f, 1.0f);

--- a/src-ui/loading_screen.h
+++ b/src-ui/loading_screen.h
@@ -8,12 +8,13 @@ namespace satdump
     class LoadingScreenSink : public slog::LoggerSink
     {
     public:
-        LoadingScreenSink(GLFWwindow* window, GLFWimage* img);
+        LoadingScreenSink(GLFWwindow* window, float scale, GLFWimage* img);
         ~LoadingScreenSink();
     protected:
         void receive(slog::LogMsg log);
     private:
         void push_frame(std::string str);
+        float scale;
         GLFWwindow* window;
         GLuint image_texture;
     };


### PR DESCRIPTION
This PR detects display scaling (desktop) or display density (Android) and correctly sets UI scaling based on that. Also makes the program aware in changes in DPI (i.e. when moved to an external monitor) and scales automatically.

The UI scale setting is still there, but only if the user wants to make the UI bigger or smaller as a preference. It's no longer necessary on high DPI screens; 1.0 should always be the developer-intended size, regardless of display type/scaling.

Still testing on macOS