### PR TITLE
Choose other cities types/size instead Capitals only and draw on map overlay

### DIFF
--- a/src-core/common/map/map_drawer.cpp
+++ b/src-core/common/map/map_drawer.cpp
@@ -208,6 +208,54 @@ namespace map
     template void drawProjectedCapitalsGeoJson(std::vector<std::string>, image::Image<uint16_t> &, uint16_t[3], std::function<std::pair<int, int>(float, float, int, int)>, int);
 
     template <typename T>
+    void drawProjectedCitiesGeoJson(std::vector<std::string> shapeFiles, image::Image<T> &map_image, T color[3], std::function<std::pair<int, int>(float, float, int, int)> projectionFunc, int font_size, int cities_type, int cities_size)
+    {
+        if (!map_image.font_ready())
+            return;
+
+        for (std::string currentShapeFile : shapeFiles)
+        {
+            nlohmann::json shapeFile;
+            {
+                std::ifstream istream(currentShapeFile);
+                istream >> shapeFile;
+                istream.close();
+            }
+
+            for (const nlohmann::json &mapStruct : shapeFile.at("features"))
+            {
+                if (mapStruct["type"] != "Feature" || mapStruct["geometry"]["type"] != "Point")
+                    continue;
+
+                std::string featurecla = mapStruct["properties"]["featurecla"].get<std::string>();
+
+                if ((cities_type == 0 && featurecla == "Admin-0 capital")
+                    || (cities_type == 1 && (featurecla == "Admin-1 capital" || featurecla == "Admin-0 capital"))
+                    || (cities_type == 2 && mapStruct["properties"]["scalerank"] <= cities_size))
+                {
+                    std::pair<float, float> coordinates = mapStruct["geometry"]["coordinates"].get<std::pair<float, float>>();
+                    std::pair<float, float> cc = projectionFunc(coordinates.second, coordinates.first,
+                                                                map_image.height(), map_image.width());
+
+                    if (cc.first == -1 || cc.first == -1)
+                        continue;
+
+                    map_image.draw_line(cc.first - font_size*0.3, cc.second - font_size*0.3, cc.first + font_size*0.3, cc.second + font_size*0.3, color);
+                    map_image.draw_line(cc.first + font_size*0.3, cc.second - font_size*0.3, cc.first - font_size*0.3, cc.second + font_size*0.3, color);
+                    map_image.draw_circle(cc.first, cc.second, 0.15 * font_size, color, true);
+
+                    std::string name = mapStruct["properties"]["nameascii"];
+                    //map_image.draw_text(cc.first, cc.second + 20 * ratio, color, font, name);
+                    map_image.draw_text(cc.first, cc.second + font_size*0.15, color, font_size, name);
+                }
+            }
+        }
+    }
+
+    template void drawProjectedCitiesGeoJson(std::vector<std::string>, image::Image<uint8_t> &, uint8_t[3], std::function<std::pair<int, int>(float, float, int, int)>, int, int, int);
+    template void drawProjectedCitiesGeoJson(std::vector<std::string>, image::Image<uint16_t> &, uint16_t[3], std::function<std::pair<int, int>(float, float, int, int)>, int, int, int);
+
+    template <typename T>
     void drawProjectedMapShapefile(std::vector<std::string> shapeFiles, image::Image<T> &map_image, T color[3], std::function<std::pair<int, int>(float, float, int, int)> projectionFunc, int maxLength)
     {
         for (std::string currentShapeFile : shapeFiles)

--- a/src-core/common/map/map_drawer.cpp
+++ b/src-core/common/map/map_drawer.cpp
@@ -208,7 +208,7 @@ namespace map
     template void drawProjectedCapitalsGeoJson(std::vector<std::string>, image::Image<uint16_t> &, uint16_t[3], std::function<std::pair<int, int>(float, float, int, int)>, int);
 
     template <typename T>
-    void drawProjectedCitiesGeoJson(std::vector<std::string> shapeFiles, image::Image<T> &map_image, T color[3], std::function<std::pair<int, int>(float, float, int, int)> projectionFunc, int font_size, int cities_type, int cities_size)
+    void drawProjectedCitiesGeoJson(std::vector<std::string> shapeFiles, image::Image<T> &map_image, T color[3], std::function<std::pair<int, int>(float, float, int, int)> projectionFunc, int font_size, int cities_type, int cities_scale_rank)
     {
         if (!map_image.font_ready())
             return;
@@ -231,7 +231,7 @@ namespace map
 
                 if ((cities_type == 0 && featurecla == "Admin-0 capital")
                     || (cities_type == 1 && (featurecla == "Admin-1 capital" || featurecla == "Admin-0 capital"))
-                    || (cities_type == 2 && mapStruct["properties"]["scalerank"] <= cities_size))
+                    || (cities_type == 2 && mapStruct["properties"]["scalerank"] <= cities_scale_rank))
                 {
                     std::pair<float, float> coordinates = mapStruct["geometry"]["coordinates"].get<std::pair<float, float>>();
                     std::pair<float, float> cc = projectionFunc(coordinates.second, coordinates.first,

--- a/src-core/common/map/map_drawer.h
+++ b/src-core/common/map/map_drawer.h
@@ -13,7 +13,7 @@ namespace map
     template <typename T>
     void drawProjectedCapitalsGeoJson(std::vector<std::string> shapeFiles, image::Image<T> &image, T color[3], std::function<std::pair<int, int>(float, float, int, int)> projectionFunc, int font_size = 50);
     template <typename T>
-    void drawProjectedCitiesGeoJson(std::vector<std::string> shapeFiles, image::Image<T> &image, T color[3], std::function<std::pair<int, int>(float, float, int, int)> projectionFunc, int font_size = 50, int cities_type = 0, int cities_size = 10);
+    void drawProjectedCitiesGeoJson(std::vector<std::string> shapeFiles, image::Image<T> &image, T color[3], std::function<std::pair<int, int>(float, float, int, int)> projectionFunc, int font_size = 50, int cities_type = 0, int cities_scale_rank = 10);
     template <typename T>
     void drawProjectedMapShapefile(std::vector<std::string> shapeFiles, image::Image<T> &image, T color[3], std::function<std::pair<int, int>(float, float, int, int)> projectionFunc, int maxLength = 2147483647);
 

--- a/src-core/common/map/map_drawer.h
+++ b/src-core/common/map/map_drawer.h
@@ -13,6 +13,8 @@ namespace map
     template <typename T>
     void drawProjectedCapitalsGeoJson(std::vector<std::string> shapeFiles, image::Image<T> &image, T color[3], std::function<std::pair<int, int>(float, float, int, int)> projectionFunc, int font_size = 50);
     template <typename T>
+    void drawProjectedCitiesGeoJson(std::vector<std::string> shapeFiles, image::Image<T> &image, T color[3], std::function<std::pair<int, int>(float, float, int, int)> projectionFunc, int font_size = 50, int cities_type = 0, int cities_size = 10);
+    template <typename T>
     void drawProjectedMapShapefile(std::vector<std::string> shapeFiles, image::Image<T> &image, T color[3], std::function<std::pair<int, int>(float, float, int, int)> projectionFunc, int maxLength = 2147483647);
 
     struct CustomLabel

--- a/src-interface/viewer/image_handler.cpp
+++ b/src-interface/viewer/image_handler.cpp
@@ -187,11 +187,13 @@ namespace satdump
             {
                 logger->info("Drawing map overlay...");
                 unsigned short color[3] = {(unsigned short)(color_cities.x * 65535.0f), (unsigned short)(color_cities.y * 65535.0f), (unsigned short)(color_cities.z * 65535.0f)};
-                map::drawProjectedCapitalsGeoJson({resources::getResourcePath("maps/ne_10m_populated_places_simple.json")},
-                                                  current_image,
-                                                  color,
-                                                  proj_func,
-                                                  cities_size);
+                map::drawProjectedCitiesGeoJson({resources::getResourcePath("maps/ne_10m_populated_places_simple.json")},
+                                                current_image,
+                                                color,
+                                                proj_func,
+                                                cities_size,
+                                                cities_type,
+                                                cities_scale_rank);
             }
         }
 
@@ -660,6 +662,11 @@ namespace satdump
                 ImGui::SameLine();
                 ImGui::ColorEdit3("##cities", (float *)&color_cities, ImGuiColorEditFlags_NoInputs | ImGuiColorEditFlags_NoLabel);
                 ImGui::SliderInt("Cities Font Size", &cities_size, 10, 500);
+                static const char* items[] = { "Capital Only", "Regional Capital Also", "All (by Scale Rank)" };
+                if (ImGui::Combo("Cities Type", &cities_type, items, IM_ARRAYSIZE(items)))
+                    asyncUpdate();
+                if (cities_type == 2 && ImGui::SliderInt("Cities Scale Rank", &cities_scale_rank, 0, 10))
+                    asyncUpdate();
             }
 
             if (ImGui::CollapsingHeader("Projection"))

--- a/src-interface/viewer/image_handler.cpp
+++ b/src-interface/viewer/image_handler.cpp
@@ -185,7 +185,7 @@ namespace satdump
             }
             if (cities_overlay)
             {
-                logger->info("Drawing map overlay...");
+                logger->info("Drawing cities overlay...");
                 unsigned short color[3] = {(unsigned short)(color_cities.x * 65535.0f), (unsigned short)(color_cities.y * 65535.0f), (unsigned short)(color_cities.z * 65535.0f)};
                 map::drawProjectedCitiesGeoJson({resources::getResourcePath("maps/ne_10m_populated_places_simple.json")},
                                                 current_image,

--- a/src-interface/viewer/image_handler.h
+++ b/src-interface/viewer/image_handler.h
@@ -40,6 +40,8 @@ namespace satdump
         bool cities_overlay = false;
 
         int cities_size = 50;
+        int cities_type = 0;
+        int cities_scale_rank = 3;
 
         // GUI
         bool range_window = false;


### PR DESCRIPTION
* `Capital Only`: Draw only Capitals
* `Regional Capital Also`: Draw Capitals and Administrative centers
* `All (by Scale Rank)`: Draw all cities by Scale Rank. The higher the "Scale Rank", the smaller cities will be drawn.

![image](https://github.com/SatDump/SatDump/assets/40061352/cdfed1ad-99d9-4f15-bd91-71f994162a54)
