### PR TITLE
Timestamp input widget

### DIFF
--- a/pipelines/Meteor-M.json
+++ b/pipelines/Meteor-M.json
@@ -23,10 +23,10 @@
                 "value": 3e6
             },
             "start_timestamp": {
-                "type": "float",
+                "type": "timestamp",
                 "value": -1,
                 "name": "Start Timestamp",
-                "description": "Unix timestamp of the start of the file provided.\nMust be UTC Unix timestamp in seconds.\nRequired in case you are not\nprocessing your file on the same Mocow day."
+                "description": "Unix timestamp of the start of the file provided.\nRequired in case you are not\nprocessing your file on the same Mocow day."
             }
         },
         "work": {

--- a/pipelines/NOAA.json
+++ b/pipelines/NOAA.json
@@ -206,10 +206,10 @@
                 "description": "For APT, it is required to know what satellite\nis being received for projections and overlays"
             },
             "start_timestamp": {
-                "type": "float",
+                "type": "timestamp",
                 "value": -1,
                 "name": "Start Timestamp",
-                "description": "Unix timestamp of the start of the file provided.\nMust be UTC Unix timestamp in seconds.\nRequired for projections and overlays\n\nIf your .wav filename is a support format it will be read automatically."
+                "description": "Unix timestamp of the start of the file provided.\nRequired for projections and overlays\n\nIf your .wav filename is a support format it will be read automatically."
             },
             "autocrop_wedges": {
                 "type": "bool",

--- a/src-core/common/widgets/datetime.cpp
+++ b/src-core/common/widgets/datetime.cpp
@@ -1,0 +1,134 @@
+#include "datetime.h"
+#include "imgui/imgui_stdlib.h"
+
+#ifdef _WIN32
+#define timegm _mkgmtime
+#endif
+
+namespace widgets
+{
+	DateTimePicker::DateTimePicker(float input_time)
+	{
+		ImGuiStyle style = ImGui::GetStyle();
+		item_spacing_y = style.ItemSpacing.y;
+		item_inner_spacing_y = style.ItemInnerSpacing.y;
+		frame_padding_y = style.FramePadding.y;
+
+		handle_input(input_time);
+	}
+	DateTimePicker::~DateTimePicker()
+	{
+	}
+	void DateTimePicker::handle_input(float input_time)
+	{
+		time_t input_timet;
+		if (input_time <= 0)
+		{
+			auto_time = true;
+			input_timet = time(NULL);
+		}
+		else
+		{
+			auto_time = false;
+			input_timet = (time_t)input_time;
+		}
+		timestamp = gmtime(&input_timet);
+		seconds_decimal = std::to_string(input_time - input_timet);
+		size_t decimal_pos = seconds_decimal.find(".");
+		seconds_decimal = seconds_decimal.substr(decimal_pos + 1);
+		year_holder = timestamp->tm_year + 1900;
+		month_holder = timestamp->tm_mon + 1;
+	}
+	float DateTimePicker::get()
+	{
+		if (auto_time)
+			return -1.0f;
+		else
+			return stof(std::to_string(timegm(timestamp)) + "." + seconds_decimal);
+	}
+	void DateTimePicker::set(float input_time)
+	{
+		handle_input(input_time);
+	}
+	void DateTimePicker::draw()
+	{
+		std::string checkbox_label = "###dsauto";
+		if (auto_time)
+			checkbox_label = "Auto###dsauto";
+		ImGui::Checkbox(checkbox_label.c_str(), &auto_time);
+
+		if (!auto_time)
+		{
+			ImGui::SameLine();
+			ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.0, 0.0, 0.0, 0.0));
+			ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, frame_padding_y));
+			ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(3, item_spacing_y));
+			ImGui::PushStyleVar(ImGuiStyleVar_ItemInnerSpacing, ImVec2(3, item_inner_spacing_y));
+
+			//Date
+			ImGui::PushItemWidth(ImGui::CalcTextSize(std::to_string(year_holder).c_str()).x);
+			if (ImGui::InputInt("/###dsparamyear", &year_holder, 0))
+				timestamp->tm_year = year_holder - 1900;
+			ImGui::PopItemWidth();
+			ImGui::SameLine();
+			ImGui::PushItemWidth(ImGui::CalcTextSize(std::to_string(month_holder).c_str()).x);
+			if (ImGui::InputInt("/###dsparammonth", &month_holder, 0))
+			{
+				if (month_holder > 12)
+					month_holder = 12;
+				if (month_holder < 1)
+					month_holder = 1;
+				timestamp->tm_mon = month_holder - 1;
+			}
+			ImGui::PopItemWidth();
+			ImGui::SameLine();
+			ImGui::PushItemWidth(ImGui::CalcTextSize(std::to_string(timestamp->tm_mday).c_str()).x);
+			if (ImGui::InputInt("###dsparamday", &timestamp->tm_mday, 0))
+			{
+				if (timestamp->tm_mday > 31 || timestamp->tm_mday < 1)
+					timestamp->tm_mday = 1;
+			}
+			ImGui::PopItemWidth();
+			ImGui::SameLine(0.0, 20.0);
+
+			//Time
+			ImGui::PushItemWidth(ImGui::CalcTextSize(std::to_string(timestamp->tm_hour).c_str()).x);
+			if (ImGui::InputInt(":###dsparamhour", &timestamp->tm_hour, 0))
+			{
+				if (timestamp->tm_hour > 23)
+					timestamp->tm_hour = 23;
+				if (timestamp->tm_hour < 0)
+					timestamp->tm_hour = 0;
+			}
+			ImGui::PopItemWidth();
+			ImGui::SameLine();
+			ImGui::PushItemWidth(ImGui::CalcTextSize(std::to_string(timestamp->tm_min).c_str()).x);
+			if (ImGui::InputInt(":###dsparammin", &timestamp->tm_min, 0))
+			{
+				if (timestamp->tm_min > 59)
+					timestamp->tm_min = 59;
+				if (timestamp->tm_min < 0)
+					timestamp->tm_min = 0;
+			}
+			ImGui::PopItemWidth();
+			ImGui::SameLine();
+			ImGui::PushItemWidth(ImGui::CalcTextSize(std::to_string(timestamp->tm_sec).c_str()).x);
+			if (ImGui::InputInt(".###dsparamsec", &timestamp->tm_sec, 0))
+			{
+				if (timestamp->tm_sec > 59)
+					timestamp->tm_sec = 59;
+				if (timestamp->tm_sec < 0)
+					timestamp->tm_sec = 0;
+			}
+			ImGui::PopItemWidth();
+			ImGui::SameLine();
+			ImGui::PushItemWidth(ImGui::CalcTextSize(seconds_decimal.c_str()).x);
+			ImGui::InputText("###dsparamsecdec", &seconds_decimal, ImGuiInputTextFlags_CharsDecimal);
+			ImGui::PopItemWidth();
+			ImGui::SameLine();
+			ImGui::PopStyleVar(3);
+			ImGui::PopStyleColor();
+			ImGui::TextUnformatted(" UTC");
+		}
+	}
+} // namespace widgets

--- a/src-core/common/widgets/datetime.cpp
+++ b/src-core/common/widgets/datetime.cpp
@@ -42,7 +42,13 @@ namespace widgets
 		if (auto_time)
 			return -1.0f;
 		else
-			return (double)timegm(&timestamp) + ((double)seconds_decimal / std::pow(10.0, int(log10(seconds_decimal) + 1)));
+		{
+			double return_value = timegm(&timestamp);
+			if (seconds_decimal > 0)
+				return_value += ((double)seconds_decimal / std::pow(10.0, int(log10(seconds_decimal) + 1)));
+
+			return return_value;
+		}
 	}
 	void DateTimePicker::set(double input_time)
 	{

--- a/src-core/common/widgets/datetime.cpp
+++ b/src-core/common/widgets/datetime.cpp
@@ -31,18 +31,18 @@ namespace widgets
 			auto_time = false;
 			input_timet = (time_t)input_time;
 		}
-		timestamp = gmtime(&input_timet);
+		timestamp = *gmtime(&input_timet);
 		seconds_holder = std::to_string(input_time - input_timet);
 		seconds_decimal = std::stoi(seconds_holder.substr(seconds_holder.find(".") + 1));
-		year_holder = timestamp->tm_year + 1900;
-		month_holder = timestamp->tm_mon + 1;
+		year_holder = timestamp.tm_year + 1900;
+		month_holder = timestamp.tm_mon + 1;
 	}
 	double DateTimePicker::get()
 	{
 		if (auto_time)
 			return -1.0f;
 		else
-			return (double)timegm(timestamp) + ((double)seconds_decimal / std::pow(10.0, int(log10(seconds_decimal) + 1)));
+			return (double)timegm(&timestamp) + ((double)seconds_decimal / std::pow(10.0, int(log10(seconds_decimal) + 1)));
 	}
 	void DateTimePicker::set(double input_time)
 	{
@@ -85,7 +85,7 @@ namespace widgets
 			ImGui::SetCursorPosX(ImGui::GetCursorPosX() + (3 * ui_scale));
 			ImGui::PushItemWidth(digit_size.x * 4);
 			if (ImGui::InputInt(std::string("/" + d_id + "year").c_str(), &year_holder, 0, 0, ImGuiInputTextFlags_NoHorizontalScroll))
-				timestamp->tm_year = year_holder - 1900;
+				timestamp.tm_year = year_holder - 1900;
 			ImGui::PopItemWidth();
 			ImGui::SameLine();
 			ImGui::PushItemWidth(digit_size.x * 2);
@@ -95,39 +95,39 @@ namespace widgets
 					month_holder = 12;
 				if (month_holder < 1)
 					month_holder = 1;
-				timestamp->tm_mon = month_holder - 1;
+				timestamp.tm_mon = month_holder - 1;
 			}
 			ImGui::SameLine();
-			if (ImGui::InputScalar(std::string(d_id + "day").c_str(), ImGuiDataType_S32, (void*)&timestamp->tm_mday, (void*)NULL, (void*)NULL, "%02d", ImGuiInputTextFlags_NoHorizontalScroll))
+			if (ImGui::InputScalar(std::string(d_id + "day").c_str(), ImGuiDataType_S32, (void*)&timestamp.tm_mday, (void*)NULL, (void*)NULL, "%02d", ImGuiInputTextFlags_NoHorizontalScroll))
 			{
-				if (timestamp->tm_mday > 31 || timestamp->tm_mday < 1)
-					timestamp->tm_mday = 1;
+				if (timestamp.tm_mday > 31 || timestamp.tm_mday < 1)
+					timestamp.tm_mday = 1;
 			}
 			ImGui::SameLine(0.0, 16.0 * ui_scale);
 
 			//Time
-			if (ImGui::InputScalar(std::string(":" + d_id + "hour").c_str(), ImGuiDataType_S32, (void*)&timestamp->tm_hour, (void*)NULL, (void*)NULL, "%02d", ImGuiInputTextFlags_NoHorizontalScroll))
+			if (ImGui::InputScalar(std::string(":" + d_id + "hour").c_str(), ImGuiDataType_S32, (void*)&timestamp.tm_hour, (void*)NULL, (void*)NULL, "%02d", ImGuiInputTextFlags_NoHorizontalScroll))
 			{
-				if (timestamp->tm_hour > 23)
-					timestamp->tm_hour = 23;
-				if (timestamp->tm_hour < 0)
-					timestamp->tm_hour = 0;
+				if (timestamp.tm_hour > 23)
+					timestamp.tm_hour = 23;
+				if (timestamp.tm_hour < 0)
+					timestamp.tm_hour = 0;
 			}
 			ImGui::SameLine();
-			if (ImGui::InputScalar(std::string(":" + d_id + "min").c_str(), ImGuiDataType_S32, (void*)&timestamp->tm_min, (void*)NULL, (void*)NULL, "%02d", ImGuiInputTextFlags_NoHorizontalScroll))
+			if (ImGui::InputScalar(std::string(":" + d_id + "min").c_str(), ImGuiDataType_S32, (void*)&timestamp.tm_min, (void*)NULL, (void*)NULL, "%02d", ImGuiInputTextFlags_NoHorizontalScroll))
 			{
-				if (timestamp->tm_min > 59)
-					timestamp->tm_min = 59;
-				if (timestamp->tm_min < 0)
-					timestamp->tm_min = 0;
+				if (timestamp.tm_min > 59)
+					timestamp.tm_min = 59;
+				if (timestamp.tm_min < 0)
+					timestamp.tm_min = 0;
 			}
 			ImGui::SameLine();
-			if (ImGui::InputScalar(std::string("." + d_id + "sec").c_str(), ImGuiDataType_S32, (void*)&timestamp->tm_sec, (void*)NULL, (void*)NULL, "%02d", ImGuiInputTextFlags_NoHorizontalScroll))
+			if (ImGui::InputScalar(std::string("." + d_id + "sec").c_str(), ImGuiDataType_S32, (void*)&timestamp.tm_sec, (void*)NULL, (void*)NULL, "%02d", ImGuiInputTextFlags_NoHorizontalScroll))
 			{
-				if (timestamp->tm_sec > 59)
-					timestamp->tm_sec = 59;
-				if (timestamp->tm_sec < 0)
-					timestamp->tm_sec = 0;
+				if (timestamp.tm_sec > 59)
+					timestamp.tm_sec = 59;
+				if (timestamp.tm_sec < 0)
+					timestamp.tm_sec = 0;
 			}
 			ImGui::PopItemWidth();
 			ImGui::SameLine();

--- a/src-core/common/widgets/datetime.h
+++ b/src-core/common/widgets/datetime.h
@@ -6,7 +6,7 @@ namespace widgets {
     class DateTimePicker
     {
     private:
-        struct tm *timestamp;
+        struct tm timestamp;
         bool auto_time;
         int year_holder, month_holder, seconds_decimal;
         std::string d_id;

--- a/src-core/common/widgets/datetime.h
+++ b/src-core/common/widgets/datetime.h
@@ -7,15 +7,15 @@ namespace widgets {
     {
     private:
         struct tm *timestamp;
-        std::string seconds_decimal;
         bool auto_time;
-        int year_holder, month_holder;
-        void handle_input(float input_time);
+        int year_holder, month_holder, seconds_decimal;
+        std::string d_id;
+        void handle_input(double input_time);
     public:
-        DateTimePicker(float input_time);
+        DateTimePicker(std::string d_id, double input_time);
         ~DateTimePicker();
-        float get();
-        void set(float input_time);
+        double get();
+        void set(double input_time);
         void draw();
     };
 } // namespace widgets

--- a/src-core/common/widgets/datetime.h
+++ b/src-core/common/widgets/datetime.h
@@ -1,0 +1,23 @@
+#pragma once
+#include <time.h>
+#include <string>
+#include "imgui/imgui.h"
+
+namespace widgets {
+    class DateTimePicker
+    {
+    private:
+        struct tm *timestamp;
+        std::string seconds_decimal;
+        bool auto_time;
+        int year_holder, month_holder;
+        float item_spacing_y, item_inner_spacing_y, frame_padding_y;
+        void handle_input(float input_time);
+    public:
+        DateTimePicker(float input_time);
+        ~DateTimePicker();
+        float get();
+        void set(float input_time);
+        void draw();
+    };
+} // namespace widgets

--- a/src-core/common/widgets/datetime.h
+++ b/src-core/common/widgets/datetime.h
@@ -1,7 +1,6 @@
 #pragma once
 #include <time.h>
 #include <string>
-#include "imgui/imgui.h"
 
 namespace widgets {
     class DateTimePicker
@@ -11,7 +10,6 @@ namespace widgets {
         std::string seconds_decimal;
         bool auto_time;
         int year_holder, month_holder;
-        float item_spacing_y, item_inner_spacing_y, frame_padding_y;
         void handle_input(float input_time);
     public:
         DateTimePicker(float input_time);

--- a/src-core/common/widgets/logger_sink.cpp
+++ b/src-core/common/widgets/logger_sink.cpp
@@ -45,6 +45,8 @@ namespace widgets
             ImGui::SetScrollY(ImGui::GetScrollMaxY());
             new_item = false;
         }
+        if(ImGui::IsWindowAppearing())
+            new_item = true;
         mtx.unlock();
     }
 }

--- a/src-core/core/params.h
+++ b/src-core/core/params.h
@@ -148,7 +148,7 @@ namespace satdump
             {
                 ImGui::TableNextRow();
                 ImGui::TableSetColumnIndex(0);
-                ImGui::Text("%s", d_name.c_str());
+                ImGui::Text("%s        ", d_name.c_str());
                 if (ImGui::IsItemHovered() && d_description.size() > 0)
                     ImGui::SetTooltip("%s", d_description.c_str());
                 ImGui::TableSetColumnIndex(1);

--- a/src-core/core/params.h
+++ b/src-core/core/params.h
@@ -136,7 +136,7 @@ namespace satdump
                 else if (type_str == "timestamp")
                 {
                     d_type = PARAM_TIMESTAMP;
-                    date_time_picker = std::make_shared<widgets::DateTimePicker>(hasValue ? p_json["value"].get<double>() : 0);
+                    date_time_picker = std::make_shared<widgets::DateTimePicker>(d_id, hasValue ? p_json["value"].get<double>() : -1);
                 }
                 else
                 {

--- a/src-core/core/params.h
+++ b/src-core/core/params.h
@@ -148,7 +148,7 @@ namespace satdump
             {
                 ImGui::TableNextRow();
                 ImGui::TableSetColumnIndex(0);
-                ImGui::Text("%s        ", d_name.c_str());
+                ImGui::Text("%s", d_name.c_str());
                 if (ImGui::IsItemHovered() && d_description.size() > 0)
                     ImGui::SetTooltip("%s", d_description.c_str());
                 ImGui::TableSetColumnIndex(1);

--- a/src-core/core/params.h
+++ b/src-core/core/params.h
@@ -4,6 +4,7 @@
 #include "logger.h"
 #include "nlohmann/json.hpp"
 #include "imgui/pfd/widget.h"
+#include "common/widgets/datetime.h"
 
 namespace satdump
 {
@@ -22,6 +23,7 @@ namespace satdump
             PARAM_BOOL,
             PARAM_OPTIONS,
             PARAM_PATH,
+            PARAM_TIMESTAMP
         };
 
         class EditableParameter
@@ -47,6 +49,8 @@ namespace satdump
             std::vector<std::string> d_options;
 
             std::shared_ptr<FileSelectWidget> file_select;
+
+            std::shared_ptr<widgets::DateTimePicker> date_time_picker;
 
         public:
             EditableParameter() {}
@@ -129,6 +133,11 @@ namespace satdump
                     file_select = std::make_shared<FileSelectWidget>(p_json["name"], p_json["name"], p_json["is_directory"]);
                     file_select->path = p_json["value"];
                 }
+                else if (type_str == "timestamp")
+                {
+                    d_type = PARAM_TIMESTAMP;
+                    date_time_picker = std::make_shared<widgets::DateTimePicker>(hasValue ? p_json["value"].get<double>() : 0);
+                }
                 else
                 {
                     logger->error("Invalid options on EditableParameter!");
@@ -156,6 +165,8 @@ namespace satdump
                     ImGui::Combo(d_id.c_str(), &d_option, d_options_str.c_str());
                 else if (d_type == PARAM_PATH)
                     file_select->draw();
+                else if (d_type == PARAM_TIMESTAMP)
+                    date_time_picker->draw();
             }
 
             nlohmann::json getValue()
@@ -173,6 +184,8 @@ namespace satdump
                     v = d_options[d_option];
                 else if (d_type == PARAM_PATH)
                     return file_select->getPath();
+                else if (d_type == PARAM_TIMESTAMP)
+                    v = date_time_picker->get();
                 return v;
             }
 
@@ -200,6 +213,8 @@ namespace satdump
                 }
                 else if (d_type == PARAM_PATH)
                     file_select->path = v.get<std::string>();
+                else if (d_type == PARAM_TIMESTAMP)
+                    date_time_picker->set(v.get<double>());
                 return v;
             }
         };

--- a/src-interface/pipeline_selector.h
+++ b/src-interface/pipeline_selector.h
@@ -335,8 +335,6 @@ namespace satdump
         {
             if (ImGui::BeginTable("##pipelineoptions", 2, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg))
             {
-                ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthFixed);
-                ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthStretch);
                 for (std::pair<std::string, satdump::params::EditableParameter> &p : parameters_ui)
                     p.second.draw();
                 for (std::pair<std::string, satdump::params::EditableParameter> &p : parameters_ui_pipeline)

--- a/src-interface/pipeline_selector.h
+++ b/src-interface/pipeline_selector.h
@@ -335,6 +335,8 @@ namespace satdump
         {
             if (ImGui::BeginTable("##pipelineoptions", 2, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg))
             {
+                ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthFixed);
+                ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthStretch);
                 for (std::pair<std::string, satdump::params::EditableParameter> &p : parameters_ui)
                     p.second.draw();
                 for (std::pair<std::string, satdump::params::EditableParameter> &p : parameters_ui_pipeline)

--- a/src-interface/recorder/tracking/tracking_widget_autotrack.cpp
+++ b/src-interface/recorder/tracking/tracking_widget_autotrack.cpp
@@ -363,12 +363,12 @@ namespace satdump
                 ImGui::TableSetColumnIndex(3);
                 ImGui::SetNextItemWidth(300*ui_scale);
                 ImGui::PushID(cpass.norad);
-                if (ImGui::BeginCombo("##pipelinesel", cpass.pipeline_selector->get_name(cpass.pipeline_selector->pipeline_id).c_str()))
+                if (ImGui::BeginCombo("##pipelinesel", cpass.pipeline_selector->get_name(cpass.pipeline_selector->pipeline_id).c_str(), ImGuiComboFlags_HeightLarge))
                 {
-                    cpass.pipeline_selector->renderSelectionBox();
+                    cpass.pipeline_selector->renderSelectionBox(300 * ui_scale);
                     ImGui::EndCombo();
                 }
-                if (ImGui::BeginCombo("##params", "Configure...", ImGuiComboFlags_NoArrowButton))
+                if (ImGui::BeginCombo("##params", "Configure..."))
                 {
                     cpass.pipeline_selector->renderParamTable();
                     ImGui::EndCombo();


### PR DESCRIPTION
This PR adds a timestamp input widget for use in pipeline parameters.

- It returns a double, just like the float param type.
- Setting it to "Auto" returns -1, otherwise it returns the specified unix timestamp, in UTC, with sub-second accuracy.
- CLI users should still specify a Unix timestamp.

    ![image](https://github.com/SatDump/SatDump/assets/24253715/49b67cfc-0451-4053-bfeb-8161e5551dc0)
    ![image](https://github.com/SatDump/SatDump/assets/24253715/d735e654-96ff-4df0-9858-a7f1f5958f40)

**I tweaked a handful of other things in this PR as well:**

- Fix Floating Console scroll location on open - if the log was not actively being written to, it would scroll to the top instead of bottom on open
- Fix double scrollbar in pipeline selection of scheduler
    ![image](https://github.com/SatDump/SatDump/assets/24253715/367c6d86-743b-45bb-9bb8-9f536d1f49a5)

- Made the GUI Param table's "key" column auto-fit to the key name, and the value column fills the rest of the available space. This makes the table more readable on smaller areas like the scheduler and live decoding.
