### PR TITLE
macOS: Improve Retina Support

### DIFF
--- a/macOS/Info.plist
+++ b/macOS/Info.plist
@@ -12,6 +12,8 @@
   <string>SatDump</string>
   <key>CFBundleIconFile</key>
   <string>icon.icns</string>
+  <key>NSHighResolutionCapable</key>
+  <true/>
   <key>CFBundleShortVersionString</key>
   <string>1.1.0</string>
   <key>CFBundleInfoDictionaryVersion</key>

--- a/src-core/CMakeLists.txt
+++ b/src-core/CMakeLists.txt
@@ -168,6 +168,10 @@ else()
     endif()
 endif()
 
+if(APPLE)
+    target_link_libraries(satdump_core PUBLIC "-framework CoreGraphics")
+endif()
+
 install(TARGETS satdump_core DESTINATION lib)
 install(DIRECTORY . DESTINATION include/satdump FILES_MATCHING PATTERN "*.h")
 install(DIRECTORY . DESTINATION include/satdump FILES_MATCHING PATTERN "*.hpp")

--- a/src-core/core/style.h
+++ b/src-core/core/style.h
@@ -16,4 +16,6 @@ namespace style
     void endDisabled();
     void setFonts();
     void setFonts(float dpi_scaling);
+
+    float macos_framebuffer_scale();
 }

--- a/src-ui/loading_screen.h
+++ b/src-ui/loading_screen.h
@@ -14,8 +14,8 @@ namespace satdump
         void receive(slog::LogMsg log);
     private:
         void push_frame(std::string str);
-        float scale;
         GLFWwindow* window;
+        float scale;
         GLuint image_texture;
     };
 }

--- a/src-ui/main.cpp
+++ b/src-ui/main.cpp
@@ -24,7 +24,7 @@ static void glfw_error_callback(int error, const char *description)
 
 void window_content_scale_callback(GLFWwindow*, float xscale, float)
 {
-    satdump::updateUI(xscale);
+    satdump::updateUI(xscale / style::macos_framebuffer_scale());
     style::setFonts();
     ImGui_ImplOpenGL3_DestroyFontsTexture();
     ImGui_ImplOpenGL3_CreateFontsTexture();
@@ -226,6 +226,7 @@ int main(int argc, char *argv[])
 #if GLFW_VERSION_MAJOR > 3 || (GLFW_VERSION_MAJOR == 3 && GLFW_VERSION_MINOR >= 3)
     glfwSetWindowContentScaleCallback(window, window_content_scale_callback);
     glfwGetWindowContentScale(window, &display_scale, nullptr);
+    display_scale /= style::macos_framebuffer_scale();
 #else
     display_scale = 1.0f;
 #endif


### PR DESCRIPTION
This PR improves display scaling for retina displays on macOS. It also improves font rendering on the same screens to make text look crisper.

`style::macos_framebuffer_scale()` is a bit of a workaround: we should be able to use `ImGui::GetIO().DisplayFramebufferScale` to get the same value, but it doesn't work consistently for me. Maybe I'm doing something wrong, but the native API seems to work more reliably.

Fixes #376 