### PR TITLE
Mac-Specific Path Changes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,8 +11,8 @@ assignees: ''
 
 **Hardware (SDR/PC/OS)**
 
-**Version (Eg, 1.0.0, CI Build #171)**
+**Version (Eg, 1.0.0, CI Build 171)**
 
-**Logs after the cras (satdump.logs)**
+**Logs after the crash (satdump.logs, or satdump.log in Console.app on macOS)**
 
 **Other info (Eg, Screenshots) / Files useful for debugging (CADU, etc)**


### PR DESCRIPTION
A few macOS-specific changes:

- **Made code to find the user's Documents folder more robust** - it's possible to make your Documents folder somewhere else other than ~/Documents.
- **Save SatDump's log to Library/Logs/satdump.log**. I dropped the "s" on macOS only so the log shows up nicely in Console.app - it even works live!

![Screen Shot 2023-09-04 at 3 11 13 PM](https://github.com/SatDump/SatDump/assets/24253715/124cf2b0-a7bc-47b2-8e3c-303bf4e52293)