### PR TITLE
Mac SDR server

### DIFF
--- a/macOS/Entitlements.plist
+++ b/macOS/Entitlements.plist
@@ -6,5 +6,7 @@
 	<true/>
 	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
 	<true/>
+	<key>com.apple.developer.networking.multicast</key>
+	<true/>
 </dict>
 </plist>

--- a/macOS/Entitlements.plist
+++ b/macOS/Entitlements.plist
@@ -6,7 +6,5 @@
 	<true/>
 	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
 	<true/>
-	<key>com.apple.developer.networking.multicast</key>
-	<true/>
 </dict>
 </plist>

--- a/macOS/bundle.sh
+++ b/macOS/bundle.sh
@@ -48,6 +48,7 @@ echo "Copying binaries..."
 cp satdump-ui MacApp/SatDump.app/Contents/MacOS
 cp libsatdump_core.dylib MacApp/SatDump.app/Contents/MacOS
 cp satdump MacApp/SatDump.app/Contents/MacOS
+cp satdump_sdr_server MacApp/SatDump.app/Contents/MacOS
 cp plugins/*.dylib MacApp/SatDump.app/Contents/Resources/plugins
 
 if [[ -n "$MACOS_SIGNING_SIGNATURE" ]]
@@ -57,7 +58,7 @@ fi
 
 echo "Re-linking binaries"
 plugin_args=$(ls MacApp/SatDump.app/Contents/Resources/plugins | xargs printf -- '-x MacApp/SatDump.app/Contents/Resources/plugins/%s ')
-dylibbundler $SIGN_FLAG -cd -s /usr/local/lib -d MacApp/SatDump.app/Contents/libs -b -x MacApp/SatDump.app/Contents/MacOS/satdump-ui -x MacApp/SatDump.app/Contents/MacOS/satdump -x MacApp/SatDump.app/Contents/MacOS/libsatdump_core.dylib $plugin_args
+dylibbundler $SIGN_FLAG -cd -s /usr/local/lib -d MacApp/SatDump.app/Contents/libs -b -x MacApp/SatDump.app/Contents/MacOS/satdump-ui -x MacApp/SatDump.app/Contents/MacOS/satdump_sdr_server -x MacApp/SatDump.app/Contents/MacOS/satdump -x MacApp/SatDump.app/Contents/MacOS/libsatdump_core.dylib $plugin_args
 
 if [[ -n "$MACOS_SIGNING_SIGNATURE" ]]
 then
@@ -75,6 +76,7 @@ then
     codesign -v --force --timestamp --sign "$MACOS_SIGNING_SIGNATURE" MacApp/SatDump.app/Contents/MacOS/libsatdump_core.dylib
     codesign -v --force --options runtime --entitlements $GITHUB_WORKSPACE/macOS/Entitlements.plist --timestamp --sign "$MACOS_SIGNING_SIGNATURE" MacApp/SatDump.app/Contents/MacOS/satdump
     codesign -v --force --options runtime --entitlements $GITHUB_WORKSPACE/macOS/Entitlements.plist --timestamp --sign "$MACOS_SIGNING_SIGNATURE" MacApp/SatDump.app/Contents/MacOS/satdump-ui
+    codesign -v --force --options runtime --entitlements $GITHUB_WORKSPACE/macOS/Entitlements.plist --timestamp --sign "$MACOS_SIGNING_SIGNATURE" MacApp/SatDump.app/Contents/MacOS/satdump_sdr_server
 fi
 
 echo "Creating SatDump.dmg..."

--- a/macOS/bundle.sh
+++ b/macOS/bundle.sh
@@ -75,8 +75,9 @@ then
 
     codesign -v --force --timestamp --sign "$MACOS_SIGNING_SIGNATURE" MacApp/SatDump.app/Contents/MacOS/libsatdump_core.dylib
     codesign -v --force --options runtime --entitlements $GITHUB_WORKSPACE/macOS/Entitlements.plist --timestamp --sign "$MACOS_SIGNING_SIGNATURE" MacApp/SatDump.app/Contents/MacOS/satdump
-    codesign -v --force --options runtime --entitlements $GITHUB_WORKSPACE/macOS/Entitlements.plist --timestamp --sign "$MACOS_SIGNING_SIGNATURE" MacApp/SatDump.app/Contents/MacOS/satdump-ui
     codesign -v --force --options runtime --entitlements $GITHUB_WORKSPACE/macOS/Entitlements.plist --timestamp --sign "$MACOS_SIGNING_SIGNATURE" MacApp/SatDump.app/Contents/MacOS/satdump_sdr_server
+    codesign -v --force --options runtime --entitlements $GITHUB_WORKSPACE/macOS/Entitlements.plist --timestamp --sign "$MACOS_SIGNING_SIGNATURE" MacApp/SatDump.app/Contents/MacOS/satdump-ui
+
 fi
 
 echo "Creating SatDump.dmg..."


### PR DESCRIPTION
Does what it says in the title - the executable is available under SatDump.app/Contents/MacOS, with the other executables.

I tested and ruled out the need for com.apple.developer.networking.multicast. With this type of distributed app, I think the only valid entitlements are the ones listed at https://developer.apple.com/documentation/security/hardened_runtime. Adding the multicast entitlement causes the app to crash.

I tested up to macOS 13 with no issues