### PR TITLE
Fix PortAudio DLL Name

### DIFF
--- a/plugins/audio_sinks/portaudio_audio_sink/CMakeLists.txt
+++ b/plugins/audio_sinks/portaudio_audio_sink/CMakeLists.txt
@@ -9,7 +9,7 @@ if(PORTAUDIO_LIBRARY OR MSVC)
     add_library(portaudio_audio_sink SHARED ${portaudio_audio_sink})
 
     if(MSVC)
-        target_link_libraries(portaudio_audio_sink PUBLIC satdump_core portaudio.dll)
+        target_link_libraries(portaudio_audio_sink PUBLIC satdump_core portaudio_x64.dll)
     else()
         target_link_libraries(portaudio_audio_sink PUBLIC satdump_core ${PORTAUDIO_LIBRARY})
     endif()


### PR DESCRIPTION
Please merge the PR on vcpkg before this one since it is the one that actually moves the file: https://github.com/Aang23/vcpkg/pull/2

This PR fixes audio output for live APT on Windows. It looks like the version of portaudio you have in vcpkg expects the DLL to be named `portaudio_x64.dll`. With the current name, this cryptic message is left in the error log:

```
[15:50:38 - 15/09/2023] (T) Loading plugin ./plugins\portaudio_audio_sink.dll...
[15:50:38 - 15/09/2023] (E) Error loading ./plugins\portaudio_audio_sink.dll! Error : ".\plugins\portaudio_audio_sink.dll": The specified module could not be found.
```

The "specified module" in this case is portaudio_x64.dll, not portaudio_audio_sink.dll. It looks like the actual module that fails to load gets lost along the way.