### PR TITLE
More Windows Installer Tweaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,6 +235,17 @@ if((NOT ANDROID) AND ENABLE_INSTALL)
     set(CPACK_PACKAGE_VERSION ${SATDUMP_VERSION})
 
     if(MSVC OR BUILD_MSVC)
+        # Customize NSIS template
+        file(READ "${CMAKE_ROOT}/Modules/Internal/CPack/NSIS.template.in" NSIS_template)
+        set(CREATE_ICONS_REPLACE "
+            SetOutPath \"$INSTDIR\\bin\"
+            @CPACK_NSIS_CREATE_ICONS@
+            SetOutPath \"$INSTDIR\"")
+        string(REPLACE "@CPACK_NSIS_CREATE_ICONS@" "${CREATE_ICONS_REPLACE}" NSIS_template "${NSIS_template}")
+        file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/NSIS.template.in" "${NSIS_template}")
+        set(CPACK_MODULE_PATH "${CMAKE_CURRENT_BINARY_DIR}")
+
+        # Generate Installer
         set(CPACK_GENERATOR NSIS)
         set(CPACK_PACKAGE_INSTALL_DIRECTORY SatDump)
         set(CPACK_NSIS_MANIFEST_DPI_AWARE ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,11 +237,8 @@ if((NOT ANDROID) AND ENABLE_INSTALL)
     if(MSVC OR BUILD_MSVC)
         # Customize NSIS template
         file(READ "${CMAKE_ROOT}/Modules/Internal/CPack/NSIS.template.in" NSIS_template)
-        set(CREATE_ICONS_REPLACE "
-            SetOutPath \"$INSTDIR\\bin\"
-            @CPACK_NSIS_CREATE_ICONS@
-            SetOutPath \"$INSTDIR\"")
-        string(REPLACE "@CPACK_NSIS_CREATE_ICONS@" "${CREATE_ICONS_REPLACE}" NSIS_template "${NSIS_template}")
+        set(CREATE_ICONS_REPLACE "  SetOutPath \"$INSTDIR\\bin\"\n@CPACK_NSIS_CREATE_ICONS@\n@CPACK_NSIS_CREATE_ICONS_EXTRA@\n  SetOutPath \"$INSTDIR\"")
+        string(REPLACE "@CPACK_NSIS_CREATE_ICONS@\n@CPACK_NSIS_CREATE_ICONS_EXTRA@" "${CREATE_ICONS_REPLACE}" NSIS_template "${NSIS_template}")
         file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/NSIS.template.in" "${NSIS_template}")
         set(CPACK_MODULE_PATH "${CMAKE_CURRENT_BINARY_DIR}")
 
@@ -249,6 +246,7 @@ if((NOT ANDROID) AND ENABLE_INSTALL)
         set(CPACK_GENERATOR NSIS)
         set(CPACK_PACKAGE_INSTALL_DIRECTORY SatDump)
         set(CPACK_NSIS_MANIFEST_DPI_AWARE ON)
+        set(CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL ON)
         set(CPACK_NSIS_BRANDING_TEXT "SatDump - The General Purpose Satellite Decoder")
         set(CPACK_NSIS_MUI_ICON "${CMAKE_CURRENT_SOURCE_DIR}/windows\\\\icon.ico")
         set(CPACK_NSIS_INSTALLED_ICON_NAME "bin\\\\satdump-ui.exe")


### PR DESCRIPTION
In this PR:

- Fix shortcuts to have the correct "Start in" path. Fixes problem of not all plugins loading. Modified form of PothosSDR's solution for the same problem.
- Prompt to uninstall old versions before installing the new version. Without this, old files can get left behind when updating, which may cause problems in the future.