### PR TITLE
Save Plugin Settings

### DIFF
--- a/plugins/sdr_sources/remote_sdr_support/plugin/main.cpp
+++ b/plugins/sdr_sources/remote_sdr_support/plugin/main.cpp
@@ -94,7 +94,9 @@ public:
 
     static void save()
     {
-        logger->info("SAVED!");
+        satdump::config::main_cfg["plugin_settings"]["remote_sdr_support"] = nlohmann::json::array();
+        for (auto& server : additional_servers)
+            satdump::config::main_cfg["plugin_settings"]["remote_sdr_support"].push_back({ {"ip", server.first}, {"port", server.second}});
     }
 
 public:
@@ -107,6 +109,8 @@ public:
     {
         satdump::eventBus->register_handler<dsp::RegisterDSPSampleSourcesEvent>(registerSources);
         satdump::eventBus->register_handler<satdump::config::RegisterPluginConfigHandlersEvent>(registerConfigHandler);
+        for (auto& server : satdump::config::main_cfg["plugin_settings"]["remote_sdr_support"])
+            additional_servers.push_back({ server["ip"], server["port"] });
     }
 
     static void registerSources(const dsp::RegisterDSPSampleSourcesEvent &evt)

--- a/plugins/sdr_sources/remote_sdr_support/plugin/remote_source.cpp
+++ b/plugins/sdr_sources/remote_sdr_support/plugin/remote_source.cpp
@@ -166,8 +166,7 @@ std::vector<dsp::SourceDescriptor> RemoteSource::getAvailableSources()
 
     for (auto server_ip : detected_servers)
     {
-        logger->debug("Found server on %s:%d", server_ip.first.c_str(), server_ip.second);
-
+        logger->info("Querying SDR Server at %s:%d", server_ip.first.c_str(), server_ip.second);
         try
         {
             TCPClient tcp_client((char *)server_ip.first.c_str(), server_ip.second);

--- a/src-core/nlohmann/json_utils.cpp
+++ b/src-core/nlohmann/json_utils.cpp
@@ -27,15 +27,17 @@ nlohmann::ordered_json merge_json_diffs(nlohmann::ordered_json master, nlohmann:
 {
     nlohmann::ordered_json output = master;
 
-    for (nlohmann::detail::iteration_proxy_value<nlohmann::detail::iter_impl<nlohmann::ordered_json>> cfg : master.items())
+    for (nlohmann::detail::iteration_proxy_value<nlohmann::detail::iter_impl<nlohmann::ordered_json>> cfg : diff.items())
     {
-        if (diff.contains(cfg.key()))
+        if (master.contains(cfg.key()))
         {
             if (cfg.value().is_object())
-                output[cfg.key()] = merge_json_diffs(cfg.value(), diff[cfg.key()]);
+                output[cfg.key()] = merge_json_diffs(master[cfg.key()], cfg.value());
             else
                 output[cfg.key()] = diff[cfg.key()];
         }
+        else
+            output[cfg.key()] = cfg.value();
     }
 
     return output;
@@ -45,14 +47,14 @@ nlohmann::ordered_json perform_json_diff(nlohmann::ordered_json master, nlohmann
 {
     nlohmann::ordered_json diff;
 
-    for (nlohmann::detail::iteration_proxy_value<nlohmann::detail::iter_impl<nlohmann::ordered_json>> cfg : master.items())
+    for (nlohmann::detail::iteration_proxy_value<nlohmann::detail::iter_impl<nlohmann::ordered_json>> cfg : modified.items())
     {
-        if (modified[cfg.key()] != cfg.value())
+        if (master[cfg.key()] != cfg.value())
         {
             if (cfg.value().is_object())
-                diff[cfg.key()] = perform_json_diff(cfg.value(), modified[cfg.key()]);
+                diff[cfg.key()] = perform_json_diff(master[cfg.key()], cfg.value());
             else
-                diff[cfg.key()] = modified[cfg.key()];
+                diff[cfg.key()] = cfg.value();
         }
     }
 


### PR DESCRIPTION
**For your review:**

This PR implements a way for plugins to save their settings within the main settings file. Each plugin can create an entry under `config::main_cfg["plugin_settings"]["<plugin-id>"]`, where it can store any values it wants as a JSON object. Implemented for the Remote SDR plugin.

The primary change needed was to invert the JSON diff logic, which allows JSON objects to exist in the user settings that do not exist in the main configuration.

I did some testing on various OSs and it seems fine, but another set of eyes would be great for a change like this.