### PR TITLE
Replace (ImGuiTableFlags)NULL with ImGuiTableFlags_None

### DIFF
--- a/src-interface/recorder/tracking/tracking_widget_interface.cpp
+++ b/src-interface/recorder/tracking/tracking_widget_interface.cpp
@@ -162,7 +162,7 @@ namespace satdump
         if (backend_needs_update)
             style::beginDisabled();
 
-        if (ImGui::BeginTable("##trackingradiotable", 2, (ImGuiTableFlags)NULL))
+        if (ImGui::BeginTable("##trackingradiotable", 2, ImGuiTableFlags_None))
         {
             ImGui::TableNextRow();
             ImGui::TableSetColumnIndex(0);


### PR DESCRIPTION
This is more portable; the cast can cause errors on some toolchains. When [compiling with musl](https://github.com/void-linux/void-packages/actions/runs/6291786525/job/17080505741?pr=45340), for example:

    error: cast from 'std::nullptr_t' to 'ImGuiTableFlags' {aka 'int'} loses precision