### PR TITLE
Viewer/Recorder Fixes

### DIFF
--- a/src-interface/recorder/recorder.cpp
+++ b/src-interface/recorder/recorder.cpp
@@ -119,11 +119,12 @@ namespace satdump
     void RecorderApplication::drawUI()
     {
         ImVec2 recorder_size = ImGui::GetContentRegionAvail();
-        // recorder_size.y -= ImGui::GetCursorPosY();
-        if (ImGui::BeginTable("##recorder_table", 2, ImGuiTableFlags_NoBordersInBodyUntilResize | ImGuiTableFlags_Resizable))
+        float new_ratio = panel_ratio;
+
+        if (ImGui::BeginTable("##recorder_table", 2, ImGuiTableFlags_NoBordersInBodyUntilResize | ImGuiTableFlags_Resizable | ImGuiTableFlags_SizingStretchProp))
         {
-            ImGui::TableSetupColumn("##panel_v", ImGuiTableColumnFlags_WidthFixed, recorder_size.x * panel_ratio);
-            ImGui::TableSetupColumn("##view", ImGuiTableColumnFlags_WidthStretch);
+            ImGui::TableSetupColumn("##panel_v", ImGuiTableColumnFlags_None, recorder_size.x * panel_ratio);
+            ImGui::TableSetupColumn("##view", ImGuiTableColumnFlags_None, recorder_size.x * (1.0f - panel_ratio));
             ImGui::TableNextColumn();
             ImGui::BeginGroup();
 
@@ -517,13 +518,11 @@ namespace satdump
             ImGui::EndChild();
             ImGui::EndGroup();
 
-            if (ImGui::IsMouseDragging(ImGuiMouseButton_Left) || last_width != recorder_size.x)
-                panel_ratio = ImGui::GetColumnWidth() / recorder_size[0];
-            last_width = recorder_size.x;
+            if (ImGui::IsMouseDragging(ImGuiMouseButton_Left))
+                new_ratio = ImGui::GetColumnWidth() / recorder_size.x;
+
             ImGui::TableNextColumn();
-
             ImGui::SameLine();
-
             ImGui::BeginGroup();
             ImGui::BeginChild("RecorderFFT", {float(recorder_size.x * (1.0 - panel_ratio)), wf_size}, false, ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
             {
@@ -563,6 +562,8 @@ namespace satdump
             ImGui::EndChild();
             ImGui::EndGroup();
             ImGui::EndTable();
+
+            panel_ratio = new_ratio;
         }
 
         if (is_processing)

--- a/src-interface/recorder/recorder.cpp
+++ b/src-interface/recorder/recorder.cpp
@@ -119,17 +119,22 @@ namespace satdump
     void RecorderApplication::drawUI()
     {
         ImVec2 recorder_size = ImGui::GetContentRegionAvail();
-        float new_ratio = panel_ratio;
 
         if (ImGui::BeginTable("##recorder_table", 2, ImGuiTableFlags_NoBordersInBodyUntilResize | ImGuiTableFlags_Resizable | ImGuiTableFlags_SizingStretchProp))
         {
             ImGui::TableSetupColumn("##panel_v", ImGuiTableColumnFlags_None, recorder_size.x * panel_ratio);
             ImGui::TableSetupColumn("##view", ImGuiTableColumnFlags_None, recorder_size.x * (1.0f - panel_ratio));
             ImGui::TableNextColumn();
-            ImGui::BeginGroup();
 
+            float left_width = ImGui::GetColumnWidth(0);
+            float right_width = recorder_size.x - left_width;
+            if (left_width != last_width && last_width != -1)
+                panel_ratio = left_width / recorder_size.x;
+            last_width = left_width;
+
+            ImGui::BeginGroup();
             float wf_size = recorder_size.y - ((is_processing && !processing_modules_floating_windows) ? 250 * ui_scale : 0); // + 13 * ui_scale;
-            ImGui::BeginChild("RecorderChildPanel", {float(recorder_size.x * panel_ratio), wf_size}, false, ImGuiWindowFlags_NoBringToFrontOnFocus);
+            ImGui::BeginChild("RecorderChildPanel", { left_width, wf_size }, false, ImGuiWindowFlags_NoBringToFrontOnFocus);
             {
                 if (ImGui::CollapsingHeader("Device", ImGuiTreeNodeFlags_DefaultOpen))
                 {
@@ -518,13 +523,10 @@ namespace satdump
             ImGui::EndChild();
             ImGui::EndGroup();
 
-            if (ImGui::IsMouseDragging(ImGuiMouseButton_Left))
-                new_ratio = ImGui::GetColumnWidth() / recorder_size.x;
-
             ImGui::TableNextColumn();
             ImGui::SameLine();
             ImGui::BeginGroup();
-            ImGui::BeginChild("RecorderFFT", {float(recorder_size.x * (1.0 - panel_ratio)), wf_size}, false, ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
+            ImGui::BeginChild("RecorderFFT", { right_width, wf_size }, false, ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
             {
                 float fft_height = wf_size * (show_waterfall ? waterfall_ratio : 1.0);
                 float wf_height = wf_size * (1 - waterfall_ratio) + 15 * ui_scale;
@@ -534,19 +536,19 @@ namespace satdump
 #else
                 int offset = 30;
 #endif
-                ImGui::SetNextWindowSizeConstraints(ImVec2((recorder_size.x * (1.0 - panel_ratio) + offset * ui_scale), 50), ImVec2((recorder_size.x * (1.0 - panel_ratio) + offset * ui_scale), wf_size));
-                ImGui::SetNextWindowSize(ImVec2((recorder_size.x * (1.0 - panel_ratio) + offset * ui_scale), show_waterfall ? waterfall_ratio * wf_size : wf_size));
-                ImGui::SetNextWindowPos(ImVec2(recorder_size.x * panel_ratio, 25 * ui_scale));
+                ImGui::SetNextWindowSizeConstraints(ImVec2((right_width + offset * ui_scale), 50), ImVec2((right_width + offset * ui_scale), wf_size));
+                ImGui::SetNextWindowSize(ImVec2((right_width + offset * ui_scale), show_waterfall ? waterfall_ratio * wf_size : wf_size));
+                ImGui::SetNextWindowPos(ImVec2(left_width, 25 * ui_scale));
                 if (ImGui::Begin("#fft", &t, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_ChildWindow | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse))
                 {
                     ImGui::SetCursorPosX(ImGui::GetCursorPosX() + 8 * ui_scale);
-                    fft_plot->draw({float(recorder_size.x * (1.0 - panel_ratio) - 8 * ui_scale), fft_height});
+                    fft_plot->draw({float(right_width - 8 * ui_scale), fft_height});
                     if (show_waterfall && ImGui::IsMouseDragging(ImGuiMouseButton_Left))
                         waterfall_ratio = ImGui::GetWindowHeight() / wf_size;
                     if (ImGui::IsWindowHovered())
                     {
                         ImVec2 mouse_pos = ImGui::GetMousePos();
-                        float ratio = (mouse_pos.x - recorder_size.x * panel_ratio - 16 * ui_scale) / (recorder_size.x * (1.0 - panel_ratio) - 8 * ui_scale) - 0.5;
+                        float ratio = (mouse_pos.x - left_width - 16 * ui_scale) / (right_width - 8 * ui_scale) - 0.5;
                         ImGui::SetTooltip("%s", ((ratio >= 0 ? "" : "- ") + format_notated(abs(ratio) * get_samplerate(), "Hz\n") +
                                                  format_notated(source_ptr->get_frequency() + ratio * get_samplerate(), "Hz"))
                                                     .c_str());
@@ -556,14 +558,12 @@ namespace satdump
                 if (show_waterfall)
                 {
                     ImGui::SetCursorPosY(ImGui::GetCursorPosY() - 15 * ui_scale);
-                    waterfall_plot->draw({float(recorder_size.x * (1.0 - panel_ratio) - 8 * ui_scale), wf_height}, is_started);
+                    waterfall_plot->draw({float(right_width - 8 * ui_scale), wf_height}, is_started);
                 }
             }
             ImGui::EndChild();
             ImGui::EndGroup();
             ImGui::EndTable();
-
-            panel_ratio = new_ratio;
         }
 
         if (is_processing)

--- a/src-interface/recorder/recorder.h
+++ b/src-interface/recorder/recorder.h
@@ -48,6 +48,7 @@ namespace satdump
 
         bool dragging_panel = false;
         float panel_ratio = 0.2;
+        float last_width = -1.0f;
 
         std::string recorder_filename;
         int select_sample_format = 0;

--- a/src-interface/recorder/recorder.h
+++ b/src-interface/recorder/recorder.h
@@ -48,7 +48,6 @@ namespace satdump
 
         bool dragging_panel = false;
         float panel_ratio = 0.2;
-        unsigned int last_width = 0;
 
         std::string recorder_filename;
         int select_sample_format = 0;

--- a/src-interface/viewer/viewer.cpp
+++ b/src-interface/viewer/viewer.cpp
@@ -334,82 +334,30 @@ namespace satdump
 
     void ViewerApplication::drawUI()
     {
-        /*
         ImVec2 viewer_size = ImGui::GetContentRegionAvail();
-        ImGui::BeginGroup();
-        ImGui::BeginChild("ViewerChildPanel", {float(viewer_size.x * panel_ratio), float(viewer_size.y)}, false);
-        {
-            drawPanel();
-        }
-        ImGui::EndChild();
-        ImGui::EndGroup();
-
-        ImVec2 mouse_pos = ImGui::GetMousePos();
-        if ((mouse_pos.x > viewer_size.x * panel_ratio + 15 * ui_scale - 10 * ui_scale &&
-             mouse_pos.x < viewer_size.x * panel_ratio + 15 * ui_scale + 10 * ui_scale &&
-             mouse_pos.y > 35 * ui_scale) ||
-            dragging_panel)
-        {
-            ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
-            if (ImGui::IsMouseDown(ImGuiMouseButton_Left))
-            {
-                float new_x = mouse_pos.x;
-                float new_ratio = new_x / viewer_size.x;
-                if (new_ratio > 0.1 && new_ratio < 0.9)
-                    panel_ratio = new_ratio;
-            }
-            else
-                dragging_panel = false;
-            if (ImGui::IsMouseClicked(ImGuiMouseButton_Left))
-                dragging_panel = true;
-        }
-        else if (ImGui::GetMouseCursor() != ImGuiMouseCursor_ResizeNS)
-            ImGui::SetMouseCursor(ImGuiMouseCursor_Arrow);
-
-        ImGui::SameLine();
-
-        ImGui::BeginGroup();
-        if (current_selected_tab == 0)
-        {
-            if (products_and_handlers.size() > 0)
-                products_and_handlers[current_handler_id]->handler->drawContents({float(viewer_size.x * (1.0 - panel_ratio) - 4), float(viewer_size.y)});
-            else
-                ImGui::GetWindowDrawList()
-                    ->AddRectFilled(ImGui::GetCursorScreenPos(),
-                                    ImVec2(ImGui::GetCursorScreenPos().x + ImGui::GetContentRegionAvail().x,
-                                           ImGui::GetCursorScreenPos().y + ImGui::GetContentRegionAvail().y),
-                                    ImColor::HSV(0, 0, 0));
-        }
-        else if (current_selected_tab == 1)
-        {
-            projection_image_widget.draw({float(viewer_size.x * (1.0 - panel_ratio) - 4), float(viewer_size.y)});
-        }
-        ImGui::EndGroup();
-        */
-
-        ImVec2 viewer_size = ImGui::GetContentRegionAvail();
-        float new_ratio = panel_ratio;
 
         if (ImGui::BeginTable("##wiever_table", 2, ImGuiTableFlags_NoBordersInBodyUntilResize | ImGuiTableFlags_Resizable | ImGuiTableFlags_SizingStretchProp))
         {
             ImGui::TableSetupColumn("##panel_v", ImGuiTableColumnFlags_None, viewer_size.x * panel_ratio);
             ImGui::TableSetupColumn("##view", ImGuiTableColumnFlags_None, viewer_size.x * (1.0f - panel_ratio));
             ImGui::TableNextColumn();
-            ImGui::BeginChild("ViewerChildPanel", {float(viewer_size.x * panel_ratio), float(viewer_size.y - 10)}, false);
-            {
-                drawPanel();
-            }
-            ImGui::EndChild();
 
-            if (ImGui::IsMouseDragging(ImGuiMouseButton_Left))
-                new_ratio = ImGui::GetColumnWidth() / viewer_size.x;
+            float left_width = ImGui::GetColumnWidth(0);
+            float right_width = viewer_size.x - left_width;
+            if (left_width != last_width && last_width != -1)
+                panel_ratio = left_width / viewer_size.x;
+            last_width = left_width;
+
+            ImGui::BeginChild("ViewerChildPanel", { left_width, float(viewer_size.y - 10) }, false);
+            drawPanel();
+            ImGui::EndChild();
 
             ImGui::TableNextColumn();
             ImGui::BeginGroup();
             if (current_selected_tab == 0)
             {
                 if (products_and_handlers.size() > 0)
-                    products_and_handlers[current_handler_id]->handler->drawContents({float(viewer_size.x * (1.0 - panel_ratio) - 4), float(viewer_size.y)});
+                    products_and_handlers[current_handler_id]->handler->drawContents({float(right_width - 4), float(viewer_size.y)});
                 else
                     ImGui::GetWindowDrawList()
                         ->AddRectFilled(ImGui::GetCursorScreenPos(),
@@ -419,11 +367,10 @@ namespace satdump
             }
             else if (current_selected_tab == 1)
             {
-                projection_image_widget.draw({float(viewer_size.x * (1.0 - panel_ratio) - 4), float(viewer_size.y)});
+                projection_image_widget.draw({float(right_width - 4), float(viewer_size.y)});
             }
             ImGui::EndGroup();
             ImGui::EndTable();
-            panel_ratio = new_ratio;
         }
     }
 

--- a/src-interface/viewer/viewer.cpp
+++ b/src-interface/viewer/viewer.cpp
@@ -388,20 +388,22 @@ namespace satdump
         */
 
         ImVec2 viewer_size = ImGui::GetContentRegionAvail();
+        float new_ratio = panel_ratio;
 
-        if (ImGui::BeginTable("##wiever_table", 2, ImGuiTableFlags_NoBordersInBodyUntilResize | ImGuiTableFlags_Resizable))
+        if (ImGui::BeginTable("##wiever_table", 2, ImGuiTableFlags_NoBordersInBodyUntilResize | ImGuiTableFlags_Resizable | ImGuiTableFlags_SizingStretchProp))
         {
-            ImGui::TableSetupColumn("##panel_v", ImGuiTableColumnFlags_WidthFixed, viewer_size.x * panel_ratio);
-            ImGui::TableSetupColumn("##view", ImGuiTableColumnFlags_WidthStretch);
+            ImGui::TableSetupColumn("##panel_v", ImGuiTableColumnFlags_None, viewer_size.x * panel_ratio);
+            ImGui::TableSetupColumn("##view", ImGuiTableColumnFlags_None, viewer_size.x * (1.0f - panel_ratio));
             ImGui::TableNextColumn();
             ImGui::BeginChild("ViewerChildPanel", {float(viewer_size.x * panel_ratio), float(viewer_size.y - 10)}, false);
             {
                 drawPanel();
             }
             ImGui::EndChild();
-            if (ImGui::IsMouseDragging(ImGuiMouseButton_Left) || last_width != viewer_size.x)
-                panel_ratio = ImGui::GetColumnWidth() / viewer_size[0];
-            last_width = viewer_size.x;
+
+            if (ImGui::IsMouseDragging(ImGuiMouseButton_Left))
+                new_ratio = ImGui::GetColumnWidth() / viewer_size.x;
+
             ImGui::TableNextColumn();
             ImGui::BeginGroup();
             if (current_selected_tab == 0)
@@ -421,6 +423,7 @@ namespace satdump
             }
             ImGui::EndGroup();
             ImGui::EndTable();
+            panel_ratio = new_ratio;
         }
     }
 

--- a/src-interface/viewer/viewer.h
+++ b/src-interface/viewer/viewer.h
@@ -51,7 +51,6 @@ namespace satdump
 
         bool dragging_panel = false;
         float panel_ratio = 0.23;
-        unsigned int last_width = 0;
 
         FileSelectWidget select_dataset_dialog = FileSelectWidget("Dataset", "Select Dataset");
         FileSelectWidget select_products_dialog = FileSelectWidget("Products", "Select Products");

--- a/src-interface/viewer/viewer.h
+++ b/src-interface/viewer/viewer.h
@@ -51,6 +51,7 @@ namespace satdump
 
         bool dragging_panel = false;
         float panel_ratio = 0.23;
+        float last_width = -1.0f;
 
         FileSelectWidget select_dataset_dialog = FileSelectWidget("Dataset", "Select Dataset");
         FileSelectWidget select_products_dialog = FileSelectWidget("Products", "Select Products");

--- a/src-ui/main.cpp
+++ b/src-ui/main.cpp
@@ -273,14 +273,6 @@ int main(int argc, char *argv[])
     // Main loop
     do
     {
-        glfwPollEvents();
-        if (glfwWindowShouldClose(window) && glfwGetWindowAttrib(window, GLFW_MAXIMIZED))
-        {
-            glfwRestoreWindow(window);
-            glfwWaitEvents();
-            glfwPollEvents();
-        }
-
         // Start the Dear ImGui frame
         ImGui_ImplOpenGL3_NewFrame();
         ImGui_ImplGlfw_NewFrame();
@@ -309,6 +301,7 @@ int main(int argc, char *argv[])
         ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 
         glfwSwapBuffers(window);
+        glfwPollEvents();
     } while (!glfwWindowShouldClose(window));
 
     satdump::exitMainUI();


### PR DESCRIPTION
Various bug fixes, all stemming from one report - 

- Fix bug where viewer/recorder panel ratio would not save correctly in some circumstances (thanks @RAD750)
- Fix bug where quickly resizing viewer/recorder panels could create a large margin between the panels
- Fix bug where resizing the recorder panel to specific sizes would cause a crash
- Clean up viewer/recorder panel ratio logic - for simplicity, left panel width is no longer maintained on window resize. Instead, it scales proportionally with the window.
- Remove old workaround that was used to help the panel ratio saving logic, but is no longer needed. It also resulted in an extra frame at the end of program termination in non-Android builds