### PR TITLE
PBM fix-ups

### DIFF
--- a/src-core/common/image/image.cpp
+++ b/src-core/common/image/image.cpp
@@ -235,7 +235,7 @@ namespace image
             load_png(file);
         else if (signature[0] == 0xff && signature[1] == 0x4f && signature[2] == 0xff && signature[3] == 0x51)
             load_j2k(file);
-        else if ((signature[0] == 'P' && signature[1] == '4') || (signature[0] == 'P' && signature[1] == '6'))
+        else if (signature[0] == 'P' && (signature[1] == '5' || signature[1] == '6'))
             load_pbm(file);
     }
 

--- a/src-core/common/image/image_pbm.cpp
+++ b/src-core/common/image/image_pbm.cpp
@@ -77,17 +77,8 @@ namespace image
             std::string signature;
             size_t width, height, maxval;
             int channels;
-            for (int i = 0; i < 4; i++)
-            {
-                if (i == 0)
-                    filei >> signature;
-                else if (i == 1)
-                    filei >> width;
-                else if(i == 2)
-                    filei >> height;
-                else if(i == 3)
-                    filei >> maxval;
-            }
+
+            filei >> signature >> width >> height >> maxval;
 
             if (signature == "P5")
                 channels = 1;

--- a/src-core/common/image/image_pbm.cpp
+++ b/src-core/common/image/image_pbm.cpp
@@ -13,7 +13,7 @@ namespace image
     {
         if (data_size == 0 || d_height == 0) // Make sure we aren't just gonna crash
         {
-            logger->trace("Tried to save empty PNG!");
+            logger->trace("Tried to save empty PBM!");
             return;
         }
 
@@ -26,12 +26,12 @@ namespace image
             channels = 3;
 
         if (channels == 1)
-            fileo.write("P4  ", 4); // Magic Number + Whitespace
+            fileo.write("P5 ", 3); // Magic Number + Whitespace
         else
-            fileo.write("P6  ", 4);                          // Magic Number + Whitespace
-        std::string swidth = std::to_string(d_width) + "  "; // Width + Whitespace
+            fileo.write("P6 ", 3);                          // Magic Number + Whitespace
+        std::string swidth = std::to_string(d_width) + " "; // Width + Whitespace
         fileo.write(swidth.c_str(), swidth.size());
-        std::string sheight = std::to_string(d_height) + "  "; // Height + Whitespace
+        std::string sheight = std::to_string(d_height) + " "; // Height + Whitespace
         fileo.write(sheight.c_str(), sheight.size());
 
         if (d_depth == 8)
@@ -39,8 +39,8 @@ namespace image
             std::string smaxval = "255\n"; // MaxVal + Whitespace
             fileo.write(smaxval.c_str(), smaxval.size());
 
-            for (int y = 0; y < d_height; y++)
-                for (int x = 0; x < d_width; x++)
+            for (size_t y = 0; y < d_height; y++)
+                for (size_t x = 0; x < d_width; x++)
                     for (int c = 0; c < channels; c++)
                         fileo.write((char *)&channel(c)[y * d_width + x], sizeof(uint8_t));
         }
@@ -49,9 +49,9 @@ namespace image
             std::string smaxval = "65535\n"; // MaxVal + Whitespace
             fileo.write(smaxval.c_str(), smaxval.size());
 
-            for (int y = 0; y < d_height; y++)
+            for (size_t y = 0; y < d_height; y++)
             {
-                for (int x = 0; x < d_width; x++)
+                for (size_t x = 0; x < d_width; x++)
                 {
                     for (int c = 0; c < channels; c++)
                     {
@@ -74,71 +74,38 @@ namespace image
         try
         {
             std::ifstream filei(file, std::ios::binary);
-
             std::string signature;
-            signature.resize(2);
-            filei.read((char *)signature.c_str(), 2);
+            size_t width, height, maxval;
+            int channels;
+            for (int i = 0; i < 4; i++)
+            {
+                if (i == 0)
+                    filei >> signature;
+                else if (i == 1)
+                    filei >> width;
+                else if(i == 2)
+                    filei >> height;
+                else if(i == 3)
+                    filei >> maxval;
+            }
 
-            logger->critical(signature);
-
-            int channels = 1;
-            if (signature == "P4")
+            if (signature == "P5")
                 channels = 1;
             else if (signature == "P6")
                 channels = 3;
-
-            uint8_t dump; // Extra char
-            filei.read((char *)&dump, 1);
-
-            std::string widthstr;
-            while (!filei.eof())
-            {
-                char c;
-                filei.read(&c, 1);
-                if (c != ' ' && c != '\r' && c != '\n')
-                    widthstr.push_back(c);
-                else
-                    break;
-            }
-            int width = std::stoi(widthstr);
-
-            logger->critical(widthstr);
-
-            std::string heightstr;
-            while (!filei.eof())
-            {
-                char c;
-                filei.read(&c, 1);
-                if (c != ' ' && c != '\r' && c != '\n')
-                    heightstr.push_back(c);
-                else
-                    break;
-            }
-            int height = std::stoi(heightstr);
-
-            logger->critical(heightstr);
+            else
+                throw std::runtime_error("Invalid Magic Number " + signature);
 
             init(width, height, channels);
-
-            std::string maxvalstr;
-            while (!filei.eof())
-            {
-                char c;
-                filei.read(&c, 1);
-                if (c != ' ' && c != '\r' && c != '\n')
-                    maxvalstr.push_back(c);
-                else
-                    break;
-            }
-            int maxval = std::stoi(maxvalstr);
+            filei.seekg(1, std::ios_base::cur);
 
             if (d_depth == 8)
             {
                 if (maxval > 255)
                 {
-                    for (int y = 0; y < d_height; y++)
+                    for (size_t y = 0; y < d_height; y++)
                     {
-                        for (int x = 0; x < d_width; x++)
+                        for (size_t x = 0; x < d_width; x++)
                         {
                             for (int c = 0; c < d_channels; c++)
                             {
@@ -151,9 +118,9 @@ namespace image
                 }
                 else
                 {
-                    for (int y = 0; y < d_height; y++)
+                    for (size_t y = 0; y < d_height; y++)
                     {
-                        for (int x = 0; x < d_width; x++)
+                        for (size_t x = 0; x < d_width; x++)
                         {
                             for (int c = 0; c < d_channels; c++)
                             {
@@ -169,9 +136,9 @@ namespace image
             {
                 if (maxval > 255)
                 {
-                    for (int y = 0; y < d_height; y++)
+                    for (size_t y = 0; y < d_height; y++)
                     {
-                        for (int x = 0; x < d_width; x++)
+                        for (size_t x = 0; x < d_width; x++)
                         {
                             for (int c = 0; c < d_channels; c++)
                             {
@@ -184,9 +151,9 @@ namespace image
                 }
                 else
                 {
-                    for (int y = 0; y < d_height; y++)
+                    for (size_t y = 0; y < d_height; y++)
                     {
-                        for (int x = 0; x < d_width; x++)
+                        for (size_t x = 0; x < d_width; x++)
                         {
                             for (int c = 0; c < d_channels; c++)
                             {


### PR DESCRIPTION
- Use P5 instead of P4 for grayscale images
- Make the PBM loader more resilient to the number of whitespaces in the header
- Fix some warnings