### PR TITLE
Viewer threads

### DIFF
--- a/src-interface/viewer/image_handler.h
+++ b/src-interface/viewer/image_handler.h
@@ -8,12 +8,15 @@
 #include "imgui/imgui_stdlib.h"
 #include "common/image/composite.h"
 #include "core/style.h"
+#include "libs/ctpl/ctpl_stl.h"
 
 namespace satdump
 {
     class ImageViewerHandler : public ViewerHandler
     {
     public:
+        ~ImageViewerHandler();
+
         // Products
         ImageProducts *products;
 
@@ -85,6 +88,7 @@ namespace satdump
         void init();
         void updateImage();
 
+        ctpl::thread_pool handler_thread_pool = ctpl::thread_pool(1);
         std::mutex async_image_mutex;
         void asyncUpdate();
         void updateRGB();

--- a/src-interface/viewer/radiation_handler.h
+++ b/src-interface/viewer/radiation_handler.h
@@ -6,12 +6,15 @@
 #include "products/radiation_products.h"
 #include "common/widgets/image_view.h"
 #include "imgui/imgui_stdlib.h"
+#include "libs/ctpl/ctpl_stl.h"
 
 namespace satdump
 {
     class RadiationViewerHandler : public ViewerHandler
     {
     public:
+        ~RadiationViewerHandler();
+
         // Products
         RadiationProducts *products;
 
@@ -51,6 +54,7 @@ namespace satdump
         unsigned int getPreviewImageTexture() { return image_view.getTextID(); }
         void setShouldProject(bool proj) { should_project = proj; }
 
+        ctpl::thread_pool handler_thread_pool = ctpl::thread_pool(1);
         std::mutex async_image_mutex;
         bool is_updating = false;
     };

--- a/src-interface/viewer/scatterometer_handler.h
+++ b/src-interface/viewer/scatterometer_handler.h
@@ -6,12 +6,15 @@
 #include "products/scatterometer_products.h"
 #include "common/widgets/image_view.h"
 #include "imgui/imgui_stdlib.h"
+#include "libs/ctpl/ctpl_stl.h"
 
 namespace satdump
 {
     class ScatterometerViewerHandler : public ViewerHandler
     {
     public:
+        ~ScatterometerViewerHandler();
+
         // Products
         ScatterometerProducts *products;
 
@@ -54,6 +57,7 @@ namespace satdump
 
         void init();
 
+        ctpl::thread_pool handler_thread_pool = ctpl::thread_pool(1);
         std::mutex async_image_mutex;
         void asyncUpdate();
         void update();

--- a/src-interface/viewer/viewer.h
+++ b/src-interface/viewer/viewer.h
@@ -80,7 +80,7 @@ namespace satdump
         virtual void drawContent();
 
         std::vector<std::string> opened_datasets;
-
+        std::mutex product_handler_mutex;
         std::vector<std::shared_ptr<ProductsHandler>> products_and_handlers;
         int products_cnt_in_dataset(std::string dataset_name)
         {

--- a/src-interface/viewer/viewer_projection.cpp
+++ b/src-interface/viewer/viewer_projection.cpp
@@ -21,6 +21,7 @@ namespace satdump
 
     void ViewerApplication::drawProjectionPanel()
     {
+        bool disable_buttons = projections_are_generating;
         if (ImGui::CollapsingHeader("Projection", ImGuiTreeNodeFlags_DefaultOpen))
         {
             ImGui::Text("Output image : ");
@@ -85,8 +86,7 @@ namespace satdump
             ImGui::Separator();
             ImGui::Spacing();
 
-            bool beginGenHide = projections_are_generating;
-            if (projections_are_generating || projection_layers.size() == 0)
+            if (disable_buttons || projection_layers.size() == 0)
                 style::beginDisabled();
             if (ImGui::Button("Generate Projection"))
             {
@@ -127,7 +127,7 @@ namespace satdump
                 if (projection_layers.size() == 0)
                     ImGui::SetTooltip("No layers loaded!");
             }
-            if (beginGenHide || projection_layers.size() == 0)
+            if (disable_buttons || projection_layers.size() == 0)
                 style::endDisabled();
         }
         if (ImGui::CollapsingHeader("Layers"))
@@ -301,7 +301,7 @@ namespace satdump
                     ImGui::Checkbox(std::string("##enablelayer" + layer.name + std::to_string(i)).c_str(), &layer.enabled);
                     // if (layer.type == 1)
                     {
-                        if (projections_are_generating)
+                        if (disable_buttons)
                             ImGui::BeginDisabled();
                         // Closing button
                         ImGui::SameLine();
@@ -332,7 +332,7 @@ namespace satdump
                             ImGui::SetTooltip("Wait for the processing to finish!");
                         ImGui::PopStyleColor();
                         ImGui::PopStyleColor();
-                        if (projections_are_generating)
+                        if (disable_buttons)
                             ImGui::EndDisabled();
                     }
                     if (layer.enabled)
@@ -374,15 +374,15 @@ namespace satdump
                 }
                 ImGui::EndListBox();
             }
-            if (!(projections_are_generating || is_opening_layer))
+            if (!(disable_buttons || is_opening_layer))
                 style::beginDisabled();
 
             ImGui::ProgressBar((general_progress + (progress_pointer == NULL ? 0 : *(progress_pointer))) / general_sum);
             
-            if (!(projections_are_generating || is_opening_layer))
+            if (!(disable_buttons || is_opening_layer))
                 style::endDisabled();
 
-            if (projections_are_generating || projection_layers.size() == 0)
+            if (disable_buttons || projection_layers.size() == 0)
                 style::beginDisabled();
             if (ImGui::Button("Generate Projection##layers"))
             {
@@ -392,7 +392,7 @@ namespace satdump
                     generateProjectionImage();
                     logger->info("Done"); });
             }
-            if (projections_are_generating || projection_layers.size() == 0)
+            if (disable_buttons || projection_layers.size() == 0)
                 style::endDisabled();
         }
         if (ImGui::CollapsingHeader("Overlay##viewerpojoverlay"))


### PR DESCRIPTION
- Fix crash when attempting to close dataset that has an ongoing operation
- Fix crash when loading and closing datasets at the same time
- Fix random crash when projection starts in the middle of the viewer panel being rendered