### PR TITLE
Memory Fixes

### DIFF
--- a/plugins/fengyun3_support/fengyun3/instruments/mwri/mwri_reader.cpp
+++ b/plugins/fengyun3_support/fengyun3/instruments/mwri/mwri_reader.cpp
@@ -7,7 +7,7 @@ namespace fengyun3
         MWRIReader::MWRIReader()
         {
             for (int i = 0; i < 10; i++)
-                channels[i].create(1000 * 266);
+                channels[i].create(266);
 
             lines = 0;
         }

--- a/plugins/fengyun3_support/fengyun3/instruments/windrad/windrad_reader.cpp
+++ b/plugins/fengyun3_support/fengyun3/instruments/windrad/windrad_reader.cpp
@@ -9,7 +9,7 @@ namespace fengyun3
         WindRADReader::WindRADReader(int width, std::string bnd, std::string dir) : width(width), band(bnd), directory(dir)
         {
             for (int i = 0; i < 2; i++)
-                channels[i].create(1000 * width);
+                channels[i].create(width);
 
             lines = 0;
         }

--- a/plugins/others_support/cryosat/instruments/siral/module_cryosat_siral.cpp
+++ b/plugins/others_support/cryosat/instruments/siral/module_cryosat_siral.cpp
@@ -55,7 +55,7 @@ namespace cryosat
 
             // cimg_library::CImg<unsigned char> outputImage(243, 100000, 1, 1, 0);
             ResizeableBuffer<unsigned char> fftImage;
-            fftImage.create(100000 * 243);
+            fftImage.create(10 * 243);
             int lines = 0;
 
             while (!data_in.eof())

--- a/src-core/common/resizeable_buffer.h
+++ b/src-core/common/resizeable_buffer.h
@@ -27,7 +27,7 @@ public:
     std::mutex buffer_lock;
     T *buf;
 
-    bool destroyed = false;
+    bool destroyed = true;
 
 public:
     ResizeableBuffer() { d_size = 0; }
@@ -53,6 +53,7 @@ public:
         d_headroom = headroom;
         d_size = d_width * d_headroom;
         buf = new T[d_size];
+        destroyed = false;
     }
 
     void resize(size_t newSize)


### PR DESCRIPTION
This PR fixes a few memory-related issues in the FY plugin:

- Fixes a bug where `ResizableBuffer` would try to `delete` a null pointer if the object never had `create()` run, crashing the program
- Removed extra 1000 in all instances that `ResizableBuffer::create()` is called. This function already multiplies all inputs by 1000, so multiplying the input by 1000 beforehand seems redundant and results in large memory allocations. On Windows, the 2nd call to `ResizableBuffer::create()` in `WindRADReader` failed with `std::bad_alloc` before this change (despite having the memory available).

I verified that the failsafe call to `ResizableBuffer::resize()` is never called within `WindRADReader` on some test FY 3E HPT data I have, and all data is saved.