### PR TITLE
Mipmap on OpenGL 2 / GL ES 2.0

### DIFF
--- a/src-ui/imgui/imgui_image_adv.cpp
+++ b/src-ui/imgui/imgui_image_adv.cpp
@@ -1,3 +1,8 @@
+// SatDump OpenGL 3 texture functions
+// - Functions in this file will load through gl3w and must be complaint with OpenGL 3+
+// - Functions here should override functions already set up in imgui_image_base.cpp
+//   to provide mordern/advanced functionality
+
 #include "imgui/imgui_image.h"
 #include "gl3w/gl3w.h"
 #include "logger.h"

--- a/src-ui/imgui/imgui_image_adv.cpp
+++ b/src-ui/imgui/imgui_image_adv.cpp
@@ -2,7 +2,7 @@
 #include "gl3w/gl3w.h"
 #include "logger.h"
 
-void funcUpdateMMImageTexture(unsigned int gl_text, uint32_t* buffer, int width, int height)
+void funcUpdateMMImageTexture_GL3(unsigned int gl_text, uint32_t* buffer, int width, int height)
 {
     glBindTexture(GL_TEXTURE_2D, gl_text);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
@@ -13,12 +13,12 @@ void funcUpdateMMImageTexture(unsigned int gl_text, uint32_t* buffer, int width,
     glBindTexture(GL_TEXTURE_2D, 0);
 }
 
-void bindMMImageTextureFunctions()
+void bindAdvancedTextureFunctions()
 {
     if (gl3wInit())
     {
         logger->critical("Could not init gl3w! Exiting");
         exit(1);
     }
-    updateMMImageTexture = funcUpdateMMImageTexture;
+    updateMMImageTexture = funcUpdateMMImageTexture_GL3;
 }

--- a/src-ui/imgui/imgui_image_base.cpp
+++ b/src-ui/imgui/imgui_image_base.cpp
@@ -1,3 +1,11 @@
+// SatDump base OpenGL texture functions
+// - All functions specified in imgui/imgui_image.h should be defined/assigned here
+// - Only OpenGL calls defined in the system headers can be called here; no loaders
+//   are used.
+// - Functions in this file must be compliant with OpenGL 2.1 and OpenGL ES 2.0
+// - Functions must also be complaint with OpenGL 3.0+, unless they are overridden
+//   by a function in imgui_image_adv.cpp.
+
 #include "imgui/imgui_image.h"
 #include "gl.h"
 
@@ -12,7 +20,7 @@ unsigned int funcMakeImageTexture()
     return gl_text;
 }
 
-void funcUpdateImageTexture(unsigned int gl_text, uint32_t *buffer, int width, int height)
+void funcUpdateImageTexture(unsigned int gl_text, uint32_t* buffer, int width, int height)
 {
     glBindTexture(GL_TEXTURE_2D, gl_text);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
@@ -24,12 +32,26 @@ void funcUpdateImageTexture(unsigned int gl_text, uint32_t *buffer, int width, i
 
 void funcUpdateMMImageTexture_GL2(unsigned int gl_text, uint32_t* buffer, int width, int height)
 {
+#if defined(IMGUI_IMPL_OPENGL_ES2)
+    if (width % 2 == 1 || height % 2 == 1)
+    {
+        funcUpdateImageTexture(gl_text, buffer, width, height);
+        return;
+    }
+    glBindTexture(GL_TEXTURE_2D, gl_text);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, buffer);
+    glGenerateMipmap(GL_TEXTURE_2D);
+#else
     glBindTexture(GL_TEXTURE_2D, gl_text);
     glTexParameteri(GL_TEXTURE_2D, 0x8191, GL_TRUE); //GL_GENERATE_MIPMAP
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, buffer);
+#endif
     glBindTexture(GL_TEXTURE_2D, 0);
 }
 

--- a/src-ui/imgui/imgui_image_base.cpp
+++ b/src-ui/imgui/imgui_image_base.cpp
@@ -24,17 +24,13 @@ void funcUpdateImageTexture(unsigned int gl_text, uint32_t *buffer, int width, i
 
 void funcUpdateMMImageTexture_GL2(unsigned int gl_text, uint32_t* buffer, int width, int height)
 {
-#ifdef GL_GENERATE_MIPMAP
     glBindTexture(GL_TEXTURE_2D, gl_text);
-    glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, GL_TRUE);
+    glTexParameteri(GL_TEXTURE_2D, 0x8191, GL_TRUE); //GL_GENERATE_MIPMAP
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, buffer);
     glBindTexture(GL_TEXTURE_2D, 0);
-#else
-    funcUpdateImageTexture(gl_text, buffer, width, height);
-#endif
 }
 
 void funcDeleteImageTexture(unsigned int /*gl_text*/)

--- a/src-ui/imgui/imgui_image_base.cpp
+++ b/src-ui/imgui/imgui_image_base.cpp
@@ -22,15 +22,30 @@ void funcUpdateImageTexture(unsigned int gl_text, uint32_t *buffer, int width, i
     glBindTexture(GL_TEXTURE_2D, 0);
 }
 
+void funcUpdateMMImageTexture_GL2(unsigned int gl_text, uint32_t* buffer, int width, int height)
+{
+#ifdef GL_GENERATE_MIPMAP
+    glBindTexture(GL_TEXTURE_2D, gl_text);
+    glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, GL_TRUE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, buffer);
+    glBindTexture(GL_TEXTURE_2D, 0);
+#else
+    funcUpdateImageTexture(gl_text, buffer, width, height);
+#endif
+}
+
 void funcDeleteImageTexture(unsigned int /*gl_text*/)
 {
     //glDeleteTextures(1, &gl_text);
 }
 
-void bindImageTextureFunctions()
+void bindBaseTextureFunctions()
 {
     makeImageTexture = funcMakeImageTexture;
     updateImageTexture = funcUpdateImageTexture;
-    updateMMImageTexture = funcUpdateImageTexture;
+    updateMMImageTexture = funcUpdateMMImageTexture_GL2;
     deleteImageTexture = funcDeleteImageTexture;
 }

--- a/src-ui/main.cpp
+++ b/src-ui/main.cpp
@@ -46,8 +46,8 @@ void window_content_scale_callback(GLFWwindow *, float xscale, float)
     }
 }
 
-void bindImageTextureFunctions();
-void bindMMImageTextureFunctions();
+void bindBaseTextureFunctions();
+void bindAdvancedTextureFunctions();
 
 int main(int argc, char *argv[])
 {
@@ -130,10 +130,10 @@ int main(int argc, char *argv[])
                          // Vsync slows down init process when items are logged quickly
 
     //Set up texture functions
-    bindImageTextureFunctions();
+    bindBaseTextureFunctions();
 #ifndef IMGUI_IMPL_OPENGL_ES2
     if (!fallback_gl)
-        bindMMImageTextureFunctions();
+        bindAdvancedTextureFunctions();
 #endif
 
     // Setup Dear ImGui context


### PR DESCRIPTION
Extend mipmapping to all supported old GL versions. Mipmapping is now used in the viewer on all devices