### PR TITLE
Set minimum width of dropdown GUI components to 50px

### DIFF
--- a/src-core/imgui/imgui_widgets.cpp
+++ b/src-core/imgui/imgui_widgets.cpp
@@ -1685,7 +1685,7 @@ bool ImGui::BeginCombo(const char* label, const char* preview_value, ImGuiComboF
 
     const float arrow_size = (flags & ImGuiComboFlags_NoArrowButton) ? 0.0f : GetFrameHeight();
     const ImVec2 label_size = CalcTextSize(label, NULL, true);
-    const float w = (flags & ImGuiComboFlags_NoPreview) ? arrow_size : CalcItemWidth();
+    const float w = (flags & ImGuiComboFlags_NoPreview) ? arrow_size : ((CalcItemWidth() < 50) ? 50 : CalcItemWidth());
     const ImRect bb(window->DC.CursorPos, window->DC.CursorPos + ImVec2(w, label_size.y + style.FramePadding.y * 2.0f));
     const ImRect total_bb(bb.Min, bb.Max + ImVec2(label_size.x > 0.0f ? style.ItemInnerSpacing.x + label_size.x : 0.0f, 0.0f));
     ItemSize(total_bb, style.FramePadding.y);


### PR DESCRIPTION
This change is in the common GUI code (for combo box). It is possible though highly unlikely that it would cause an issue (if somewhere a smaller than 50px combo box is needed).

https://github.com/gurrsoft/SatDump/issues/1