### PR TITLE
Various MODIS fixes

### DIFF
--- a/plugins/eos_support/eos/instruments/modis/calibrator/modis_calibrator.h
+++ b/plugins/eos_support/eos/instruments/modis/calibrator/modis_calibrator.h
@@ -12,24 +12,24 @@ namespace eos
         struct ValsPerScan
         {
             // General
-            bool MS;
+            bool MS = false;
             bool valid = false;
 
             // Emissive
-            int emissive_DN_SVs[160];
-            int emissive_DN_BBs[160];
+            int emissive_DN_SVs[160] = {0};
+            int emissive_DN_BBs[160] = {0};
 
-            double emissive_a0[160];
-            double emissive_a2[160];
-            double emissive_b1[160];
-            float emissive_Planck_mir[160];
+            double emissive_a0[160] = {0.0};
+            double emissive_a2[160] = {0.0};
+            double emissive_b1[160] = {0.0};
+            float emissive_Planck_mir[160] = {0.0f};
 
             // Temperature
-            double T_bb;
-            double T_mir;
-            double T_cav;
-            double T_ins;
-            double fp_temps[4];
+            double T_bb = 0.0;
+            double T_mir = 0.0;
+            double T_cav = 0.0;
+            double T_ins = 0.0;
+            double fp_temps[4] = {0};
 
             NLOHMANN_DEFINE_TYPE_INTRUSIVE(ValsPerScan,
                                            MS, valid,

--- a/plugins/eos_support/eos/instruments/modis/calibrator/modis_calibrator_utils.cpp
+++ b/plugins/eos_support/eos/instruments/modis/calibrator/modis_calibrator_utils.cpp
@@ -50,8 +50,6 @@ namespace eos
                         goto skip_scan;
                     if (!d_vars[scan].contains("inst_temp"))
                         goto skip_scan;
-                    if (!d_vars[scan].contains("inst_temp"))
-                        goto skip_scan;
                     if (!d_vars[scan].contains("fp_temp"))
                         goto skip_scan;
                     if (!d_vars[scan].contains("fp_temp_info"))

--- a/plugins/eos_support/eos/instruments/modis/calibrator/modis_calibrator_utils.cpp
+++ b/plugins/eos_support/eos/instruments/modis/calibrator/modis_calibrator_utils.cpp
@@ -23,12 +23,12 @@ namespace eos
                 else
                     raw_coeffs_emmissive = loadCborFile(resources::getResourcePath("calibration/modis_emissive_table_terra.cbor"));
 
-                Coefficients_Emissive Sat_CoeffsE = raw_coeffs_emmissive;
+                Coefficients_Emissive *Sat_CoeffsE = new Coefficients_Emissive(raw_coeffs_emmissive);
                 //  logger->trace("Loading reflective!");
                 //  Sat_CoeffsR = loadCborFile("/home/alan/Documents/SatDump_ReWork/build/reflective_table_aqua.cbor");
 
                 logger->trace("Calculate RVS/RSB!");
-                calculate_rvs_correction(Sat_CoeffsE, cvars);
+                calculate_rvs_correction(*Sat_CoeffsE, cvars);
 
                 for (int scan = 0; scan < (int)d_products->images[7].image.height() / 10; scan++)
                 {
@@ -74,7 +74,7 @@ namespace eos
                         scaninfo.emissive_DN_SVs[D_emiss] = DN_sv;
                         scaninfo.emissive_DN_BBs[D_emiss] = DN_bb;
 
-                        if (get_emissive_coeffs(Sat_CoeffsE, is_aqua, cvars,
+                        if (get_emissive_coeffs(*Sat_CoeffsE, is_aqua, cvars,
                                                 scaninfo.emissive_a0[D_emiss],
                                                 scaninfo.emissive_a2[D_emiss],
                                                 scaninfo.emissive_b1[D_emiss],
@@ -100,6 +100,7 @@ namespace eos
                 nlohmann::json finalv;
                 finalv["cvars"] = cvars;
                 finalv["c_emissive"] = raw_coeffs_emmissive;
+                delete Sat_CoeffsE;
                 return finalv;
             }
 

--- a/plugins/eos_support/eos/instruments/modis/calibrator/modis_calibrator_utils.cpp
+++ b/plugins/eos_support/eos/instruments/modis/calibrator/modis_calibrator_utils.cpp
@@ -50,6 +50,12 @@ namespace eos
                         goto skip_scan;
                     if (!d_vars[scan].contains("inst_temp"))
                         goto skip_scan;
+                    if (!d_vars[scan].contains("inst_temp"))
+                        goto skip_scan;
+                    if (!d_vars[scan].contains("fp_temp"))
+                        goto skip_scan;
+                    if (!d_vars[scan].contains("fp_temp_info"))
+                        goto skip_scan;
 
                     scaninfo.MS = d_vars[scan]["mirror_side"];                    // Mirror side
                     scaninfo.T_bb = get_bb_temperature(d_vars, is_aqua, scan);    // BB Temperature

--- a/plugins/eos_support/eos/instruments/modis/calibrator/modis_emiss_table.h
+++ b/plugins/eos_support/eos/instruments/modis/calibrator/modis_emiss_table.h
@@ -47,11 +47,15 @@ inline void from_json(const nlohmann::json &j, Coefficients_Emissive &v)
     memcpy(v.delta_T_bb_beta, j["delta_T_bb_beta"].get<std::vector<float>>().data(), NUM_EMISSIVE_DETECTORS * sizeof(float));
     memcpy(v.delta_T_bb_delta, j["delta_T_bb_delta"].get<std::vector<float>>().data(), NUM_EMISSIVE_DETECTORS * sizeof(float));
 
-    memcpy(v.RSR_AQUA, j["RSR"].get<std::vector<float>>().data(), NUM_EMISSIVE_DETECTORS * MAX_NUM_RSR_vs_LAMBDA_AQUA * sizeof(float));
-    memcpy(v.WAVELENGTH_AQUA, j["WAVELENGTH"].get<std::vector<float>>().data(), NUM_EMISSIVE_DETECTORS * MAX_NUM_RSR_vs_LAMBDA_AQUA * sizeof(float));
+    if(j["RSR"].get<std::vector<float>>().size() == NUM_EMISSIVE_DETECTORS * MAX_NUM_RSR_vs_LAMBDA_AQUA)
+        memcpy(v.RSR_AQUA, j["RSR"].get<std::vector<float>>().data(), NUM_EMISSIVE_DETECTORS * MAX_NUM_RSR_vs_LAMBDA_AQUA * sizeof(float));
+    if(j["WAVELENGTH"].get<std::vector<float>>().size() == NUM_EMISSIVE_DETECTORS * MAX_NUM_RSR_vs_LAMBDA_AQUA)
+        memcpy(v.WAVELENGTH_AQUA, j["WAVELENGTH"].get<std::vector<float>>().data(), NUM_EMISSIVE_DETECTORS * MAX_NUM_RSR_vs_LAMBDA_AQUA * sizeof(float));
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    memcpy(v.RSR_TERRA, j["RSR"].get<std::vector<float>>().data(), NUM_EMISSIVE_DETECTORS * MAX_NUM_RSR_vs_LAMBDA_TERRA * sizeof(float));
-    memcpy(v.WAVELENGTH_TERRA, j["WAVELENGTH"].get<std::vector<float>>().data(), NUM_EMISSIVE_DETECTORS * MAX_NUM_RSR_vs_LAMBDA_TERRA * sizeof(float));
+    if(j["RSR"].get<std::vector<float>>().size() == NUM_EMISSIVE_DETECTORS * MAX_NUM_RSR_vs_LAMBDA_TERRA)
+        memcpy(v.RSR_TERRA, j["RSR"].get<std::vector<float>>().data(), NUM_EMISSIVE_DETECTORS * MAX_NUM_RSR_vs_LAMBDA_TERRA * sizeof(float));
+    if (j["WAVELENGTH"].get<std::vector<float>>().size() == NUM_EMISSIVE_DETECTORS * MAX_NUM_RSR_vs_LAMBDA_TERRA)
+        memcpy(v.WAVELENGTH_TERRA, j["WAVELENGTH"].get<std::vector<float>>().data(), NUM_EMISSIVE_DETECTORS * MAX_NUM_RSR_vs_LAMBDA_TERRA * sizeof(float));
 
     memcpy(v.A0, j["A0"].get<std::vector<float>>().data(), NUM_a0_vs_T_inst_COEFF * NUM_MIRROR_SIDES * NUM_EMISSIVE_DETECTORS * sizeof(float));
     memcpy(v.A2, j["A2"].get<std::vector<float>>().data(), NUM_a2_vs_T_inst_COEFF * NUM_MIRROR_SIDES * NUM_EMISSIVE_DETECTORS * sizeof(float));


### PR DESCRIPTION
- Move some of the MODIS calibration data to the heap. Over 3MB was going on the stack, which is too much for Windows (and, if compounded, would become a problem on Linux too). As a result, MODIS now works on Windows
- Fixed buffer overrun in `modis_emiss_table.h`
- Add missing checks into precomputeVars to prevent errors on scans missing data. Fixes additional issues in sample data from @RAD750 
- Ensure all members of `ValsPerScan` are initialized to prevent corrupt product.cbor files when some scans have missing data