### PR TITLE
Update CMakeList and build instructions for Apple Silicon Macs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,14 @@ if(APPLE)
     include_directories(/usr/local/Cellar/fftw/3.3.9/include)
     link_directories(/usr/local/lib)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
+
+    if(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
+        include_directories(/opt/homebrew/include/)
+        link_directories(/opt/homebrew/lib/)
+    endif()
+
 endif()
+
 
 if(UNIX)
     set(CMAKE_CXX_FLAGS "-Wall -Wextra")

--- a/README.md
+++ b/README.md
@@ -99,13 +99,22 @@ General build instructions (Brew and XCode command line tools required)
 # Install dependencies
 brew install cmake volk jpeg libpng glfw airspy rtl-sdr hackrf mbedtls pkg-config libomp dylibbundler portaudio
 
+# On Apple Silicon also run
+brew link --force libomp
+
 # Build and install libfftw3 to work around issue with brew version
 wget http://www.fftw.org/fftw-3.3.9.tar.gz
 tar xf fftw-3.3.9.tar.gz
 rm fftw-3.3.9.tar.gz
 cd fftw-3.3.9
 mkdir build && cd build
+
+# For Intel Macs
 cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=false -DENABLE_FLOAT=true -DENABLE_THREADS=true -DENABLE_SSE=true -DENABLE_SSE2=true -DENABLE_AVX=true -DENABLE_AVX2=true ..
+
+# For Apple Silicon Macs
+cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=false -DENABLE_FLOAT=true -DENABLE_THREADS=true -DENABLE_SSE=false -DENABLE_SSE2=false -DENABLE_AVX=false -DENABLE_AVX2=false ..
+
 make
 sudo make install
 cd ../..


### PR DESCRIPTION
I tested all of these changes on a MacBook Pro with an M3 Pro SOC running macOS 14 Sonoma and Xcode 15.

The main changes have been made to the include & link directories in homebrew.
Those seem to have moved to a new location on Apple Silicon Macs. On my older Intel machine the usual includes work just fine which is why these new changes are only applied on Apple Silicon Macs. 

The build instructions for fftw3 also had to be updated as the ARM SOCs do not support SSE or AVX, those are for x86 only. 

Otherwise no other changes are required as of now.