### PR TITLE
fix autogened cities overlay

### DIFF
--- a/src-core/common/overlay_handler.cpp
+++ b/src-core/common/overlay_handler.cpp
@@ -80,7 +80,8 @@ void OverlayHandler::apply(image::Image<uint16_t> &img, std::function<std::pair<
     // Draw cities points
     if (draw_cities_overlay)
     {
-        logger->info("Drawing map overlay...");
+        logger->info("Drawing cities overlay...");
+        img.init_font(resources::getResourcePath("fonts/font.ttf"));
         unsigned short color[4] = {(unsigned short)(color_cities.x * 65535.0f), (unsigned short)(color_cities.y * 65535.0f), (unsigned short)(color_cities.z * 65535.0f), 65535};
         map::drawProjectedCitiesGeoJson({resources::getResourcePath("maps/ne_10m_populated_places_simple.json")},
                                         img,


### PR DESCRIPTION
Added forgotten font initialization that caused cities to not appear in the final image.