### PR TITLE
Change 2 LUA composites

### DIFF
--- a/resources/scripted_compos/NightFire.lua
+++ b/resources/scripted_compos/NightFire.lua
@@ -10,9 +10,9 @@ function process()
     for y = 0, rgb_output:height() -1, 1 do
 
       -- set variables for each calibrated channel with their respective names
-      
-      local cch3b = get_calibrated_value(3, x, y, true)
-      local cch4 = get_calibrated_value(4, x, y, true)
+      get_channel_values(x, y)
+      local cch3b = get_channel_value(0) * 1000
+      local cch4 = get_channel_value(1) * 1000
       
       if cch3b > 305 then
         if cch4 > 280 then

--- a/resources/scripted_compos/NightFire.lua
+++ b/resources/scripted_compos/NightFire.lua
@@ -11,12 +11,12 @@ function process()
 
       -- set variables for each calibrated channel with their respective names
       get_channel_values(x, y)
-      local cch3b = get_channel_value(0) * 1000
-      local cch4 = get_channel_value(1) * 1000
+      local cch3b = get_channel_value(0)
+      local cch4 = get_channel_value(1)
       
-      if cch3b > 305 then
-        if cch4 > 280 then
-          if (cch3b-cch4) > 10 then
+      if cch3b > 0.305 then
+        if cch4 > 0.280 then
+          if (cch3b-cch4) > 0.01 then
             -- output as red and 100% opaque if the pixel passes the thresholds
             set_img_out(0, x, y, 1)
             set_img_out(3, x, y, 1)

--- a/resources/scripted_compos/ndwi.lua
+++ b/resources/scripted_compos/ndwi.lua
@@ -4,7 +4,7 @@ function init()
     --create an empty image for the LUT
     img_lut = image8.new()
     --load the LUT
-    img_lut:load_png(get_resource_path("lut/NDWI.png"))
+    img_lut:load_png(get_resource_path("lut/NDWI.png"), false)
     --return 3 channels, RGB
     return 3
 end
@@ -14,10 +14,9 @@ function process()
         for y = 0, rgb_output:height() - 1, 1 do
 
             --get channels from satdump.json
-
-            local cch2 = get_calibrated_value(1, x, y, true)
-            local cch3a = get_calibrated_value(2, x, y, true)
-            
+            get_channel_values(x, y)
+            local cch2 = get_channel_value(0) * 1000
+            local cch3a = get_channel_value(1) * 1000
             
             --perform NDWI
             local ndwi = (cch2-cch3a)/(cch2+cch3a)

--- a/resources/scripted_compos/ndwi.lua
+++ b/resources/scripted_compos/ndwi.lua
@@ -15,8 +15,8 @@ function process()
 
             --get channels from satdump.json
             get_channel_values(x, y)
-            local cch2 = get_channel_value(0) * 1000
-            local cch3a = get_channel_value(1) * 1000
+            local cch2 = get_channel_value(0)
+            local cch3a = get_channel_value(1)
             
             --perform NDWI
             local ndwi = (cch2-cch3a)/(cch2+cch3a)


### PR DESCRIPTION
Standardize LUA scripts to not use get_calibrated_value since it causes issues when channel counts are different on different downlinks (ie APT and HRPT)

Fixes Nighttime fire detection for APT