### PR TITLE
Docker: change build options, control parallel build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ ARG DEBIAN_IMAGE_TAG=bookworm
 FROM debian:${DEBIAN_IMAGE_TAG} AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG CMAKE_BUILD_PARALLEL_LEVEL
 ENV TZ=Etc/UTC
 
 WORKDIR /usr/local/src/
@@ -15,11 +16,13 @@ WORKDIR /usr/local/src/satdump
 COPY . .
 
 RUN cmake -B build \
-          -DCMAKE_INSTALL_PREFIX=/target/usr \
+          -DCMAKE_STAGING_PREFIX=/target/usr \
+          -DCMAKE_INSTALL_PREFIX=/usr \
           -DCMAKE_BUILD_TYPE=Release \
           -DBUILD_GUI=OFF \
-          -DBUILD_TOOLS=OFF &&\
-    cmake --build build --target install # -- -j$(nproc)
+          -DPLUGIN_SCRIPTING=ON \
+          -DBUILD_TOOLS=ON &&\
+    cmake --build build --target install
 
 
 ARG DEBIAN_IMAGE_TAG=bookworm


### PR DESCRIPTION
Build with 8 cores, add: --build-arg CMAKE_BUILD_PARALLEL_LEVEL=8
The CMAKE_STAGING_PREFIX better matches the cross compiling style to the multistage