### PR TITLE
stop sample loss on low power hardware

### DIFF
--- a/plugins/sdr_sources/rtlsdr_sdr_support/rtlsdr_sdr.h
+++ b/plugins/sdr_sources/rtlsdr_sdr_support/rtlsdr_sdr.h
@@ -35,7 +35,7 @@ protected:
 
     void mainThread()
     {
-        int buffer_size = std::min<int>(roundf(samplerate_widget.get_value() / (250 * 512)) * 512, dsp::STREAM_BUFFER_SIZE);
+        int buffer_size = 16384;
 
         while (thread_should_run)
         {

--- a/src-core/modules/demod/module_demod_base.h
+++ b/src-core/modules/demod/module_demod_base.h
@@ -63,7 +63,7 @@ namespace demod
 
         // Min/Max sample per symbol the demodulator will accept before resampling the input
         float MIN_SPS = 1.1;
-        float MAX_SPS = 4.0;
+        float MAX_SPS = 3.0;
         bool resample = false;
 
         std::ofstream data_out;


### PR DESCRIPTION
As discussed in https://github.com/SatDump/SatDump/issues/600 I noticed that Satdump V1.x wasn't working properly with Elektro-L on the Orange Pi 5, but Satdump 0.0.39 worked fine (actually 1.0.0-alpha works fine too). On other more powerful x64 any version worked fine.

I traced the problem back to two commits. First 9f18f56b9c95462cba574b6f4829ef844f774dfd where the MAX_SPS value was increased, and secondly to eb4b831f62448a1823a30c0b18dab0e15b83e52c where the rtlsdr_read_async buffer size was changed.

Changing these two values back to what they were before fixes the sample drop issues I'm seeing, and I'm now able to get perfect images on the latest code.