### PR TITLE
Add support for SDRPlay RSP1B

### DIFF
--- a/plugins/sdr_sources/sdrplay_sdr_support/sdrplay_sdr.cpp
+++ b/plugins/sdr_sources/sdrplay_sdr_support/sdrplay_sdr.cpp
@@ -40,7 +40,7 @@ void SDRPlaySource::set_bias()
     if (!is_started)
         return;
 
-    if (sdrplay_dev.hwVer == SDRPLAY_RSP1A_ID) // RSP1A
+    if (sdrplay_dev.hwVer == SDRPLAY_RSP1A_ID || sdrplay_dev.hwVer == SDRPLAY_RSP1B_ID) // RSP1A or RSP1B
     {
         channel_params->rsp1aTunerParams.biasTEnable = bias;
         sdrplay_api_Update(sdrplay_dev.dev, sdrplay_dev.tuner, sdrplay_api_Update_Rsp1a_BiasTControl, sdrplay_api_Update_Ext1_None);
@@ -83,7 +83,7 @@ void SDRPlaySource::set_others()
     if (!is_started)
         return;
 
-    if (sdrplay_dev.hwVer == SDRPLAY_RSP1A_ID) // RSP1A
+    if (sdrplay_dev.hwVer == SDRPLAY_RSP1A_ID || sdrplay_dev.hwVer == SDRPLAY_RSP1B_ID) // RSP1A or RSP1B
     {
         dev_params->devParams->rsp1aParams.rfNotchEnable = fm_notch;
         dev_params->devParams->rsp1aParams.rfDabNotchEnable = dab_notch;
@@ -213,7 +213,7 @@ void SDRPlaySource::open()
     // Set max gain
     if (sdrplay_dev.hwVer == SDRPLAY_RSP1_ID) // RSP1
         max_gain = 4;
-    else if (sdrplay_dev.hwVer == SDRPLAY_RSP1A_ID) // RSP1A
+    else if (sdrplay_dev.hwVer == SDRPLAY_RSP1A_ID || sdrplay_dev.hwVer == SDRPLAY_RSP1B_ID) // RSP1A or RSP1B
         max_gain = 10;
     else if (sdrplay_dev.hwVer == SDRPLAY_RSP2_ID) // RSP2
         max_gain = 9;
@@ -359,7 +359,7 @@ void SDRPlaySource::drawControlUI()
         set_agcs();
 
     // RSP1A-specific settings
-    if (sdrplay_dev.hwVer == SDRPLAY_RSP1A_ID)
+    if (sdrplay_dev.hwVer == SDRPLAY_RSP1A_ID || sdrplay_dev.hwVer == SDRPLAY_RSP1B_ID)
     {
         if (RImGui::Checkbox("FM Notch", &fm_notch))
             set_others();
@@ -457,6 +457,8 @@ std::vector<dsp::SourceDescriptor> SDRPlaySource::getAvailableSources()
             results.push_back({"sdrplay", "RSP1 " + ss.str(), i});
         else if (devices_addresses[i].hwVer == SDRPLAY_RSP1A_ID)
             results.push_back({"sdrplay", "RSP1A " + ss.str(), i});
+        else if (devices_addresses[i].hwVer == SDRPLAY_RSP1B_ID)
+            results.push_back({"sdrplay", "RSP1B " + ss.str(), i});
         else if (devices_addresses[i].hwVer == SDRPLAY_RSP2_ID)
             results.push_back({"sdrplay", "RSP2 " + ss.str(), i});
         else if (devices_addresses[i].hwVer == SDRPLAY_RSPduo_ID)

--- a/plugins/sdr_sources/sdrplay_sdr_support/sdrplay_sdr.h
+++ b/plugins/sdr_sources/sdrplay_sdr_support/sdrplay_sdr.h
@@ -6,6 +6,11 @@
 #include "common/rimgui.h"
 #include "common/widgets/double_list.h"
 
+// define HW id for RSP1B if it's not available in older version of SDRPlay API
+#ifndef SDRPLAY_RSP1B_ID
+#define SDRPLAY_RSP1B_ID                      (6)
+#endif
+
 class SDRPlaySource : public dsp::DSPSampleSource
 {
 protected:


### PR DESCRIPTION
Hi,
This adds support for SDRplay's RSP1B. According to the website, it is an enhanced hardware revision of RSP1A (https://www.sdrplay.com/rsp1b/).
For this reason, I've just added the RSP1B hardware id wherever A was used (except for the name in the UI).

It works for me with SDRplay API v3.14.0 (on MacOS 14.2.1, Intel), which aded support for RSP1B. The device is detected correctly and I can use the radio, just I didn't have a chance to get outside and test an actual reception with it.

Note: The application build requires to manually set  DYLD_LIBRARY path when launching, i.e. `DYLD_LIBRARY_PATH="/Library/SDRplayAPI/3.14.0/lib/" ./satdump-ui`

Looking at the linked SDRplay plugin: It seems odd the libsdrplay_api is linked with a relative path only. 
```
ebirn@oldboy SatDump % otool -L plugins/libsdrplay_sdr_support.dylib  
plugins/libsdrplay_sdr_support.dylib:
	@rpath/libsdrplay_sdr_support.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/local/opt/jemalloc/lib/libjemalloc.2.dylib (compatibility version 0.0.0, current version 0.0.0)
	@rpath/libsatdump_core.dylib (compatibility version 0.0.0, current version 0.0.0)
-->	libsdrplay_api.so.3.14 (compatibility version 0.0.0, current version 0.0.0)
	/System/Library/Frameworks/OpenCL.framework/Versions/A/OpenCL (compatibility version 1.0.0, current version 1.0.0)
	/usr/local/opt/libomp/lib/libomp.dylib (compatibility version 5.0.0, current version 5.0.0)
	/usr/local/opt/volk/lib/libvolk.3.1.dylib (compatibility version 3.1.0, current version 3.1.1)
	/usr/local/opt/libpng/lib/libpng16.16.dylib (compatibility version 58.0.0, current version 58.0.0)
	/usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.12)
	@rpath/libfftw3f.3.6.9.dylib (compatibility version 3.6.9, current version 3.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1336.61.1)
	/usr/local/opt/nng/lib/libnng.1.dylib (compatibility version 1.0.0, current version 1.7.2)
	/usr/local/opt/zstd/lib/libzstd.1.dylib (compatibility version 1.0.0, current version 1.5.5)
	/usr/local/opt/armadillo/lib/libarmadillo.12.dylib (compatibility version 12.0.0, current version 12.8.0)
	/System/Library/Frameworks/CoreGraphics.framework/Versions/A/CoreGraphics (compatibility version 64.0.0, current version 1774.2.3)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1600.157.0)
```

The libs are installed in both `/Library` and `/usr/local/lib/`. It's not clear to me why it is not picked up automatically at runtime. I have this with other software too, so I'm not sure this is related to SatDump.