### PR TITLE
Inmarsat UDP : Update station_id formatting and send SatDump Version

### DIFF
--- a/plugins/inmarsat_support/aero/module_aero_parser.cpp
+++ b/plugins/inmarsat_support/aero/module_aero_parser.cpp
@@ -85,7 +85,10 @@ namespace inmarsat
                     {
                         nlohmann::json msg2 = msg;
                         if (d_station_id != "")
-                            msg2["station_id"] = d_station_id;
+                            msg2["source"]["station_id"] = d_station_id;
+                        
+                        msg2["source"]["app"]["name"] = "SatDump";
+                        msg2["source"]["app"]["version"] = (std::string)SATDUMP_VERSION;
                         std::string m = msg2.dump();
                         c->send((uint8_t *)m.data(), m.size());
                     }

--- a/plugins/inmarsat_support/aero/module_aero_parser.cpp
+++ b/plugins/inmarsat_support/aero/module_aero_parser.cpp
@@ -84,11 +84,12 @@ namespace inmarsat
                     try
                     {
                         nlohmann::json msg2 = msg;
-                        if (d_station_id != "")
+                        if (d_station_id != ""){
                             msg2["source"]["station_id"] = d_station_id;
+                            msg2["source"]["app"]["name"] = "SatDump";
+                            msg2["source"]["app"]["version"] = (std::string)SATDUMP_VERSION;
+                        }
                         
-                        msg2["source"]["app"]["name"] = "SatDump";
-                        msg2["source"]["app"]["version"] = (std::string)SATDUMP_VERSION;
                         std::string m = msg2.dump();
                         c->send((uint8_t *)m.data(), m.size());
                     }

--- a/plugins/inmarsat_support/stdc/module_stdc_parser.cpp
+++ b/plugins/inmarsat_support/stdc/module_stdc_parser.cpp
@@ -69,7 +69,10 @@ namespace inmarsat
                     {
                         nlohmann::json msg2 = msg;
                         if (d_station_id != "")
-                            msg2["station_id"] = d_station_id;
+                            msg2["source"]["station_id"] = d_station_id;
+                        
+                        msg2["source"]["app"]["name"] = "SatDump";
+                        msg2["source"]["app"]["version"] = (std::string)SATDUMP_VERSION;
                         std::string m = msg2.dump();
                         c->send((uint8_t *)m.data(), m.size());
                     }

--- a/plugins/inmarsat_support/stdc/module_stdc_parser.cpp
+++ b/plugins/inmarsat_support/stdc/module_stdc_parser.cpp
@@ -68,11 +68,12 @@ namespace inmarsat
                     try
                     {
                         nlohmann::json msg2 = msg;
-                        if (d_station_id != "")
+                        if (d_station_id != ""){
                             msg2["source"]["station_id"] = d_station_id;
+                            msg2["source"]["app"]["name"] = "SatDump";
+                            msg2["source"]["app"]["version"] = (std::string)SATDUMP_VERSION;
+                        }
                         
-                        msg2["source"]["app"]["name"] = "SatDump";
-                        msg2["source"]["app"]["version"] = (std::string)SATDUMP_VERSION;
                         std::string m = msg2.dump();
                         c->send((uint8_t *)m.data(), m.size());
                     }


### PR DESCRIPTION
Just a small change to the JSON structure for the station_id when being sent via UDP. As well as sending along the program name and version to make it more identifiable when being ingested.