### PR TITLE
Composite improvements

### DIFF
--- a/resources/scripted_compos/underlay_with_clouds.lua
+++ b/resources/scripted_compos/underlay_with_clouds.lua
@@ -26,14 +26,7 @@ function process()
     height = rgb_output:height()
     background_size = img_background:width() * img_background:height()
 
-    ch_equal = image16.new(width, height, 1)
-    for x = 0, width - 1, 1 do
-        for y = 0, height - 1, 1 do
-            get_channel_values(x, y)
-            ch_equal:set((y * width) + x, get_channel_value(0) * 65535.0)
-        end
-        set_progress(x, width)
-    end
+    ch_equal = get_channel_image(0)
     ch_equal:equalize()
 
     pos = geodetic_coords_t.new()

--- a/satdump_cfg.json
+++ b/satdump_cfg.json
@@ -993,9 +993,9 @@
                         "lua": "scripted_compos/underlay_with_clouds_lut.lua",
                         "description": "descriptions/MCIR_precip.md",
                         "lua_vars": {
-                            "minoffset": 0.25,
-                            "scalar": 1.5,
-                            "thresold": 0,
+                            "minoffset": 0.21,
+                            "scalar": 1,
+                            "thresold": 0.8,
                             "lut": "lut/WXtoImg-NO_mod_APT.png"
                         },
                         "draw_map_overlay": true,
@@ -1244,7 +1244,7 @@
                     "MSA": {
                         "channels": "ch1",
                         "lua": "scripted_compos/underlay_with_clouds.lua",
-                        "description": "descriptions/MCIR.md",
+                        "description": "descriptions/MSA.md",
                         "lua_vars": {
                             "minoffset": 0,
                             "scalar": 1,

--- a/satdump_cfg.json
+++ b/satdump_cfg.json
@@ -1241,6 +1241,24 @@
                             0
                         ]
                     },
+                    "MSA": {
+                        "channels": "ch1",
+                        "lua": "scripted_compos/underlay_with_clouds.lua",
+                        "description": "descriptions/MCIR.md",
+                        "lua_vars": {
+                            "minoffset": 0,
+                            "scalar": 1,
+                            "thresold": 0,
+                            "blend": 1,
+                            "invert": 0
+                        },
+                        "draw_map_overlay": true,
+                        "borders_color": [
+                            1,
+                            1,
+                            0
+                        ]
+                    },
                     "Channel 4 Equalized": {
                         "equation": "1 - ch4",
                         "individual_equalize": true,

--- a/satdump_cfg.json
+++ b/satdump_cfg.json
@@ -556,8 +556,8 @@
                         "lua": "scripted_compos/underlay_with_clouds.lua",
                         "description": "descriptions/CloudUnderlay.md",
                         "lua_vars": {
-                            "minoffset": 0.4,
-                            "scalar": 4.0,
+                            "minoffset": 0,
+                            "scalar": 1.5,
                             "thresold": 0,
                             "blend": 0,
                             "invert": 0
@@ -569,8 +569,8 @@
                         "lua": "scripted_compos/underlay_with_clouds.lua",
                         "description": "descriptions/CloudUnderlay.md",
                         "lua_vars": {
-                            "minoffset": 0.58,
-                            "scalar": 4.0,
+                            "minoffset": 0,
+                            "scalar": 1.5,
                             "thresold": 0.15,
                             "blend": 0,
                             "invert": 0
@@ -581,10 +581,9 @@
                         "channels": "cch4",
                         "lua": "scripted_compos/underlay_with_clouds.lua",
                         "description": "descriptions/MCIR.md",
-                        "equalize": true,
                         "lua_vars": {
-                            "minoffset": 0.05,
-                            "scalar": 1.1,
+                            "minoffset": 0,
+                            "scalar": 1,
                             "thresold": 0,
                             "blend": 1,
                             "invert": 1
@@ -600,11 +599,10 @@
                         "channels": "cch1",
                         "lua": "scripted_compos/underlay_with_clouds.lua",
                         "description": "descriptions/MSA.md",
-                        "equalize": true,
                         "geo_correct": true,
                         "lua_vars": {
-                            "minoffset": -0.29,
-                            "scalar": 2.0,
+                            "minoffset": 0,
+                            "scalar": 0.95,
                             "thresold": 0,
                             "blend": 1,
                             "invert": 0
@@ -620,11 +618,10 @@
                         "channels": "cch2",
                         "lua": "scripted_compos/underlay_with_clouds.lua",
                         "description": "descriptions/MSA.md",
-                        "equalize": true,
                         "geo_correct": true,
                         "lua_vars": {
-                            "minoffset": -0.15,
-                            "scalar": 2.0,
+                            "minoffset": 0,
+                            "scalar": 0.95,
                             "thresold": 0,
                             "blend": 1,
                             "invert": 0
@@ -960,8 +957,8 @@
                         "lua": "scripted_compos/underlay_with_clouds.lua",
                         "description": "descriptions/MCIR.md",
                         "lua_vars": {
-                            "minoffset": 0.35,
-                            "scalar": 2.5,
+                            "minoffset": 0,
+                            "scalar": 1,
                             "thresold": 0,
                             "blend": 1,
                             "invert": 0
@@ -978,8 +975,8 @@
                         "lua": "scripted_compos/underlay_with_clouds.lua",
                         "description": "descriptions/MSA.md",
                         "lua_vars": {
-                            "minoffset": 0.02,
-                            "scalar": 2.0,
+                            "minoffset": 0,
+                            "scalar": 0.95,
                             "thresold": 0,
                             "blend": 1,
                             "invert": 0
@@ -1230,10 +1227,9 @@
                         "channels": "ch4",
                         "lua": "scripted_compos/underlay_with_clouds.lua",
                         "description": "descriptions/MCIR.md",
-                        "equalize": true,
                         "lua_vars": {
-                            "minoffset": 0.45,
-                            "scalar": 2.6,
+                            "minoffset": 0,
+                            "scalar": 1,
                             "thresold": 0,
                             "blend": 1,
                             "invert": 1

--- a/src-core/common/image/composite.cpp
+++ b/src-core/common/image/composite.cpp
@@ -105,7 +105,7 @@ namespace image
 
     // Generate a composite from channels and an equation
     template <typename T>
-    Image<T> generate_composite_from_equ(std::vector<Image<T>> inputChannels, std::vector<std::string> channelNumbers, std::string equation, nlohmann::json offsets_cfg, float *progress)
+    Image<T> generate_composite_from_equ(std::vector<Image<T>> &inputChannels, std::vector<std::string> channelNumbers, std::string equation, nlohmann::json offsets_cfg, float *progress)
     {
         // Equation parsing stuff
         mu::Parser rgbParser;
@@ -207,12 +207,12 @@ namespace image
         return rgb_output;
     }
 
-    template Image<uint8_t> generate_composite_from_equ<uint8_t>(std::vector<Image<uint8_t>>, std::vector<std::string>, std::string, nlohmann::json, float *);
-    template Image<uint16_t> generate_composite_from_equ<uint16_t>(std::vector<Image<uint16_t>>, std::vector<std::string>, std::string, nlohmann::json, float *);
+    template Image<uint8_t> generate_composite_from_equ<uint8_t>(std::vector<Image<uint8_t>>&, std::vector<std::string>, std::string, nlohmann::json, float *);
+    template Image<uint16_t> generate_composite_from_equ<uint16_t>(std::vector<Image<uint16_t>>&, std::vector<std::string>, std::string, nlohmann::json, float *);
 
     // Generate a composite from channels and a LUT
     template <typename T>
-    Image<T> generate_composite_from_lut(std::vector<Image<T>> inputChannels, std::vector<std::string> channelNumbers, std::string lut_path, nlohmann::json offsets_cfg, float *progress)
+    Image<T> generate_composite_from_lut(std::vector<Image<T>> &inputChannels, std::vector<std::string> channelNumbers, std::string lut_path, nlohmann::json offsets_cfg, float *progress)
     {
         Image<T> lut;
         lut.load_png(lut_path);
@@ -272,8 +272,8 @@ namespace image
         return rgb_output;
     }
 
-    template Image<uint8_t> generate_composite_from_lut<uint8_t>(std::vector<Image<uint8_t>>, std::vector<std::string>, std::string, nlohmann::json, float *);
-    template Image<uint16_t> generate_composite_from_lut<uint16_t>(std::vector<Image<uint16_t>>, std::vector<std::string>, std::string, nlohmann::json, float *);
+    template Image<uint8_t> generate_composite_from_lut<uint8_t>(std::vector<Image<uint8_t>>&, std::vector<std::string>, std::string, nlohmann::json, float *);
+    template Image<uint16_t> generate_composite_from_lut<uint16_t>(std::vector<Image<uint16_t>>&, std::vector<std::string>, std::string, nlohmann::json, float *);
 
     void bindCompoCfgType(sol::state &lua)
     {
@@ -290,7 +290,7 @@ namespace image
 
     // Generate a composite from channels and a Lua script
     template <typename T>
-    Image<T> generate_composite_from_lua(satdump::ImageProducts *img_pro, std::vector<Image<T>> inputChannels, std::vector<std::string> channelNumbers, std::string lua_path, nlohmann::json lua_vars, nlohmann::json offsets_cfg, std::vector<double> *final_timestamps, float *progress)
+    Image<T> generate_composite_from_lua(satdump::ImageProducts *img_pro, std::vector<Image<T>> &inputChannels, std::vector<std::string> channelNumbers, std::string lua_path, nlohmann::json lua_vars, nlohmann::json offsets_cfg, std::vector<double> *final_timestamps, float *progress)
     {
         compo_cfg_t f = get_compo_cfg(inputChannels, /*channelNumbers, */ offsets_cfg);
 
@@ -378,6 +378,6 @@ namespace image
         return rgb_output;
     }
 
-    template Image<uint8_t> generate_composite_from_lua<uint8_t>(satdump::ImageProducts *, std::vector<Image<uint8_t>>, std::vector<std::string>, std::string, nlohmann::json, nlohmann::json, std::vector<double> *, float *);
-    template Image<uint16_t> generate_composite_from_lua<uint16_t>(satdump::ImageProducts *, std::vector<Image<uint16_t>>, std::vector<std::string>, std::string, nlohmann::json, nlohmann::json, std::vector<double> *, float *);
+    template Image<uint8_t> generate_composite_from_lua<uint8_t>(satdump::ImageProducts *, std::vector<Image<uint8_t>>&, std::vector<std::string>, std::string, nlohmann::json, nlohmann::json, std::vector<double> *, float *);
+    template Image<uint16_t> generate_composite_from_lua<uint16_t>(satdump::ImageProducts *, std::vector<Image<uint16_t>>&, std::vector<std::string>, std::string, nlohmann::json, nlohmann::json, std::vector<double> *, float *);
 }

--- a/src-core/common/image/composite.cpp
+++ b/src-core/common/image/composite.cpp
@@ -347,6 +347,8 @@ namespace image
             { return channelValues[x]; };
             lua["get_channel_values"] = [channelValues, &inputChannels, &channelNumbers, &f](size_t x, size_t y)
             { get_channel_vals(channelValues, inputChannels, channelNumbers, f, y, x); };
+            lua["get_channel_image"] = [&inputChannels](int ch)
+            { return inputChannels[ch]; };
             lua["get_calibrated_image"] = [img_pro](int ch, std::string type, float min, float max)
             { 
                 satdump::ImageProducts::calib_vtype_t ctype = satdump::ImageProducts::CALIB_VTYPE_AUTO;

--- a/src-core/common/image/composite.h
+++ b/src-core/common/image/composite.h
@@ -10,13 +10,13 @@ namespace image
 {
     // Generate a composite from channels and an equation
     template <typename T>
-    Image<T> generate_composite_from_equ(std::vector<Image<T>> inputChannels, std::vector<std::string> channelNumbers, std::string equation, nlohmann::json offsets_cfg, float *progress = nullptr);
+    Image<T> generate_composite_from_equ(std::vector<Image<T>> &inputChannels, std::vector<std::string> channelNumbers, std::string equation, nlohmann::json offsets_cfg, float *progress = nullptr);
 
     // Generate a composite from channels and a LUT
     template <typename T>
-    Image<T> generate_composite_from_lut(std::vector<Image<T>> inputChannels, std::vector<std::string> channelNumbers, std::string lut_path, nlohmann::json offsets_cfg, float *progress = nullptr);
+    Image<T> generate_composite_from_lut(std::vector<Image<T>> &inputChannels, std::vector<std::string> channelNumbers, std::string lut_path, nlohmann::json offsets_cfg, float *progress = nullptr);
 
     // Generate a composite from channels and a Lua script
     template <typename T>
-    Image<T> generate_composite_from_lua(satdump::ImageProducts *img_pro, std::vector<Image<T>> inputChannels, std::vector<std::string> channelNumbers, std::string lua_path, nlohmann::json lua_vars, nlohmann::json offsets_cfg, std::vector<double> *final_timestamps = nullptr, float *progress = nullptr);
+    Image<T> generate_composite_from_lua(satdump::ImageProducts *img_pro, std::vector<Image<T>> &inputChannels, std::vector<std::string> channelNumbers, std::string lua_path, nlohmann::json lua_vars, nlohmann::json offsets_cfg, std::vector<double> *final_timestamps = nullptr, float *progress = nullptr);
 }


### PR DESCRIPTION
- Add `get_channel_image(int)` function to Lua to get a copy of the channel specified in the config, as an object. You can call `:equalize()`, `:white_balance()`, etc on this object within Lua
- MCIR/MSA/etc: equalize source before compositing for a more reliable result; re-balanced tuning for new algorithm
- Add MSA for MSU-MR
- Slight memory reduction when making composites