### PR TITLE
Remove deprecated Encoding and add Main Category

### DIFF
--- a/satdump.appdata.xml
+++ b/satdump.appdata.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>org.satdump.satdump</id>
+  
+  <name>satdump</name>
+  <summary>SatDump is a general purpose satellite data processing software</summary>
+  
+  <metadata_license>FSFAP</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  
+  <description>
+    <p>
+      A one-stop-shop that provides all the necessary stages to get from the satellite transmission to actual products.
+    </p>
+  </description>
+  
+  <launchable type="desktop-id">satdump.desktop</launchable>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://www.satdump.org/assets/release_110/SatDump_autotrack.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://github.com/SatDump/SatDump/blob/master/gui_recording.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://github.com/SatDump/SatDump/blob/master/cli_example.png</image>
+    </screenshot>
+  </screenshots>
+</component>

--- a/satdump.desktop
+++ b/satdump.desktop
@@ -1,5 +1,4 @@
 [Desktop Entry]
-Encoding=UTF-8
 Version=1.0
 Type=Application
 Terminal=false
@@ -7,4 +6,4 @@ Exec=@CMAKE_INSTALL_PREFIX@/bin/satdump-ui
 Name=SatDump
 Icon=@CMAKE_INSTALL_PREFIX@/share/satdump/icon.png
 StartupWMClass=SatDump v@SATDUMP_VERSION@
-Categories=HamRadio
+Categories=Science;HamRadio


### PR DESCRIPTION
According freedesktop.org "Encoding" key is deprecated and should be removed. Also there should be at least one Main Category.