### PR TITLE
APT Improvements

### DIFF
--- a/pipelines/NOAA.json
+++ b/pipelines/NOAA.json
@@ -259,7 +259,8 @@
                 "noaa_apt_decoder": {
                     "audio_samplerate": 50e3,
                     "max_crop_stddev": 3500,
-                    "save_unsynced": true
+                    "save_unsynced": true,
+                    "align_timestamps": true
                 }
             }
         }

--- a/plugins/analog_support/noaa_apt/module_noaa_apt_decoder.cpp
+++ b/plugins/analog_support/noaa_apt/module_noaa_apt_decoder.cpp
@@ -788,16 +788,24 @@ namespace noaa_apt
             cha = wip_apt_image.crop_to(86, 86 + 909);
             chb = wip_apt_image.crop_to(1126, 1126 + 909);
 
+            // Fixup "bleed" of telemetry wedges on right edge
+            // TODO: Find a better way to do this...
+            for (size_t y = 0; y < cha.height(); y++)
+            {
+                cha[y * 909 + 908] = (float)cha[y * 909 + 908] * 0.25f + (float)cha[y * 909 + 907] * 0.75f;
+                chb[y * 909 + 908] = (float)chb[y * 909 + 908] * 0.25f + (float)chb[y * 909 + 907] * 0.75f;
+            }
+
             if (channel_a1 != -1)
             {
                 cha1 = image::Image<uint16_t>(cha);
                 cha2 = image::Image<uint16_t>(cha);
-                for (unsigned int i = switchy; i < cha2.height(); i++)
-                    for (unsigned int x = 0; x < cha2.width(); x++)
+                for (size_t i = switchy; i < cha2.height(); i++)
+                    for (size_t x = 0; x < cha2.width(); x++)
                         cha2[i * cha2.width() + x] = 0;
 
                 for (int i = 0; i < switchy; i++)
-                    for (unsigned int x = 0; x < cha1.width(); x++)
+                    for (size_t x = 0; x < cha1.width(); x++)
                         cha1[i * cha1.width() + x] = 0;
             }
 

--- a/plugins/analog_support/noaa_apt/module_noaa_apt_decoder.cpp
+++ b/plugins/analog_support/noaa_apt/module_noaa_apt_decoder.cpp
@@ -335,8 +335,8 @@ namespace noaa_apt
             new_white = (new_white + new_white1) / 2;
             new_black = (new_black + new_black1) / 2;
 
-            for (size_t l = 0; l < line_cnt; l++)    // Calib image
-                for (size_t x = 0; x < APT_IMG_WIDTH; x++) // for (int x = 86; x < 86 + 909; x++)
+            for (int l = 0; l < line_cnt; l++)    // Calib image
+                for (int x = 0; x < APT_IMG_WIDTH; x++) // for (int x = 86; x < 86 + 909; x++)
                     scale_val(wip_apt_image[l * APT_IMG_WIDTH + x], new_black, new_white);
 
             int valid_temp1 = 0, valid_temp2 = 0, valid_temp3 = 0, valid_temp4 = 0, valid_patch = 0,

--- a/plugins/analog_support/noaa_apt/module_noaa_apt_decoder.cpp
+++ b/plugins/analog_support/noaa_apt/module_noaa_apt_decoder.cpp
@@ -927,7 +927,7 @@ namespace noaa_apt
                         {
                             good_timing_lines = true;
                             for (size_t i = 0; i < timing_lines.size() - 1; i++)
-                                if (timing_lines[1] - timing_lines[0] != 120)
+                                if ((timing_lines[1] - timing_lines[0]) % 120 != 0)
                                     good_timing_lines = false;
                         }
                         if (good_timing_lines)

--- a/plugins/analog_support/noaa_apt/module_noaa_apt_decoder.cpp
+++ b/plugins/analog_support/noaa_apt/module_noaa_apt_decoder.cpp
@@ -537,7 +537,7 @@ namespace noaa_apt
                     double stddev = 0;
                     for (size_t i = 0; i < space_a1.width(); i++)
                         stddev += (space_a1[y * space_a1.width() + i] - avg) * (space_a1[y * space_a1.width() + i] - avg);
-                    stddev = sqrt(stddev / space_a1.width() - 1);
+                    stddev = sqrt(stddev / (space_a1.width() - 1));
                     scale_val(avg, new_black, new_white);
                     if (stddev < MAX_STDDEV_VALID && avg > stddev && avg < 65535.0 - stddev)
                     {
@@ -557,7 +557,7 @@ namespace noaa_apt
                 double stddev = 0;
                 for (size_t i = 0; i < space_a.width(); i++)
                     stddev += (space_a[y * space_a.width() + i] - avg) * (space_a[y * space_a.width() + i] - avg);
-                stddev = sqrt(stddev / space_a.width() - 1);
+                stddev = sqrt(stddev / (space_a.width() - 1));
                 scale_val(avg, new_black, new_white);
                 if (stddev < MAX_STDDEV_VALID && avg > stddev && avg < 65535.0 - stddev)
                 {
@@ -576,7 +576,7 @@ namespace noaa_apt
                 double stddev = 0;
                 for (size_t i = 0; i < space_b.width(); i++)
                     stddev += (space_b[y * space_b.width() + i] - avg) * (space_b[y * space_b.width() + i] - avg);
-                stddev = sqrt(stddev / space_b.width() - 1);
+                stddev = sqrt(stddev / (space_b.width() - 1));
                 scale_val(avg, new_black, new_white);
                 // logger->trace("Avg %f, StdDev %f", avg, stddev);
                 if (stddev < MAX_STDDEV_VALID)

--- a/plugins/analog_support/noaa_apt/module_noaa_apt_decoder.h
+++ b/plugins/analog_support/noaa_apt/module_noaa_apt_decoder.h
@@ -52,7 +52,8 @@ namespace noaa_apt
         long d_audio_samplerate;
         int d_max_crop_stddev = 3500;
         bool d_autocrop_wedges = false;
-        bool save_unsynced = true;
+        bool d_save_unsynced = true;
+        bool d_align_timestamps = true;
 
         std::shared_ptr<dsp::RealToComplexBlock> rtc;
         std::shared_ptr<dsp::FreqShiftBlock> frs;
@@ -66,7 +67,7 @@ namespace noaa_apt
         instrument_status_t apt_status = DECODING;
         bool has_to_update = false;
         unsigned int textureID = 0;
-        uint32_t *textureBuffer;
+        uint32_t *textureBuffer = nullptr;
 
         // Functions
         image::Image<uint16_t> synchronize(int line_cnt);

--- a/plugins/noaa_metop_support/noaa/module_noaa_instruments.cpp
+++ b/plugins/noaa_metop_support/noaa/module_noaa_instruments.cpp
@@ -222,6 +222,7 @@ namespace noaa
                     if (scid == 15) // NOAA-19
                         proj_settings = loadJsonFile(resources::getResourcePath("projections_settings/noaa_19_avhrr.json"));
 
+                    proj_settings.erase("apt_marker_offset");
                     if (is_gac)
                         proj_settings["image_width"] = 409;
 

--- a/resources/projections_settings/noaa_15_avhrr.json
+++ b/resources/projections_settings/noaa_15_avhrr.json
@@ -17,5 +17,7 @@
     ///////////////////////
     "corr_swath": 2900,
     "corr_resol": 1.1,
-    "corr_altit": 865
+    "corr_altit": 865,
+    ///////////////////////
+    "apt_marker_offset": -4.0
 }

--- a/resources/projections_settings/noaa_18_avhrr.json
+++ b/resources/projections_settings/noaa_18_avhrr.json
@@ -18,5 +18,7 @@
     "corr_width": 2048,
     "corr_swath": 2900,
     "corr_resol": 1.1,
-    "corr_altit": 865
+    "corr_altit": 865,
+    ///////////////////////
+    "apt_marker_offset": 13.0
 }

--- a/resources/projections_settings/noaa_19_avhrr.json
+++ b/resources/projections_settings/noaa_19_avhrr.json
@@ -18,5 +18,7 @@
     "corr_width": 2048,
     "corr_swath": 2900,
     "corr_resol": 1.1,
-    "corr_altit": 865
+    "corr_altit": 865,
+    ///////////////////////
+    "apt_marker_offset": -14.0
 }


### PR DESCRIPTION
- Fix scaled values, used for calibration, etc
- Switch space parsing over to use Standard Deviation, like everything else in APT.
- Fixed some bugs where the timing lines would be added into the space average instead of excluded
- Use timing lines to align passes to the correct time