### PR TITLE
Add WSL2 X11 option in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,8 @@ services:
 #        source: './srv'
 #        target: '/srv'
 #      - type: 'bind'  # for X11 usage
-#        source: '/tmp/.X11-unix'
+#        source: '/tmp/.X11-unix'  # on Linux
+#        source: '/run/desktop/mnt/host/wslg/.X11-unix'  # on Windows WSL2
 #        target: '/tmp/.X11-unix'
       - type: 'volume'  # persistent storage of configs
         source: 'satdump-config'


### PR DESCRIPTION
Confirmed to work on WSL 2.2.4.0 on Windows 11 Home 23H2