### PR TITLE
Change docker to user instead of root

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,3 +15,4 @@ vcpkg/
 .github
 .git
 docker-compose.yml
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ resources/gk2a/EncryptionKeyMessage.bin
 .directory
 vcpkg/
 srv/
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,3 +35,17 @@ RUN apt -y update && \
     rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local/src/satdump/build/satdump_*.deb /usr/local/src/
 RUN apt install /usr/local/src/satdump_*.deb
+
+# Add a user, possibility to map it to a user on the host to get the same uid & gid on files
+ARG HOST_UID=1000
+ARG HOST_GID=1000
+RUN groupadd -r -g ${HOST_GID} satdump && \
+	useradd -r -u ${HOST_UID} \
+            -g satdump \
+            -d /srv \
+            -s /bin/bash \
+            -G audio,dialout,plugdev \
+            -m \
+            satdump
+USER satdump
+WORKDIR /srv

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,15 @@ services:
   satdump:
     build:
       context: .
+      args:
+        # default values, override with .env
+        HOST_UID: ${HOST_UID:-1000}
+        HOST_GID: ${HOST_GID:-1000}
     image: satdump:latest
-    command: bash
+    command: ${COMMAND:-bash}
     init: true
     network_mode: host
-    working_dir: '/srv'
+    working_dir: ${WORKDIR:-/srv}
     environment:
       - DISPLAY=${DISPLAY:-:0}
     device_cgroup_rules:
@@ -16,18 +20,12 @@ services:
     volumes:
       - type: 'tmpfs'
         target: '/tmp'
-#      - type: 'bind'  # map working dir to host
-#        source: './srv'
-#        target: '/srv'
+      - type: 'bind'  # map working dir to host
+        source: './srv'
+        target: '/srv'
 #      - type: 'bind'  # for X11 usage
 #        source: '/tmp/.X11-unix'  # on Linux
 #        source: '/run/desktop/mnt/host/wslg/.X11-unix'  # on Windows WSL2
 #        target: '/tmp/.X11-unix'
-      - type: 'volume'  # persistent storage of configs
-        source: 'satdump-config'
-        target: '/root/.config/'
     restart: 'unless-stopped'
     stop_grace_period: 3s
-
-volumes:
-  satdump-config:


### PR DESCRIPTION
Added .env file to control build and running of container. 
Updated documentation.
Removed volume for settings, located in shared directory instead.