### PR TITLE
Better OLS RTD line frame sync

### DIFF
--- a/pipelines/DMSP.json
+++ b/pipelines/DMSP.json
@@ -19,6 +19,17 @@
             ]
         ],
         "parameters": {
+            "tag_bit_override": {
+                "type": "options",
+                "value": "VIS/IR",
+                "name": "Fine/Smooth channel configuration",
+                "options": [
+                    "VIS/IR",
+                    "IR/VIS",
+                    "Auto"
+                ],
+                "description": "Manual channel config setting.\nAuto detection can introduce\nextra errors."
+            },
             "satellite_number": {
                 "type": "options",
                 "value": "18",

--- a/plugins/dmsp_support/dmsp/instruments/ols/ols_rtd_reader.cpp
+++ b/plugins/dmsp_support/dmsp/instruments/ols/ols_rtd_reader.cpp
@@ -45,7 +45,7 @@ namespace dmsp
                 }
 
             }
-            if (alarm_match > 88)
+            if (alarm_match > 70)
             {
                 current_direction = (rtd_words[15] >> 2) & 1;
                 line_sync_code = (rtd_words[13] & 0b11111100) | rtd_words[14] >> 6;
@@ -59,8 +59,16 @@ namespace dmsp
             else
             {
                 // Get current channels configuration
-                bool tag_bit = (rtd_frame[1] >> 2) & 1;
-                // bool tag_bit = false;
+                bool tag_bit = true;
+                switch (tag_bit_override)
+                {
+                    case 0: tag_bit = (rtd_frame[1] >> 2) & 1;
+                        break;
+                    case 1: tag_bit = false;
+                        break;
+                    case 2: tag_bit = true;
+                        break;
+                }
 
                 // Extract fine pixel data
                 for (int i = 0; i < 15; i++)

--- a/plugins/dmsp_support/dmsp/instruments/ols/ols_rtd_reader.cpp
+++ b/plugins/dmsp_support/dmsp/instruments/ols/ols_rtd_reader.cpp
@@ -23,18 +23,29 @@ namespace dmsp
 
         void OLSRTDReader::work(uint8_t *rtd_frame, uint8_t *rtd_words)
         {
-            if (rtd_words[1] == 0xFB &&
-                rtd_words[2] == 0x07 &&
-                rtd_words[3] == 0xFB &&
-                rtd_words[4] == 0x07 &&
-                rtd_words[5] == 0xFB &&
-                rtd_words[6] == 0x07 &&
-                rtd_words[7] == 0xFB &&
-                rtd_words[8] == 0x07 &&
-                rtd_words[9] == 0xFB &&
-                rtd_words[10] == 0x07 &&
-                rtd_words[11] == 0xFB &&
-                rtd_words[12] == 0x07)
+            int alarm_match = 0;
+
+            for (int i = 1; i < 13; i++)
+            {
+                // Determine odd/even alarm code for word
+                int alarm_code = ((i & 1) == 0) ? 0x07 : 0xFB;
+
+                // Read word to check against alarm code
+                int check_word = rtd_words[i];
+
+                // Compare each bit and count matches
+                for (int j = 1; j < 9; j++)
+                {
+                    if ((check_word & 0x01) == (alarm_code & 0x01))
+                    {
+                        alarm_match++;
+                    }
+                    check_word = check_word >> 1;
+                    alarm_code = alarm_code >> 1;
+                }
+
+            }
+            if (alarm_match > 88)
             {
                 current_direction = (rtd_words[15] >> 2) & 1;
                 line_sync_code = (rtd_words[13] & 0b11111100) | rtd_words[14] >> 6;
@@ -49,6 +60,7 @@ namespace dmsp
             {
                 // Get current channels configuration
                 bool tag_bit = (rtd_frame[1] >> 2) & 1;
+                // bool tag_bit = false;
 
                 // Extract fine pixel data
                 for (int i = 0; i < 15; i++)

--- a/plugins/dmsp_support/dmsp/instruments/ols/ols_rtd_reader.h
+++ b/plugins/dmsp_support/dmsp/instruments/ols/ols_rtd_reader.h
@@ -26,6 +26,8 @@ namespace dmsp
             int offset_ir = 0;
             int offset_vis = 0;
 
+            int tag_bit_override = 0;
+
         public:
             OLSRTDReader();
             ~OLSRTDReader();
@@ -41,6 +43,11 @@ namespace dmsp
             {
                 offset_ir = i;
                 offset_vis = v;
+            }
+
+            void set_tag_bit(int t)
+            {
+                tag_bit_override = t;
             }
         };
     } // namespace avhrr

--- a/plugins/dmsp_support/dmsp/module_dmsp_rtd_instruments.cpp
+++ b/plugins/dmsp_support/dmsp/module_dmsp_rtd_instruments.cpp
@@ -49,6 +49,20 @@ namespace dmsp
         else if (sat_num == 18)
             ols_reader.set_offsets(0, 14);
 
+        std::string fs_config = d_parameters["tag_bit_override"].get<std::string>();
+
+        if (fs_config == "VIS/IR")
+        {
+            ols_reader.set_tag_bit(1);
+        }
+        else if (fs_config == "IR/VIS")
+        {
+            ols_reader.set_tag_bit(2);
+        } else
+        {
+            ols_reader.set_tag_bit(0);
+        }
+
         uint8_t rtd_words[19];
 
         time_t lastTime = 0;


### PR DESCRIPTION
Uses two not very efficient loops that compare each bit of the frame sync words to what they should be and if at least 88 out of the 96 bits are in a correct position then the frame is marked as sync. Recovers considerably more image data, the original implementation would lose a line to a bit flip anywhere in the 96 bit sequence.

For even better implementation the fixed threshold could be made into a variable accessible from the UI via the RTD pipeline

Before/after;
![image](https://github.com/user-attachments/assets/e88a6ad0-0e4f-4e09-a852-17dfd1aa0ab6)
