### PR TITLE
Fix build error when ziq is disabled

### DIFF
--- a/src-core/common/dsp/io/baseband_interface.h
+++ b/src-core/common/dsp/io/baseband_interface.h
@@ -86,6 +86,7 @@ namespace dsp
 #ifdef BUILD_ZIQ
             if (format == ZIQ)
                 ziqReader = std::make_shared<ziq::ziq_reader>(input_file);
+            else
 #endif
 #ifdef BUILD_ZIQ2
             if (format == ZIQ2)

--- a/src-core/common/dsp/io/baseband_interface.h
+++ b/src-core/common/dsp/io/baseband_interface.h
@@ -90,8 +90,9 @@ namespace dsp
 #ifdef BUILD_ZIQ2
             if (format == ZIQ2)
                 input_file.seekg(4);
+            else
 #endif
-            else if (is_wav)
+            if (is_wav)
                 input_file.seekg(sizeof(wav::WavHeader));
             else if (is_rf64)
                 input_file.seekg(sizeof(wav::RF64Header));


### PR DESCRIPTION
When both BUILD_ZIQ and BUILD_ZIQ2 are not defined, an orphaned else causes the build to fail