### PR TITLE
Add docker dependencies, reorder install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,12 +29,12 @@ ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
 
 COPY packages.runner /usr/local/src/
+COPY --from=builder /usr/local/src/satdump/build/satdump_*.deb /usr/local/src/
 RUN apt -y update && \
     apt -y upgrade && \
     xargs -a /usr/local/src/packages.runner apt install -qy && \
+    apt install -qy /usr/local/src/satdump_*.deb && \
     rm -rf /var/lib/apt/lists/*
-COPY --from=builder /usr/local/src/satdump/build/satdump_*.deb /usr/local/src/
-RUN apt install /usr/local/src/satdump_*.deb
 
 # Add a user, possibility to map it to a user on the host to get the same uid & gid on files
 ARG HOST_UID=1000

--- a/packages.builder
+++ b/packages.builder
@@ -11,6 +11,7 @@ libcurl4-openssl-dev
 libfftw3-dev
 libglfw3-dev
 libhackrf-dev
+libhdf5-dev
 libiio-dev
 libjemalloc-dev
 liblimesuite-dev

--- a/packages.runner
+++ b/packages.runner
@@ -5,6 +5,7 @@ libbladerf2
 libfftw3-bin
 libglfw3
 libhackrf0
+libhdf5-103
 libiio0
 libjemalloc2
 liblimesuite22.09-1


### PR DESCRIPTION
Reordering the install to allow it to automatically pull in any new dependencies, adding the -dev packages is still needed for any new features to be built.