### PR TITLE
Support for the new GEOSCAN satellite platform

### DIFF
--- a/pipelines/Geoscan.json
+++ b/pipelines/Geoscan.json
@@ -1,55 +1,4 @@
 {
-    "geoscan_eldeveis_uhf": {
-        "name": "Geoscan-Eldeveis UHF",
-        "live": true,
-        "live_cfg": [
-            [
-                1,
-                0
-            ],
-            [
-                2,
-                0
-            ]
-        ],
-        "parameters": {
-            "start_timestamp": {
-                "type": "timestamp",
-                "value": -1,
-                "name": "Start Timestamp",
-                "description": "Unix timestamp of the start of the file provided.\nRequired for doppler correction, along with your QTH.\n\nIf your baseband filename is a support format it will be read automatically."
-            },
-            "enable_doppler": {
-                "type": "bool",
-                "value": true,
-                "name": "Doppler Correction",
-                "description": "Apply doppler correction"
-            }
-        },
-        "frequencies": [
-            [
-                "Main",
-                436.2e6
-            ]
-        ],
-        "work": {
-            "baseband": {},
-            "soft": {
-                "xfsk_burst_demod": {
-                    "symbolrate": 9600,
-                    "enable_doppler": true,
-                    "satellite_norad": 53385,
-                    "satellite_frequency": 436.2e6
-                }
-            },
-            "frm": {
-                "geoscan_decoder": {}
-            },
-            "products": {
-                "geoscan_data_decoder": {}
-            }
-        }
-    },
     "stratosat_tk1_uhf": {
         "name": "StratoSat-TK1 UHF",
         "live": true,
@@ -94,10 +43,288 @@
                 }
             },
             "frm": {
-                "geoscan_decoder": {}
+                "geoscan_decoder": {
+                    "frame_length": 66,
+                    "thresold": 4
+                }
             },
             "products": {
                 "geoscan_data_decoder": {}
+            }
+        }
+    },
+    "rtumirea1_uhf": {
+        "name": "RTU-MIREA1 UHF",
+        "live": true,
+        "live_cfg": [
+            [
+                1,
+                0
+            ],
+            [
+                2,
+                0
+            ]
+        ],
+        "parameters": {
+            "start_timestamp": {
+                "type": "timestamp",
+                "value": -1,
+                "name": "Start Timestamp",
+                "description": "Unix timestamp of the start of the file provided.\nRequired for doppler correction, along with your QTH.\n\nIf your baseband filename is a support format it will be read automatically."
+            },
+            "enable_doppler": {
+                "type": "bool",
+                "value": true,
+                "name": "Doppler Correction",
+                "description": "Apply doppler correction"
+            }
+        },
+        "frequencies": [
+            [
+                "Main UHF",
+                436.20e6
+            ],
+            [
+                "Main DVB-S2",
+                10473.00e6
+            ]
+        ],
+        "work": {
+            "baseband": {},
+            "soft": {
+                "xfsk_burst_demod": {
+                    "symbolrate": 9600,
+                    "enable_doppler": true,
+                    "satellite_norad": 98894,
+                    "satellite_frequency": 436.20e6
+                }
+            },
+            "frm": {
+                "geoscan_decoder": {
+                    "frame_length": 74,
+                    "thresold": 6
+                }
+            }
+        }
+    },
+    "tusur_go_uhf": {
+        "name": "TUSUR-GO UHF",
+        "live": true,
+        "live_cfg": [
+            [
+                1,
+                0
+            ],
+            [
+                2,
+                0
+            ]
+        ],
+        "parameters": {
+            "start_timestamp": {
+                "type": "timestamp",
+                "value": -1,
+                "name": "Start Timestamp",
+                "description": "Unix timestamp of the start of the file provided.\nRequired for doppler correction, along with your QTH.\n\nIf your baseband filename is a support format it will be read automatically."
+            },
+            "enable_doppler": {
+                "type": "bool",
+                "value": true,
+                "name": "Doppler Correction",
+                "description": "Apply doppler correction"
+            }
+        },
+        "frequencies": [
+            [
+                "Main UHF",
+                437.73e6
+            ],
+            [
+                "Main DVB-S2",
+                10475.00e6
+            ]
+        ],
+        "work": {
+            "baseband": {},
+            "soft": {
+                "xfsk_burst_demod": {
+                    "symbolrate": 9600,
+                    "enable_doppler": true,
+                    "satellite_norad": 98788,
+                    "satellite_frequency": 437.73e6
+                }
+            },
+            "frm": {
+                "geoscan_decoder": {
+                    "frame_length": 74,
+                    "thresold": 6
+                }
+            }
+        }
+    },
+    "vizard_ion_uhf": {
+        "name": "VIZARD-ION UHF",
+        "live": true,
+        "live_cfg": [
+            [
+                1,
+                0
+            ],
+            [
+                2,
+                0
+            ]
+        ],
+        "parameters": {
+            "start_timestamp": {
+                "type": "timestamp",
+                "value": -1,
+                "name": "Start Timestamp",
+                "description": "Unix timestamp of the start of the file provided.\nRequired for doppler correction, along with your QTH.\n\nIf your baseband filename is a support format it will be read automatically."
+            },
+            "enable_doppler": {
+                "type": "bool",
+                "value": true,
+                "name": "Doppler Correction",
+                "description": "Apply doppler correction"
+            }
+        },
+        "frequencies": [
+            [
+                "Main UHF",
+                436.87e6
+            ],
+            [
+                "Main DVB-S2",
+                10475.00e6
+            ]
+        ],
+        "work": {
+            "baseband": {},
+            "soft": {
+                "xfsk_burst_demod": {
+                    "symbolrate": 9600,
+                    "enable_doppler": true,
+                    "satellite_norad": 98789,
+                    "satellite_frequency": 436.87e6
+                }
+            },
+            "frm": {
+                "geoscan_decoder": {
+                    "frame_length": 74,
+                    "thresold": 6
+                }
+            }
+        }
+    },
+    "colibri_s_uhf": {
+        "name": "COLIBRI-S UHF",
+        "live": true,
+        "live_cfg": [
+            [
+                1,
+                0
+            ],
+            [
+                2,
+                0
+            ]
+        ],
+        "parameters": {
+            "start_timestamp": {
+                "type": "timestamp",
+                "value": -1,
+                "name": "Start Timestamp",
+                "description": "Unix timestamp of the start of the file provided.\nRequired for doppler correction, along with your QTH.\n\nIf your baseband filename is a support format it will be read automatically."
+            },
+            "enable_doppler": {
+                "type": "bool",
+                "value": true,
+                "name": "Doppler Correction",
+                "description": "Apply doppler correction"
+            }
+        },
+        "frequencies": [
+            [
+                "Main UHF",
+                436.835e6
+            ],
+            [
+                "Main DVB-S2",
+                10475.00e6
+            ]
+        ],
+        "work": {
+            "baseband": {},
+            "soft": {
+                "xfsk_burst_demod": {
+                    "symbolrate": 9600,
+                    "enable_doppler": true,
+                    "satellite_norad": 98794,
+                    "satellite_frequency": 436.835e6
+                }
+            },
+            "frm": {
+                "geoscan_decoder": {
+                    "frame_length": 74,
+                    "thresold": 6
+                }
+            }
+        }
+    },
+    "horizon_uhf": {
+        "name": "HORIZON UHF",
+        "live": true,
+        "live_cfg": [
+            [
+                1,
+                0
+            ],
+            [
+                2,
+                0
+            ]
+        ],
+        "parameters": {
+            "start_timestamp": {
+                "type": "timestamp",
+                "value": -1,
+                "name": "Start Timestamp",
+                "description": "Unix timestamp of the start of the file provided.\nRequired for doppler correction, along with your QTH.\n\nIf your baseband filename is a support format it will be read automatically."
+            },
+            "enable_doppler": {
+                "type": "bool",
+                "value": true,
+                "name": "Doppler Correction",
+                "description": "Apply doppler correction"
+            }
+        },
+        "frequencies": [
+            [
+                "Main UHF",
+                435.43e6
+            ],
+            [
+                "Main DVB-S2",
+                10474.00e6
+            ]
+        ],
+        "work": {
+            "baseband": {},
+            "soft": {
+                "xfsk_burst_demod": {
+                    "symbolrate": 9600,
+                    "enable_doppler": true,
+                    "satellite_norad": 98793,
+                    "satellite_frequency": 435.43e6
+                }
+            },
+            "frm": {
+                "geoscan_decoder": {
+                    "frame_length": 74,
+                    "thresold": 6
+                }
             }
         }
     }

--- a/plugins/cubesat_support/geoscan/module_geoscan_decoder.cpp
+++ b/plugins/cubesat_support/geoscan/module_geoscan_decoder.cpp
@@ -7,16 +7,38 @@
 
 namespace geoscan
 {
-    GEOSCANDecoderModule::GEOSCANDecoderModule(std::string input_file, std::string output_file_hint, nlohmann::json parameters) : ProcessingModule(input_file, output_file_hint, parameters)
+    GEOSCANDecoderModule::GEOSCANDecoderModule(std::string input_file, std::string output_file_hint, nlohmann::json parameters) : ProcessingModule(input_file, output_file_hint, parameters),
+                                                                                                                                  d_frame_length(parameters["frame_length"].get<int>()),
+                                                                                                                                  d_thresold(parameters["thresold"].get<int>())
     {
         input_buffer = new int8_t[256];
 
-        deframer = std::make_unique<def::SimpleDeframer>(0x930B51DE, 32, 560, 3, false, true);
+        deframer = std::make_unique<def::SimpleDeframer>(0x930B51DE, 32, (int)((d_frame_length+4)*8), d_thresold, false, true);
     }
 
     GEOSCANDecoderModule::~GEOSCANDecoderModule()
     {
         delete[] input_buffer;
+    }
+
+    const uint8_t* GEOSCANDecoderModule::PN9_MASK_Generator(){
+        uint8_t mask[8192] = {0};
+        uint16_t buffer = 0x1FF;
+        uint8_t xor_state = 0;
+        uint8_t *mask_bytes = (uint8_t*)malloc(1024 * sizeof(uint8_t));
+        memset(mask_bytes, 0, 1024);
+        for(int i=0; i<8192; i++){
+            mask[i] = buffer & 0b1;
+            xor_state = (buffer & 0b1)^(buffer >> 5 & 0b1);
+            if(xor_state){buffer = (buffer >> 1) | 0x0100;}
+            else {buffer = (buffer >> 1);}
+        }
+        for (int i = 0; i < 1024; i++) {
+            for (int j = 0; j < 8; j++) {
+                mask_bytes[i] |= (mask[i * 8 + j] & 0x01) << (0 + j);
+            }
+        }
+        return mask_bytes;
     }
 
     std::vector<ModuleDataType> GEOSCANDecoderModule::getInputTypes()
@@ -47,6 +69,7 @@ namespace geoscan
         logger->info("Decoding to " + d_output_file_hint + ".frm");
 
         time_t lastTime = 0;
+        const uint8_t* pn9_scrambling = GEOSCANDecoderModule::PN9_MASK_Generator();
         while (input_data_type == DATA_FILE ? !data_in.eof() : input_active.load())
         {
             // Read buffer
@@ -59,13 +82,11 @@ namespace geoscan
 
             for (auto &framebuf : frames)
             {
-                const uint8_t pn9_scrambling[] = {0xFF, 0xE1, 0x1D, 0x9A, 0xED, 0x85, 0x33, 0x24, 0xEA, 0x7A, 0xD2, 0x39, 0x70, 0x97, 0x57, 0x0A, 0x54, 0x7D, 0x2D, 0xD8, 0x6D, 0x0D, 0xBA, 0x8F, 0x67, 0x59, 0xC7, 0xA2, 0xBF, 0x34, 0xCA, 0x18, 0x30, 0x53, 0x93, 0xDF, 0x92, 0xEC, 0xA7, 0x15, 0x8A, 0xDC, 0xF4, 0x86, 0x55, 0x4E, 0x18, 0x21, 0x40, 0xC4, 0xC4, 0xD5, 0xC6, 0x91, 0x8A, 0xCD, 0xE7, 0xD1, 0x4E, 0x09, 0x32, 0x17, 0xDF, 0x83, 0xFF, 0xF0};
-
-                for (int i = 0; i < 66; i++)
+                for (int i = 0; i < (int)d_frame_length; i++)
                     framebuf[4 + i] ^= pn9_scrambling[i];
 
-                uint16_t crc_frm1 = crc_check.compute(&framebuf[4], 64);
-                uint16_t crc_frm2 = framebuf[4 + 64 + 0] << 8 | framebuf[4 + 64 + 1];
+                uint16_t crc_frm1 = crc_check.compute(&framebuf[4], (int)(d_frame_length-2));
+                uint16_t crc_frm2 = framebuf[4 + (int)(d_frame_length-2) + 0] << 8 | framebuf[4 + (int)(d_frame_length-2) + 1];
 
                 if (crc_frm1 == crc_frm2)
                 {
@@ -90,7 +111,7 @@ namespace geoscan
 
     void GEOSCANDecoderModule::drawUI(bool window)
     {
-        ImGui::Begin("GeoScan Decoder", NULL, window ? 0 : NOWINDOW_FLAGS);
+        ImGui::Begin("GEOSCAN Decoder", NULL, window ? 0 : NOWINDOW_FLAGS);
 
         ImGui::Button("Deframer", {200 * ui_scale, 20 * ui_scale});
         {

--- a/plugins/cubesat_support/geoscan/module_geoscan_decoder.h
+++ b/plugins/cubesat_support/geoscan/module_geoscan_decoder.h
@@ -14,6 +14,8 @@ namespace geoscan
     {
     protected:
         int8_t *input_buffer;
+        int d_frame_length;
+        int d_thresold;
 
         std::ifstream data_in;
         std::ofstream data_out;
@@ -31,6 +33,7 @@ namespace geoscan
         GEOSCANDecoderModule(std::string input_file, std::string output_file_hint, nlohmann::json parameters);
         ~GEOSCANDecoderModule();
         void process();
+        const uint8_t* PN9_MASK_Generator();
         void drawUI(bool window);
         std::vector<ModuleDataType> getInputTypes();
         std::vector<ModuleDataType> getOutputTypes();


### PR DESCRIPTION
This update allows receiving data packets from the new GEOSCAN satellite platform, which has several amateur radio satellites that will be launched into orbit on November 5. These satellites are planned to broadcast images, but the transmission protocol is not yet fully approved and may change, so I have not added a decoder for this, but will do it later when we decide on the image data packaging format.