### PR TITLE
added version display switches

### DIFF
--- a/src-cli/main.cpp
+++ b/src-cli/main.cpp
@@ -51,6 +51,11 @@ int main(int argc, char *argv[])
             logger->error("Error running project! %s", e.what());
         }
     }
+    else if (std::string(argv[1]) == "version" || std::string(argv[1]) == "--v")
+    {
+        logger->info("This is SatDump v" + (std::string)SATDUMP_VERSION);
+        return 0;
+    }
     //////////////
     else if (std::string(argv[1]) == "sdr_probe")
     {


### PR DESCRIPTION
"version" or "--v" as first argument to pull the latest satdump version string and send it to logger, then exit 0

This references #716 - I am not sure how to/if I need to do anything with src-ui, but it works fine in src-cli