### PR TITLE
Create help menu for the CLI version

### DIFF
--- a/src-cli/help_general.cpp
+++ b/src-cli/help_general.cpp
@@ -1,0 +1,42 @@
+#include "logger.h"
+#include "init.h"
+#include "help_general.h"
+
+void help_general()
+{
+    // We don't wanna spam with init this time around
+    logger->set_level(slog::LOG_ERROR);
+    satdump::initSatdump();
+    completeLoggerInit();
+    logger->set_level(slog::LOG_TRACE);
+
+	logger->error("");
+	logger->error("Visit: www.satdump.org");
+	logger->error("");
+	logger->info("Many usecases of SatDump CLI are cover at the following link");
+	logger->debug("www.satdump.org/posts/basic-usage/#cli-this-part-was-made-by-aang23");
+	logger->info("");
+	logger->info("This is SatDump v" + (std::string)SATDUMP_VERSION);
+	logger->info("Live processing");
+	logger->debug("	- Usage: satdump live + parameters");
+	logger->debug("	- info: use 'satdump live' for more information on 'live' usage and parameters");	
+	logger->info("record processing");
+	logger->debug("	- Usage: satdump record + parameters");
+	logger->debug("	- info: use 'satdump record' for more information on 'record' usage and parameters");	
+	logger->info("autotrack feature");
+	logger->debug("	- Usage: satdump autotrack + parameters");
+	logger->debug("	- info: use 'satdump autotrack' for more information on 'autotrack' usage and parameters");	
+	logger->info("SatDump GUI version");
+	logger->debug("	- Usage: satdump-ui");
+	logger->debug("	- info: GUI version of SatDump");
+	logger->info("SDR probe");
+	logger->debug("	- Usage: satdump sdr_probe");
+	logger->debug("	- info: Return a list of local and remote receivers ");
+	logger->info("General help");
+	logger->debug("	- Usage: satdump help or -h");
+	logger->debug("	- info: Display the general help function");
+	logger->info("version of satdump");
+	logger->debug("	- Usage: satdump version");
+	logger->debug("	- info: Display the current version of SatDump. Also visible above");
+
+}

--- a/src-cli/help_general.h
+++ b/src-cli/help_general.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void help_general();

--- a/src-cli/main.cpp
+++ b/src-cli/main.cpp
@@ -6,6 +6,7 @@
 #include "autotrack/autotrack.h"
 
 #include "sdr_probe.h"
+#include "help_general.h"
 
 #include "project/project.h"
 
@@ -17,6 +18,7 @@ int main(int argc, char *argv[])
     if (argc < 2)
     {
         logger->error("Please specify either live/record or pipeline name!");
+		logger->error("Use -h or help for information");
         return 1;
     }
 
@@ -60,6 +62,12 @@ int main(int argc, char *argv[])
     else if (std::string(argv[1]) == "sdr_probe")
     {
         sdr_probe();
+    }
+    //////////////
+	//////////////
+    else if ((std::string(argv[1]) == "-h") or (std::string(argv[1]) == "help"))
+    {
+        help_general();
     }
     //////////////
     else


### PR DESCRIPTION
Hi,

I found that the CLI version hasn't any "help" or "-h" like many utility in commande line. They were some information once you were in "Live", "record", etc. but nothing at the basic "satdump" level

You can now use: satdump -h  or satdump help to get some information and get you started.

Hoping that will help people 