### PR TITLE
Add Enable/Disable all layers buttons, lock-out projection buttons with zero active layers

### DIFF
--- a/src-interface/viewer/viewer.h
+++ b/src-interface/viewer/viewer.h
@@ -104,8 +104,8 @@ namespace satdump
         double projection_osm_lon1 = -180.0;
         double projection_osm_lat2 = 85.0511;
         double projection_osm_lon2 = 180.0;
-        bool is_opening_layer = false;
 
+        std::mutex projection_layers_mtx;
         std::deque<ProjectionLayer> projection_layers;
 
         int selected_external_type = 0;

--- a/src-interface/viewer/viewer_projection.cpp
+++ b/src-interface/viewer/viewer_projection.cpp
@@ -19,7 +19,7 @@
 #include "common/widgets/json_editor.h"
 
 namespace satdump
-{    
+{ 
     int osm_url_regex_len = 0;
     float general_progress = 0;
     float general_sum = 1;

--- a/src-interface/viewer/viewer_projection.cpp
+++ b/src-interface/viewer/viewer_projection.cpp
@@ -327,7 +327,7 @@ namespace satdump
             if (ImGui::Button("Enable All"))
             {
                 logger->info("Enabling all layers for projection");
-                for (auto& lay : projection_layers)
+                for (auto &lay : projection_layers)
                     lay.enabled = true;
             }
 
@@ -335,7 +335,7 @@ namespace satdump
             if (ImGui::Button("Disable All"))
             {
                 logger->info("Disabling all layers for projection");
-                for (auto& lay : projection_layers)
+                for (auto &lay : projection_layers)
                     lay.enabled = false;
             }
 

--- a/src-interface/viewer/viewer_projection.cpp
+++ b/src-interface/viewer/viewer_projection.cpp
@@ -125,7 +125,7 @@ namespace satdump
             ImGui::Separator();
             ImGui::Spacing();
 
-            if (disable_buttons || projection_layers.size() == 0 || active_layers == 0)
+            if (disable_buttons || active_layers == 0)
                 style::beginDisabled();
             if (ImGui::Button("Generate Projection"))
             {
@@ -156,7 +156,7 @@ namespace satdump
                     ImGui::SetTooltip("Generating, please wait...");
                 if (projection_layers.size() == 0)
                     ImGui::SetTooltip("No layers loaded!");
-                if (active_layers == 0 && projection_layers.size() > 0)
+                if (active_layers == 0)
                     ImGui::SetTooltip("No layers active for projection!");
             }
 
@@ -183,10 +183,10 @@ namespace satdump
                     ImGui::SetTooltip("Generating, please wait...");
                 if (projection_layers.size() == 0)
                     ImGui::SetTooltip("No layers loaded!");
-                if (active_layers == 0 && projection_layers.size() > 0)
+                if (active_layers == 0)
                     ImGui::SetTooltip("No layers active for projection!");
             }
-            if (disable_buttons || projection_layers.size() == 0 || active_layers == 0)
+            if (disable_buttons || active_layers == 0)
                 style::endDisabled();
         }
         if (ImGui::CollapsingHeader("Layers"))
@@ -370,11 +370,6 @@ namespace satdump
                     ImGui::PushTextWrapPos(ImGui::GetContentRegionMax().x - 70 * ui_scale);
                     ImGui::Text("%s", label.c_str());
                     ImGui::PopTextWrapPos();
-
-                    active_layers = 0;
-                    for (auto &lay : projection_layers)
-                        if (lay.enabled)
-                            active_layers++;
 
                     if (settings::advanced_mode)
                     {

--- a/src-interface/viewer/viewer_projection.cpp
+++ b/src-interface/viewer/viewer_projection.cpp
@@ -19,8 +19,7 @@
 #include "common/widgets/json_editor.h"
 
 namespace satdump
-{
-    int active_layers;
+{    
     int osm_url_regex_len = 0;
     float general_progress = 0;
     float general_sum = 1;
@@ -30,6 +29,12 @@ namespace satdump
     {
         bool disable_buttons = projections_are_generating;
         bool disable_add_layer = is_opening_layer;
+
+        int active_layers = 0;
+        for (auto &lay : projection_layers)
+            if (lay.enabled)
+                active_layers++;
+        
         if (ImGui::CollapsingHeader("Projection", ImGuiTreeNodeFlags_DefaultOpen))
         {
             ImGui::Text("Output image : ");

--- a/src-interface/viewer/viewer_projection.cpp
+++ b/src-interface/viewer/viewer_projection.cpp
@@ -20,6 +20,7 @@
 
 namespace satdump
 {
+    int active_layers;
     int osm_url_regex_len = 0;
     float general_progress = 0;
     float general_sum = 1;
@@ -119,7 +120,7 @@ namespace satdump
             ImGui::Separator();
             ImGui::Spacing();
 
-            if (disable_buttons || projection_layers.size() == 0)
+            if (disable_buttons || projection_layers.size() == 0 || active_layers == 0)
                 style::beginDisabled();
             if (ImGui::Button("Generate Projection"))
             {
@@ -150,6 +151,8 @@ namespace satdump
                     ImGui::SetTooltip("Generating, please wait...");
                 if (projection_layers.size() == 0)
                     ImGui::SetTooltip("No layers loaded!");
+                if (active_layers == 0)
+                    ImGui::SetTooltip("No layers active for projection!");
             }
 
             ImGui::Spacing();
@@ -175,8 +178,10 @@ namespace satdump
                     ImGui::SetTooltip("Generating, please wait...");
                 if (projection_layers.size() == 0)
                     ImGui::SetTooltip("No layers loaded!");
+                if (active_layers == 0)
+                    ImGui::SetTooltip("No layers active for projection!");
             }
-            if (disable_buttons || projection_layers.size() == 0)
+            if (disable_buttons || projection_layers.size() == 0 || active_layers == 0)
                 style::endDisabled();
         }
         if (ImGui::CollapsingHeader("Layers"))
@@ -204,8 +209,8 @@ namespace satdump
             ImGuiStyle &imguistyle = ImGui::GetStyle();
             ImGui::SetCursorPosX(ImGui::GetContentRegionMax().x - ((projections_loading_new_layer ? 16.0 * ui_scale + imguistyle.ItemSpacing.x : 0) + 
                                                                    (ImGui::CalcTextSize("Add Layer").x + imguistyle.FramePadding.x * 2.0) + imguistyle.ItemSpacing.x +
-                                                                   (ImGui::CalcTextSize("Enable All").x + imguistyle.FramePadding.x * 2.0) + imguistyle.ItemSpacing.x +
-                                                                   (ImGui::CalcTextSize("Disable All").x + imguistyle.FramePadding.x * 2.0)));
+                                                                   (ImGui::CalcTextSize("All").x + imguistyle.FramePadding.x * 2.0) + imguistyle.ItemSpacing.x +
+                                                                   (ImGui::CalcTextSize("None").x + imguistyle.FramePadding.x * 2.0)));
 
             if (projections_loading_new_layer)
             {
@@ -326,17 +331,17 @@ namespace satdump
             ImGui::SameLine();
             if (ImGui::Button("Enable All"))
             {
-                logger->info("Enabling all layers for projection");
                 for (auto &lay : projection_layers)
                     lay.enabled = true;
+                logger->info("Enabled all layers for projection");
             }
 
             ImGui::SameLine();
             if (ImGui::Button("Disable All"))
             {
-                logger->info("Disabling all layers for projection");
                 for (auto &lay : projection_layers)
                     lay.enabled = false;
+                logger->info("Disabled all layers for projection");
             }
 
             if (ImGui::BeginListBox("##projectionslistbox", ImVec2(ImGui::GetWindowWidth(), 300 * ui_scale)))
@@ -353,7 +358,7 @@ namespace satdump
                     ImGui::Text("%s", label.c_str());
                     ImGui::PopTextWrapPos();
 
-                    int active_layers = 0;
+                    active_layers = 0;
                     for (auto &lay : projection_layers)
                         if (lay.enabled)
                             active_layers++;

--- a/src-interface/viewer/viewer_projection.cpp
+++ b/src-interface/viewer/viewer_projection.cpp
@@ -156,7 +156,7 @@ namespace satdump
                     ImGui::SetTooltip("Generating, please wait...");
                 if (projection_layers.size() == 0)
                     ImGui::SetTooltip("No layers loaded!");
-                if (active_layers == 0)
+                if (active_layers == 0 && projection_layers.size() > 0)
                     ImGui::SetTooltip("No layers active for projection!");
             }
 
@@ -183,7 +183,7 @@ namespace satdump
                     ImGui::SetTooltip("Generating, please wait...");
                 if (projection_layers.size() == 0)
                     ImGui::SetTooltip("No layers loaded!");
-                if (active_layers == 0)
+                if (active_layers == 0 && projection_layers.size() > 0)
                     ImGui::SetTooltip("No layers active for projection!");
             }
             if (disable_buttons || projection_layers.size() == 0 || active_layers == 0)

--- a/src-interface/viewer/viewer_projection.cpp
+++ b/src-interface/viewer/viewer_projection.cpp
@@ -19,7 +19,7 @@
 #include "common/widgets/json_editor.h"
 
 namespace satdump
-{ 
+{
     int osm_url_regex_len = 0;
     float general_progress = 0;
     float general_sum = 1;

--- a/src-interface/viewer/viewer_projection.cpp
+++ b/src-interface/viewer/viewer_projection.cpp
@@ -27,13 +27,13 @@ namespace satdump
 
     void ViewerApplication::drawProjectionPanel()
     {
-        bool disable_buttons = projections_are_generating;
-        bool disable_add_layer = is_opening_layer;
-
+        bool disable_buttons = projections_are_generating || projections_loading_new_layer;
         int active_layers = 0;
+        projection_layers_mtx.lock();
         for (auto &lay : projection_layers)
             if (lay.enabled)
                 active_layers++;
+        projection_layers_mtx.unlock();
         
         if (ImGui::CollapsingHeader("Projection", ImGuiTreeNodeFlags_DefaultOpen))
         {
@@ -207,15 +207,14 @@ namespace satdump
 
             ImGui::Text("Layers :");
 
-            if (disable_add_layer)
+            if (disable_buttons)
                 style::beginDisabled();
 
             ImGui::SameLine();
             ImGuiStyle &imguistyle = ImGui::GetStyle();
             ImGui::SetCursorPosX(ImGui::GetContentRegionMax().x - ((projections_loading_new_layer ? 16.0 * ui_scale + imguistyle.ItemSpacing.x : 0) + 
-                                                                   (ImGui::CalcTextSize("Add Layer").x + imguistyle.FramePadding.x * 2.0) + imguistyle.ItemSpacing.x +
-                                                                   (ImGui::CalcTextSize("All").x + imguistyle.FramePadding.x * 2.0) + imguistyle.ItemSpacing.x +
-                                                                   (ImGui::CalcTextSize("None").x + imguistyle.FramePadding.x * 2.0)));
+                                                                  ImGui::CalcTextSize("Add Layer").x + ImGui::CalcTextSize("All").x + ImGui::CalcTextSize("None").x +
+                                                                  imguistyle.FramePadding.x * 6 + imguistyle.ItemSpacing.x * 2));
 
             if (projections_loading_new_layer)
             {
@@ -226,7 +225,7 @@ namespace satdump
             if (ImGui::Button("Add Layer##button"))
                 ImGui::OpenPopup("Add Layer##popup", ImGuiPopupFlags_None);
 
-            if (disable_add_layer)
+            if (disable_buttons)
                 style::endDisabled();
 
             {
@@ -293,7 +292,9 @@ namespace satdump
                                     logger->info("Generating tile map");
                                     image::Image timemap = downloadTileMap(mapurl, projection_osm_lat1, projection_osm_lon1, projection_osm_lat2, projection_osm_lon2, projection_osm_zoom);
 
+                                    projection_layers_mtx.lock();
                                     projection_layers.push_front({"Tile Map", timemap});
+                                    projection_layers_mtx.unlock();
                                 }
                                 catch (std::exception &e)
                                 {
@@ -307,7 +308,9 @@ namespace satdump
                                 {
                                     ProjectionLayer newlayer = satdump::loadExternalLayer(cfg);
                                     newlayer.name = projection_new_layer_name;
+                                    projection_layers_mtx.lock();
                                     projection_layers.push_front(newlayer);
+                                    projection_layers_mtx.unlock();
                                 }
                                 catch (std::exception &e)
                                 {
@@ -334,6 +337,7 @@ namespace satdump
             }
 
             ImGui::SameLine();
+            projection_layers_mtx.lock();
             if (active_layers == projection_layers.size())
                 style::beginDisabled();
             if (ImGui::Button("All"))
@@ -346,6 +350,7 @@ namespace satdump
                 style::endDisabled();
 
             ImGui::SameLine();
+
             if (active_layers == 0)
                 style::beginDisabled();
             if (ImGui::Button("None"))
@@ -356,9 +361,11 @@ namespace satdump
             }
             if (active_layers == 0)
                 style::endDisabled();
+            projection_layers_mtx.unlock();
 
             if (ImGui::BeginListBox("##projectionslistbox", ImVec2(ImGui::GetWindowWidth(), 300 * ui_scale)))
             {
+                projection_layers_mtx.lock();
                 for (int i = 0; i < (int)projection_layers.size(); i++)
                 {
                     ImGui::PushID(i);
@@ -462,14 +469,15 @@ namespace satdump
                     ImGui::PopID();
                     ImGui::Separator();
                 }
+                projection_layers_mtx.unlock();
                 ImGui::EndListBox();
             }
-            if (!(disable_buttons || disable_add_layer))
+            if (!disable_buttons)
                 style::beginDisabled();
 
             ImGui::ProgressBar((general_progress + (progress_pointer == nullptr ? 0 : *(progress_pointer))) / general_sum);
 
-            if (!(disable_buttons || disable_add_layer))
+            if (!disable_buttons)
                 style::endDisabled();
         }
         if (ImGui::CollapsingHeader("Overlay##viewerpojoverlay"))

--- a/src-interface/viewer/viewer_projection.cpp
+++ b/src-interface/viewer/viewer_projection.cpp
@@ -202,8 +202,10 @@ namespace satdump
 
             ImGui::SameLine();
             ImGuiStyle &imguistyle = ImGui::GetStyle();
-            ImGui::SetCursorPosX(ImGui::GetContentRegionMax().x - ((projections_loading_new_layer ? 16.0 * ui_scale + imguistyle.ItemSpacing.x : 0) +
-                                                                   ImGui::CalcTextSize("Add Layer").x + imguistyle.FramePadding.x * 2.0));
+            ImGui::SetCursorPosX(ImGui::GetContentRegionMax().x - ((projections_loading_new_layer ? 16.0 * ui_scale + imguistyle.ItemSpacing.x : 0) + 
+                                                                   (ImGui::CalcTextSize("Add Layer").x + imguistyle.FramePadding.x * 2.0) + imguistyle.ItemSpacing.x +
+                                                                   (ImGui::CalcTextSize("Enable All").x + imguistyle.FramePadding.x * 2.0) + imguistyle.ItemSpacing.x +
+                                                                   (ImGui::CalcTextSize("Disable All").x + imguistyle.FramePadding.x * 2.0)));
 
             if (projections_loading_new_layer)
             {
@@ -321,6 +323,22 @@ namespace satdump
                 }
             }
 
+            ImGui::SameLine();
+            if (ImGui::Button("Enable All"))
+            {
+                logger->info("Enabling all layers for projection");
+                for (auto& lay : projection_layers)
+                    lay.enabled = true;
+            }
+
+            ImGui::SameLine();
+            if (ImGui::Button("Disable All"))
+            {
+                logger->info("Disabling all layers for projection");
+                for (auto& lay : projection_layers)
+                    lay.enabled = false;
+            }
+
             if (ImGui::BeginListBox("##projectionslistbox", ImVec2(ImGui::GetWindowWidth(), 300 * ui_scale)))
             {
                 for (int i = 0; i < (int)projection_layers.size(); i++)
@@ -350,9 +368,6 @@ namespace satdump
                     ImGui::SameLine(ImGui::GetWindowWidth() - 70 * ui_scale);
                     ImGui::SetCursorPosY(ImGui::GetCursorPos().y - 2 * ui_scale);
                     ImGui::Checkbox(std::string("##enablelayer" + layer.name + std::to_string(i)).c_str(), &layer.enabled);
-
-                    if (active_layers < 1)
-                        layer.enabled = true;
 
                     {
                         if (disable_buttons)

--- a/src-interface/viewer/viewer_projection.cpp
+++ b/src-interface/viewer/viewer_projection.cpp
@@ -334,20 +334,28 @@ namespace satdump
             }
 
             ImGui::SameLine();
+            if (active_layers == projection_layers.size())
+                style::beginDisabled();
             if (ImGui::Button("All"))
             {
                 for (auto &lay : projection_layers)
                     lay.enabled = true;
                 logger->info("Enabled all layers for projection");
             }
+            if (active_layers == projection_layers.size())
+                style::endDisabled();
 
             ImGui::SameLine();
+            if (active_layers == 0)
+                style::beginDisabled();
             if (ImGui::Button("None"))
             {
                 for (auto &lay : projection_layers)
                     lay.enabled = false;
                 logger->info("Disabled all layers for projection");
             }
+            if (active_layers == 0)
+                style::endDisabled();
 
             if (ImGui::BeginListBox("##projectionslistbox", ImVec2(ImGui::GetWindowWidth(), 300 * ui_scale)))
             {

--- a/src-interface/viewer/viewer_projection.cpp
+++ b/src-interface/viewer/viewer_projection.cpp
@@ -334,7 +334,7 @@ namespace satdump
             }
 
             ImGui::SameLine();
-            if (ImGui::Button("Enable All"))
+            if (ImGui::Button("All"))
             {
                 for (auto &lay : projection_layers)
                     lay.enabled = true;
@@ -342,7 +342,7 @@ namespace satdump
             }
 
             ImGui::SameLine();
-            if (ImGui::Button("Disable All"))
+            if (ImGui::Button("None"))
             {
                 for (auto &lay : projection_layers)
                     lay.enabled = false;


### PR DESCRIPTION
This PR was based off my work with large layer sets, sometimes 30+ at a time. Sometimes you genuinely do want to disable ALL of the layers before reselecting new ones from scratch in a different area of the world. Sometimes you want to enable just one layer out of a set to make an image, but hate having to manually click on EVERY inactive layer to turn them all back on.

This change fixes this issue and also gets rid of the hack that always ensures that one layer is selected. This was apparently to protect against crashes, but adding code to lockout the projection buttons if no layers are active in the layer set gets around this.

Happy to take suggestions to change bits of this or improve it, but I am struggling to think of anything I have changed that is "game-breaking" and a few brief tests on Windows worked fine for me with buttons enabling/disabling as required.