### PR TITLE
Add a note for building on RPi3

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,8 @@ sudo make install
 ### Raspberry Pi
 
 In case you are building Satdump on Raspberry Pi 3 (any revision) and older. 
-It's required to run ```make -j1``` instead of ```make -j 'nproc'```, otherwise the system will crash during compilation.
+It's required to run ```make -j1``` instead of ```make -j 'nproc'``. 
+Else the system will crash during compilation.
 
 ### Android
 

--- a/README.md
+++ b/README.md
@@ -305,6 +305,10 @@ sudo make install
 # Run (if you want!)
 ./satdump-ui
 ```
+### Raspberry Pi
+
+In case you are building Satdump on Raspberry Pi 3 (any revision) and older. 
+It's required to run ```make -j1``` instead of ```make -j 'nproc'```, otherwise the system will crash during compilation.
 
 ### Android
 

--- a/README.md
+++ b/README.md
@@ -308,7 +308,9 @@ sudo make install
 ### Raspberry Pi
 
 In case you are building Satdump on Raspberry Pi 3 (any revision) and older. 
+
 It's required to run ```make -j1``` instead of ```make -j 'nproc'```. 
+
 Else the system will crash during compilation.
 
 ### Android

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ sudo make install
 ### Raspberry Pi
 
 In case you are building Satdump on Raspberry Pi 3 (any revision) and older. 
-It's required to run ```make -j1``` instead of ```make -j 'nproc'``. 
+It's required to run ```make -j1``` instead of ```make -j 'nproc'```. 
 Else the system will crash during compilation.
 
 ### Android

--- a/pipelines/MTG.json
+++ b/pipelines/MTG.json
@@ -1,0 +1,25 @@
+{
+    "mtg_s_band_link": {
+        "name": "MTG S-band TLM link",
+        "live": true,
+        "live_cfg": [
+            [
+                1,
+                0
+            ]
+        ],
+        "work": {
+            "baseband": {},
+            "soft": {
+                "pm_demod": {
+                    "resample_after_pll": true,
+                    "symbolrate": 16.38e3,
+                    "pll_bw": 0.01,
+                    "rrc_alpha": 0.35,
+                    "costas_bw": 0.01,
+                    "subcarrier_offset": 64e3
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added a note, that if the user is compiling on RPi3 or older, they should use -j1 instead of -j 'nproc'.