### PR TITLE
Added GOES GVAR correction

### DIFF
--- a/plugins/goes_support/goes/gvar/module_gvar_image_decoder.cpp
+++ b/plugins/goes_support/goes/gvar/module_gvar_image_decoder.cpp
@@ -13,12 +13,8 @@
 #include "common/image/brightness_contrast.h"
 #include "common/thread_priority.h"
 #include "common/image/io.h"
-#include <format>
 
 #define FRAME_SIZE 32786
-#define NULL nullptr
-#define size_t unsigned int
-
 
 // Return filesize
 uint64_t getFilesize(std::string filepath);
@@ -213,7 +209,7 @@ namespace goes
             }
 
             // Processes all frames
-            for (int8_t i = 0; i < frame_buffer.size(); i++) {
+            for (size_t i = 0; i < frame_buffer.size(); i++) {
 
                 uint8_t *current_frame = frame_buffer[i].frame;
                 PrimaryBlockHeader cur_block_header = get_header(current_frame);
@@ -222,7 +218,7 @@ namespace goes
                 // Tries to recover the block ID in case it is damaged within a series
                 // Junk will never pass through this, as those frames are thrown out before
                 // being added to the frame buffer
-                if (1 < i < 10 ) {
+                if (i > 1 && i < 10 ) {
                     uint32_t prev_counter = frame_buffer[i-1].block_id;
                     uint32_t next_counter = frame_buffer[i+1].block_id;
 

--- a/plugins/goes_support/goes/gvar/module_gvar_image_decoder.h
+++ b/plugins/goes_support/goes/gvar/module_gvar_image_decoder.h
@@ -24,6 +24,12 @@ namespace goes
             int sat_number;
             int vis_width;
         };
+        struct Block
+            {
+                uint8_t block_id;
+                uint32_t original_counter;
+                uint8_t *frame;
+            };
 
         namespace events
         {
@@ -76,7 +82,7 @@ namespace goes
             void writeSounder();
             void writeImagesThread();
 
-            int nonEndCount, endCount;
+            int imageFrameCount;
 
             // Stats
             std::vector<int> scid_stats;
@@ -91,6 +97,7 @@ namespace goes
             ~GVARImageDecoderModule();
             static std::string getGvarFilename(int sat_number, std::tm *timeReadable, std::string channel);
             void process();
+            void process_frame_buffer(std::vector<Block> &frame_buffer);
             void drawUI(bool window);
             std::vector<ModuleDataType> getInputTypes();
             std::vector<ModuleDataType> getOutputTypes();
@@ -101,5 +108,5 @@ namespace goes
             static std::vector<std::string> getParameters();
             static std::shared_ptr<ProcessingModule> getInstance(std::string input_file, std::string output_file_hint, nlohmann::json parameters);
         };
-    } // namespace elektro_arktika
+    }
 }


### PR DESCRIPTION
GOES GVAR is very prone to corruption due to lacking FEC, this PR makes imagery significantly more presentable at low SNRs by applying several types of correction:
- **The header is triple redundant, majority law is applied between them now**
- **The scan count is gathered by using majority law from within a series** (Blocks are transmitted 1 through 11, in that order, with each one having the same scan count) to ensure the scan count is consistent between all frames
- **Block IDs are recovered in cases where the block Id gets corrupted in the middle of a series** (I.e. 1,2,3,66,5,6,7,8,9,10)
- **Bit masks are now applied to ensure impossible scenarios won't happen** (Image width and scan count)
- **Junk data is thrown out before it can get processed by checking against a spare present in the block headers, eradicating white lines in resulting imagery**

This PR also tries to make the image decoder code a bit more readable by refactoring a few things within the file.


Sample RX at 5.5 dB without correction:
![image](https://github.com/user-attachments/assets/dd50c035-fff3-41f5-ac90-538c0b8621dd)

Same RX with correction applied:
![image](https://github.com/user-attachments/assets/d7e05a20-10d2-48d5-8c04-6d541c5bb644)
