### PR TITLE
Updated incorrect MSU-GS 221 composite channels

### DIFF
--- a/satdump_cfg.json
+++ b/satdump_cfg.json
@@ -2383,7 +2383,7 @@
                 "name": "MSU-GS",
                 "rgb_composites": {
                     "AVHRR 221 False Color": {
-                        "equation": "ch2,ch2,ch1",
+                        "equation": "ch3,ch3,ch1",
                         "description": "descriptions/221.md"
                     },
                     "MSU-GS 321 False Color": {


### PR DESCRIPTION
MSU-GS channel 3 has the center wavelength at 0.86 µm, making ch3,ch3,ch1 much closer to the range of AVHRR 221 than the previous ch2,ch2,ch1

**AVHRR/3**
1 - 0.63 µm (0.58-0.68)
2 - 0.862 µm (0.725-1.00)

**MSU-GS**
1 - 0.57 µm (0.5-0.65)
2 - 0.72 µm (0.65-0.8)
3 - 0.86 µm (0.8-0.9)
