### PR TITLE
Modified USRPSource::start to not re-run open_channel() if the USRPSo…

### DIFF
--- a/plugins/sdr_sources/usrp_sdr_support/usrp_sdr.cpp
+++ b/plugins/sdr_sources/usrp_sdr_support/usrp_sdr.cpp
@@ -138,7 +138,9 @@ void USRPSource::start()
 {
     DSPSampleSource::start();
     open_sdr();
-    open_channel();
+    if (!is_open) {
+        open_channel();
+    }
 
     uint64_t current_samplerate = samplerate_widget.get_value();
 


### PR DESCRIPTION
Hey, I found that on my USRP device upon clicking "start" for the source the sampling rate would revert to the first entry. I've made a quick fix for that (see commit message for details), not sure if this is the best way, let me know if not :)