### PR TITLE
Added rudimentary S-VISSR correction

### DIFF
--- a/plugins/fengyun2_support/fengyun2/svissr/module_svissr_image_decoder.cpp
+++ b/plugins/fengyun2_support/fengyun2/svissr/module_svissr_image_decoder.cpp
@@ -189,9 +189,7 @@ namespace fengyun_svissr
                     // Unlocks if we are starting a new series
                     if (counter_locked && (counter == 1 || counter == 2)) {
                         counter_locked = false;
-                    }
-
-                    if (!counter_locked) {
+                    } else if (!counter_locked) {
                         // Can we lock?
                         if (counter == global_counter+1) {
                             counter_locked = true;

--- a/plugins/fengyun2_support/fengyun2/svissr/module_svissr_image_decoder.cpp
+++ b/plugins/fengyun2_support/fengyun2/svissr/module_svissr_image_decoder.cpp
@@ -192,6 +192,8 @@ namespace fengyun_svissr
                     } else if (!counter_locked) {
                         // Can we lock?
                         if (counter == global_counter+1) {
+                            // LOCKED!
+                            logger->debug("Counter correction LOCKED! Counter: " + std::to_string(counter));
                             counter_locked = true;
                         } else {
                             // We can't lock, save this counter for a check on the next one
@@ -234,6 +236,14 @@ namespace fengyun_svissr
 
                 // Try to detect a new scan
                 uint8_t is_back = most_common(&last_status[0], &last_status[20], 0);
+
+                // Ensures the counter doesn't lock during rollback
+                // Situation: 
+                //   Image ends -> Rollback starts -> Corrector erroneously locks during rollback
+                //   -> Corrector shows "LOCKED" until 40 rollback lines are scanned
+                if (is_back && valid_lines < 5) {
+                    counter_locked = false;
+                }
 
                 if (is_back && valid_lines > 40)
                 {

--- a/plugins/fengyun2_support/fengyun2/svissr/module_svissr_image_decoder.h
+++ b/plugins/fengyun2_support/fengyun2/svissr/module_svissr_image_decoder.h
@@ -26,6 +26,9 @@ namespace fengyun_svissr
         bool writingImage = false;
         int valid_lines;
         float approx_progess;
+        bool apply_correction;
+        int global_counter;
+        bool counter_locked = false;
 
         struct SVISSRBuffer
         {
@@ -80,6 +83,7 @@ namespace fengyun_svissr
         std::vector<int> scid_stats;
 
         // UI Stuff
+        float corr_history_ca[200];
         unsigned int textureID = 0;
         uint32_t *textureBuffer;
 
@@ -97,4 +101,4 @@ namespace fengyun_svissr
         static std::vector<std::string> getParameters();
         static std::shared_ptr<ProcessingModule> getInstance(std::string input_file, std::string output_file_hint, nlohmann::json parameters);
     };
-} // namespace elektro_arktika
+}

--- a/resources/pipelines/FengYun-2.json
+++ b/resources/pipelines/FengYun-2.json
@@ -42,6 +42,14 @@
             ]
         ],
         "samplerate": 6e6,
+        "parameters": {
+            "apply_correction": {
+                "type": "bool",
+                "value": false,
+                "name": "Apply rudimentary correction",
+                "description": "This applies correction on the basis of a sequential order check. While making imagery more presentably, it can lead to several issues:\n- Missed image starts\n- Earth being deformed (because of dropped frames)"
+            }
+        },
         "work": {
             "baseband": {},
             "soft": {

--- a/resources/pipelines/FengYun-2.json
+++ b/resources/pipelines/FengYun-2.json
@@ -47,7 +47,7 @@
                 "type": "bool",
                 "value": false,
                 "name": "Apply rudimentary correction",
-                "description": "This applies correction on the basis of a sequential order check. While making imagery more presentably, it can lead to several issues:\n- Missed image starts\n- Earth being deformed (because of dropped frames)"
+                "description": "This applies correction on the basis of a sequential order check. While making imagery more presentable at low SNRs, it can lead to several issues:\n- Missed image starts\n- Earth being deformed (because of dropped frames)"
             }
         },
         "work": {


### PR DESCRIPTION
S-VISSR is prone to misplaced lines because of the lack of FEC, this PR addresses that by adding a  **user toggleable** option to enable rudimentary, **sequential-based** correction - if the current counter is the last one plus one, assume the next will be this one plus one and so on.

There are drawbacks to this, since the Earth can be deformed and imagery might be cut unexpectedly. For this reason, I made it toggleable - if you know what you're in for, you can use it, otherwise it can remain off. Note that it is VERY useful in cases such as 5-10 dB where a few lines might be misplaced even though imagery is more than presentable.

Results:
![image](https://github.com/user-attachments/assets/259a26a9-cc7a-4bb0-bd19-fcac0a7b8496)

Inspired by https://github.com/Foxiks/fengyun2-svissr-corrector