### PR TITLE
Option to record demodulated and Doppler-corrected audio

### DIFF
--- a/pipelines/Analog.json
+++ b/pipelines/Analog.json
@@ -37,7 +37,15 @@
           "value": 435.87e6,
           "name": "Satellite Nominal Frequency",
           "units": "Hz",
-          "description": "Frequency the satellite is transmitting."
+          "description": "Downlink frequency of the satellite."
+        },
+        "satellite_name":
+        {
+          "type": "string",
+          "value": "",
+          "name": "Satellite Name",
+          "units": "Hz",
+          "description": "Human-readable identifier for the satellite."
         },
         "modulation_type":
         {
@@ -77,12 +85,6 @@
           "generic_analog_demod":
           {
             "symbolrate": 48e3
-            //"enable_doppler": true,
-            //"satellite_norad": 57167,
-            //"satellite_frequency": 435.87e6,
-            //"options": "NFM",
-            //"bandwidth": 12500,
-            //"record_demod_audio": false
           }
         }
       }

--- a/pipelines/Analog.json
+++ b/pipelines/Analog.json
@@ -1,0 +1,90 @@
+{
+    "analog_demod": {
+        "name": "Analog Demodulation",
+        "live": true,
+        "live_cfg": [
+            [
+                1,
+                0
+            ]
+        ],
+      "parameters":
+      {
+        "start_timestamp":
+        {
+          "type": "timestamp",
+          "value": -1,
+          "name": "Start Timestamp",
+          "description": "Unix timestamp of the start of the file provided.\nRequired for doppler correction, along with your QTH.\n\nIf your baseband filename is a support format it will be read automatically."
+        },
+        "enable_doppler":
+        {
+          "type": "bool",
+          "value": true,
+          "name": "Doppler Correction",
+          "description": "Apply doppler correction"
+        },
+        "satellite_norad":
+        {
+          "type": "int",
+          "value": 57167,
+          "name": "Satellite NORAD Number",
+          "description": "NORAD number identifying the satellite to correct the Doppler effect for."
+        },
+        "satellite_frequency":
+        {
+          "type": "notated_int",
+          "value": 435.87e6,
+          "name": "Satellite Nominal Frequency",
+          "units": "Hz",
+          "description": "Frequency the satellite is transmitting."
+        },
+        "modulation_type":
+        {
+          "type": "options",
+          "value": "AM",
+          "options":
+          [
+            "AM",
+            "NFM"
+          ],
+          "name": "Modulation Technique",
+          "description": "The analog modulation technique to demodulate."
+        },
+        "bandwidth":
+        {
+          "type": "notated_int",
+          "value": 12500,
+          "name": "Bandwidth",
+          "units": "Hz",
+          "description": "Samplerate of the demodulated signal."
+        },
+        "record_demod_audio":
+        {
+          "type": "bool",
+          "value": true,
+          "name": "Record Audio from Demodulation",
+          "description": "Write the resulting audio signal after demodulation to a file."
+        }
+      },
+      "work":
+      {
+        "baseband":
+        {
+        },
+        "audio_wav":
+        {
+          "generic_analog_demod":
+          {
+            "symbolrate": 48e3
+            //"enable_doppler": true,
+            //"satellite_norad": 57167,
+            //"satellite_frequency": 435.87e6,
+            //"options": "NFM",
+            //"bandwidth": 12500,
+            //"record_demod_audio": false
+          }
+        }
+      }
+    }
+}

--- a/plugins/analog_support/generic/module_generic_analog_demod.cpp
+++ b/plugins/analog_support/generic/module_generic_analog_demod.cpp
@@ -79,7 +79,7 @@ namespace generic_analog
             {
                 output_file_hint.push_back('_');
                 output_file_hint.append(
-                    safe_string(
+                    make_safe_string(
                         std::to_string(
                             d_parameters["satellite_norad"].get<nlohmann::json::number_unsigned_t>()
                         )
@@ -88,10 +88,10 @@ namespace generic_analog
             }
 
             // append satellite name to filename
-            if (d_parameters.contains("satellite_name") && d_parameters["satellite_name"].size() > 0)
+            if (d_parameters.contains("satellite_name") && d_parameters["satellite_name"].get<nlohmann::json::string_t>().size() > 0)
             {
                 output_file_hint.push_back('_');
-                output_file_hint.append(safe_string(d_parameters["satellite_name"]));
+                output_file_hint.append(make_safe_string(d_parameters["satellite_name"]));
             }
 
             // append satellite downlink frequency to filename
@@ -99,7 +99,7 @@ namespace generic_analog
             {
                 output_file_hint.push_back('_');
                 output_file_hint.append(
-                    safe_string(
+                    make_safe_string(
                         std::to_string(
                             d_parameters["satellite_frequency"].get<nlohmann::json::number_unsigned_t>()
                         ) + "Hz"
@@ -355,7 +355,7 @@ namespace generic_analog
         drawFFT();
     }
 
-    std::string GenericAnalogDemodModule::safe_string(const std::string& str)
+    std::string GenericAnalogDemodModule::make_safe_string(const std::string& str)
     {
         std::string safe_str;
         for (const char c : str)
@@ -364,10 +364,14 @@ namespace generic_analog
             {
                 safe_str.push_back(c);
             }
-            else if (safe_str.back() != '_') // replace other characters with _
+            else if (safe_str.empty() || safe_str.back() != '_') // replace other characters with underscore
             {
                 safe_str.push_back('_'); // but only once in a row
             }
+        }
+        if (!safe_str.empty() && safe_str.back() == '_') // remove trailing underscore
+        {
+            safe_str.pop_back();
         }
         return safe_str;
     }

--- a/plugins/analog_support/generic/module_generic_analog_demod.h
+++ b/plugins/analog_support/generic/module_generic_analog_demod.h
@@ -38,7 +38,7 @@ namespace generic_analog
         bool enable_audio = false;
 
     private:
-        std::string safe_string(const std::string& str);
+        std::string make_safe_string(const std::string& str);
 
     public:
         static std::string getID();

--- a/plugins/analog_support/generic/module_generic_analog_demod.h
+++ b/plugins/analog_support/generic/module_generic_analog_demod.h
@@ -7,18 +7,20 @@ namespace generic_analog
 {
     class GenericAnalogDemodModule : public demod::BaseDemodModule
     {
+        enum ModulationType : int
+        {
+            AM,
+            NFM
+        };
+
     protected:
         std::shared_ptr<dsp::RationalResamplerBlock<complex_t>> res;
         std::shared_ptr<dsp::QuadratureDemodBlock> qua;
 
-
-        bool nfm_demod = true;
-        bool am_demod = false;
-
-        
         bool settings_changed = false;
         int upcoming_symbolrate = 0;
-        int e = 0;
+        bool record_demod_audio = false;
+        ModulationType modulation_type = ModulationType::AM;
 
         bool play_audio;
         uint64_t audio_samplerate = 48e3;

--- a/plugins/analog_support/generic/module_generic_analog_demod.h
+++ b/plugins/analog_support/generic/module_generic_analog_demod.h
@@ -37,6 +37,9 @@ namespace generic_analog
 
         bool enable_audio = false;
 
+    private:
+        std::string safe_string(const std::string& str);
+
     public:
         static std::string getID();
         virtual std::string getIDM() { return getID(); };


### PR DESCRIPTION
I added two features SatDump was missing for my purposes:

1. An option to record AM or FM demodulated audio to a file for manual post-processing.
2. Apply Doppler correction when demodulating AM or FM.

All puzzle pieces were already there - I just connected them 🙂

# Changes

The implementation was done in the plugin `Generic Analog Demod` and a new pipeline "Analog Demodulation" was added.

Multiple new pipeline keys were introduced:

- `modulation_type`: `AM` or `NFM`,
- `record_demod_audio`: `true` to enable recording to a file
- `satellite_name`: name of the satellite for display, included in recording filename

Setting `enable_doppler = false` and `record_demod_audio` restores the original behavior of the plugin.

# Example

![Pipeline configuration UI](https://github.com/user-attachments/assets/1850af8f-e2e5-4bf0-9c62-764d43855910)

An example for recording the Doppler corrected AM-demodulated audio of SEEDS II's CW telemetry downlink looks like this:

```
{
    "parameters": {
        ...
    },
    ...
    "tracking": {
        ...
    },
    "tracked_objects": [
        {
            "norad": 32791,
            "downlinks": [
                {
                    "frequency": 437485000,
                    "record": false,
                    "live": true,
                    "pipeline_name": "analog_demod",
                    "pipeline_params": {
                        "bandwidth": 2500,
                        "dc_block": false,
                        "enable_doppler": true,
                        "freq_shift": 0,
                        "iq_swap": false,
                        "modulation_type": "AM",
                        "record_demod_audio": true,
                        "satellite_frequency": 437485000,
                        "satellite_norad": 32791,
                        "satellite_name": "SEEDS II (CO-66)",
                        "start_timestamp": -1.0
                    },
                    "baseband_format": "cs16",
                    "baseband_decimation": 1
                }
            ]
        }
```

The resulting filenames contain important metainformation (NORAD, satellite name, and downlink frequency), e.g. `analog_demod_32791_SEEDS_II_CO_66_437485000Hz`.