### PR TITLE
New Elektro-L LRIT pll bandwidth

### DIFF
--- a/pipelines/Elektro_Arktika.json
+++ b/pipelines/Elektro_Arktika.json
@@ -107,7 +107,7 @@
                     "constellation": "bpsk",
                     "symbolrate": 294000,
                     "rrc_alpha": 0.5,
-                    "pll_bw": 0.02,
+                    "pll_bw": 0.0145,
                     "max_sps": 3
                 }
             },


### PR DESCRIPTION
This bandwidth offers a **significantly** stabler lock at low SNRs, shouldn't have an effect on better ones. A stable lock at 0.8 dB is possible with it, while the old pipeline sometimes unlocked even at 2 dB.