### PR TITLE
Double VCID check in CADU for MSU-GS

### DIFF
--- a/plugins/elektro_arktika_support/elektro_arktika/instruments/msugs/module_msugs.cpp
+++ b/plugins/elektro_arktika_support/elektro_arktika/instruments/msugs/module_msugs.cpp
@@ -46,26 +46,27 @@ namespace elektro_arktika
                 data_in.read((char *)cadu, 1024);
 
                 int vcid = (cadu[5] >> 1) & 7;
+                int vcid_2 = (cadu[11] >> 1) & 7;
 
-                if (vcid == 2)
+                if ((vcid == 2) || (vcid_2 == 2))
                 {
                     std::vector<std::vector<uint8_t>> frames = deframerVIS1.work(&cadu[24], 1024 - 24);
                     for (std::vector<uint8_t> &frame : frames)
                         vis1_reader.pushFrame(&frame[0], offset);
                 }
-                else if (vcid == 3)
+                else if ((vcid == 3) || (vcid_2 == 3))
                 {
                     std::vector<std::vector<uint8_t>> frames = deframerVIS2.work(&cadu[24], 1024 - 24);
                     for (std::vector<uint8_t> &frame : frames)
                         vis2_reader.pushFrame(&frame[0], offset);
                 }
-                else if (vcid == 5)
+                else if ((vcid == 5) || (vcid_2 == 5))
                 {
                     std::vector<std::vector<uint8_t>> frames = deframerVIS3.work(&cadu[24], 1024 - 24);
                     for (std::vector<uint8_t> &frame : frames)
                         vis3_reader.pushFrame(&frame[0], offset);
                 }
-                else if (vcid == 4)
+                else if ((vcid == 4) || (vcid_2 == 4))
                 {
                     std::vector<std::vector<uint8_t>> frames = deframerIR.work(&cadu[24], 1024 - 24);
                     for (std::vector<uint8_t> &frame : frames)


### PR DESCRIPTION
I noticed that CADU has a backup for VCID. Checking it helps to extract data with low SNR more effectively.
![image](https://github.com/user-attachments/assets/3a9fac74-a312-43a8-8ca4-b0c1bf57ebf1)
