### PR TITLE
Improves GGAK sync performance

### DIFF
--- a/resources/credits.md
+++ b/resources/credits.md
@@ -107,6 +107,7 @@ First time here? See the reference documents below to get started using SatDump.
 - Jpjonte
 - LazzSnazz
 - Mark Pentier
+- Meti (@cpt_dingus)
 - MeteoOleg
 - Oleg Kutkov
 - Peter Kooistra

--- a/resources/pipelines/Elektro_Arktika.json
+++ b/resources/pipelines/Elektro_Arktika.json
@@ -203,7 +203,7 @@
                 "module": "pm_demod",
                 "parameters": {
                     "symbolrate": 5e3,
-                    "pll_bw": 0.01,
+                    "pll_bw": 0.02,
                     "rrc_alpha": 0.5
                 }
             },
@@ -238,7 +238,7 @@
                 "module": "pm_demod",
                 "parameters": {
                     "symbolrate": 5e3,
-                    "pll_bw": 0.01,
+                    "pll_bw": 0.02,
                     "rrc_alpha": 0.5
                 }
             },


### PR DESCRIPTION
GGAK loves to get stuck at +/- 3 kHz of the signal and never sync, I have seen a significant improvement with this PLL bandwidth with the pipeline eventually jumping to the correct one. 0.025 has been reported to work good as well, I have only tested 0.02 though.