### PR TITLE
Makes the invalid SPS error more user friendy

### DIFF
--- a/src-core/pipeline/modules/demod/module_demod_base.cpp
+++ b/src-core/pipeline/modules/demod/module_demod_base.cpp
@@ -94,8 +94,17 @@ namespace satdump
                 logger->debug("Dec factor : %f", decimation_factor);
                 logger->debug("Final SPS : %f", final_sps);
 
+                // clang-format off
                 if (input_sps < 1.0)
-                    throw satdump_exception("SPS is invalid. Must be above 1!");
+                    // Formats according to the symbol rate (0.001 Msps would be awful to read)
+                    throw satdump_exception("Your sampling rate is too low! Minimum: " +
+                        (
+                        d_symbolrate > 1e6
+                        ? std::to_string(d_symbolrate / 1e6) + " Msps"
+                        : std::to_string(d_symbolrate / 1e3) + " ksps"
+                        )
+                    );
+                // clang-format on
 
                 // Init DSP Blocks
                 if (input_data_type == DATA_FILE)


### PR DESCRIPTION
Before it was a generic `SPS is invalid. Must be above 1!` which doesn't convey what it is trying to say at all, instead just describing the calling condition

This makes the error properly say what's wrong:
<img width="306" height="108" alt="image" src="https://github.com/user-attachments/assets/0925f635-43bd-402e-96bf-68518c08b188" />
<img width="304" height="100" alt="image" src="https://github.com/user-attachments/assets/ef9fb318-888d-4f05-937c-6bc204358d33" />
