### PR TITLE
Fixed crash on paste & go when clipboard doesn't have text

### DIFF
--- a/src-interface/explorer/explorer.cpp
+++ b/src-interface/explorer/explorer.cpp
@@ -222,7 +222,13 @@ namespace satdump
                         }
                         ImGui::SameLine();
                         if (ImGui::Button("Paste & Load"))
-                            tryOpenFileInExplorer(std::string(ImGui::GetClipboardText()));
+                        {
+                            // Returns nullptr if clipboard didn't have text or failed for some reason
+                            if (ImGui::GetClipboardText() != nullptr)
+                            {
+                                tryOpenFileInExplorer(std::string(ImGui::GetClipboardText()));
+                            }
+                        }
                         ImGui::EndMenu();
                     }
 


### PR DESCRIPTION
Tried casting nullptr to a string, cpp wasn't happy and crashed