### PR TITLE
Adds color+ir merges

### DIFF
--- a/resources/instrument_cfgs/goesn_imager.json
+++ b/resources/instrument_cfgs/goesn_imager.json
@@ -7,13 +7,23 @@
             "autogen": true
         },
         {
-            "name": "False Color IR Merge",
-            "expression": "cch=(2, emissive_radiance, 1.500000, 0.010000);bm=equp(maps/nasa_hd.jpg); s=(1, sun_angle, 0.000000, 32.000000);lut=lut(lut/goes/gvar/fc_lut.png);(cch * (cch) + (1-cch) * bm(0)) * (1-s) + lut(ch1, ch4, 0) * s,(cch * (cch) + (1-cch) * bm(1)) * (1-s) + lut(ch1, ch4, 1) * s,(cch * (cch) + (1-cch) * bm(2)) * (1-s) + lut(ch1, ch4, 2) * s"
+            // This could use a calibrated VIS if needed, should be good tho
+            "name": "False Color + IR Merge",
+            "expression": "cch4=(4, emissive_radiance, 5, 110); s=(4, sun_angle, 0.000000, 32.000000);lut=lut(lut/goes/gvar/fc_lut.png);lut(ch1, ch4, 0)*s+(1-s)*(1-cch4),lut(ch1, ch4, 1)*s+(1-s)*(1-cch4),lut(ch1, ch4, 2)*s+(1-s)*(1-cch4)",
+            "image": {
+                "remove_background": true
+            }
+        },
+        {
+            "name": "False Color + IR Underlay",
+            "expression": "cch=(2, emissive_radiance, 1.500000, 0.010000);bm=equp(maps/nasa_hd.jpg); s=(1, sun_angle, 0.000000, 32.000000);lut=lut(lut/goes/gvar/fc_lut.png);(cch * (cch) + (1-cch) * bm(0)) * (1-s) + lut(ch1, ch4, 0) * s,(cch * (cch) + (1-cch) * bm(1)) * (1-s) + lut(ch1, ch4, 1) * s,(cch * (cch) + (1-cch) * bm(2)) * (1-s) + lut(ch1, ch4, 2) * s",
+
         },
         {
             "name": "MCIR",
             "expression": "cch=(2, emissive_radiance, 1.500000, 0.010000);bm=equp(maps/nasa_hd.jpg); cch * (cch) + (1-cch) * bm(0), cch * (cch) + (1-cch) * bm(1), cch * (cch) + (1-cch) * bm(2)"
         },
+
         {
             "name": "AVHRR 543b IR False Color",
             "expression": "ch5 == 0 ? 0 : 1-ch5, ch4 == 0 ? 0 : 1-ch4, ch2 == 0 ? 0 : 1-ch2",

--- a/resources/instrument_cfgs/msu_gs.json
+++ b/resources/instrument_cfgs/msu_gs.json
@@ -56,10 +56,10 @@
                 "remove_background": true
             }
         },
+        // Could use calibrated visible channels if needed
         {
-            // Could use calibrated visible channels if needed
             "name": "False Color + IR Merge",
-            "expression": "cch9=({10.4um}, emissive_radiance, 15, 110);ch2^cch9,ch3^cch9,ch1^cch9",
+            "expression": "cch9=({10.4um}, emissive_radiance, 5, 130);ch2^cch9,ch3^cch9,ch1^cch9",
             "image": {
                 "remove_background": true
             }

--- a/resources/instrument_cfgs/msu_gs.json
+++ b/resources/instrument_cfgs/msu_gs.json
@@ -57,7 +57,15 @@
             }
         },
         {
-            "name": "Color IR Merge",
+            // Could use calibrated visible channels if needed
+            "name": "False Color + IR Merge",
+            "expression": "cch9=({10.4um}, emissive_radiance, 15, 110);ch2^cch9,ch3^cch9,ch1^cch9",
+            "image": {
+                "remove_background": true
+            }
+        },
+        {
+            "name": "False Color + IR Underlay",
             "expression": "bm=equp(maps/nasa_night.jpg);s=(1, sun_angle, 0.000000, 8.000000);ci=((1-ch9) - 0.4) * 1.5;s * ch3 + (1-s) * (ci * (ci) + (1-ci) * bm(0)),s * ch2 + (1-s) * (ci * (ci) + (1-ci) * bm(1)),s * ch1 + (1-s) * (ci * (ci) + (1-ci) * bm(2))",
             "image": {
                 "remove_background": true


### PR DESCRIPTION
Adds a color + IR merge without an underlay to Elektro (MSU-GS) and GOES-N (IMAGER)

<img width="1296" height="1295" alt="image" src="https://github.com/user-attachments/assets/4d9d57c0-97c0-4fd7-b9c4-fd90e57dee75" />
<img width="1402" height="1293" alt="image" src="https://github.com/user-attachments/assets/c4782cb2-214a-443a-a468-85acd00ed720" />
