### PR TITLE
S-VISSR calibration, projections, majority law handling

### DIFF
--- a/plugins/fengyun2_support/fengyun2/svissr/module_svissr_image_decoder.cpp
+++ b/plugins/fengyun2_support/fengyun2/svissr/module_svissr_image_decoder.cpp
@@ -1,19 +1,65 @@
 #include "module_svissr_image_decoder.h"
+
+#include <cstdint>
+#include <filesystem>
+#include <vector>
+
+#include "common/majority_law.h"
 #include "imgui/imgui.h"
 #include "imgui/imgui_image.h"
 #include "logger.h"
 #include "products/image_product.h"
+#include "projection/thinplatespline.h"
 #include "utils/stats.h"
-#include <cstdint>
-#include <filesystem>
 
-#define FRAME_SIZE 44356
+#define FRAME_SIZE 44356 /* Standard S-VISSR frame in bytes */
+
+// Sector ID (2) + S/C & CDAS block (126) + Constants (64) + Subcom ID (4)
+#define SUBCOM_START_OFFSET 196
+
+// Simplified mapping (100) + Orbit & attitude (128) + MANAM (410) + Calib (256+1024) + Spare (179)
+#define SUBCOM_GROUP_SIZE 2097 /* Size of the repeated (Subcommunication) section of the documentation sector */
+
+std::map<fengyun_svissr::SVISSRSubCommunicaitonBlockType, fengyun_svissr::SVISSRSubcommunicationBlock> subcom_blocks = {
+    {fengyun_svissr::Simplified_mapping, {0, 99}}, {fengyun_svissr::Orbit_and_attitude, {100, 227}}, {fengyun_svissr::MANAM, {228, 637}},
+    {fengyun_svissr::Calibration_1, {638, 893}},   {fengyun_svissr::Calibration_2, {894, 1917}},     {fengyun_svissr::Spare, {1918, 2096}}};
 
 // Return filesize
 uint64_t getFilesize(std::string filepath);
 
 namespace fengyun_svissr
 {
+    SVISSRImageDecoderModule::SVISSRImageDecoderModule(std::string input_file, std::string output_file_hint, nlohmann::json parameters)
+        : satdump::pipeline::base::FileStreamToFileStreamModule(input_file, output_file_hint, parameters)
+    {
+        frame = new uint8_t[FRAME_SIZE * 2];
+
+        // Counter related vars
+        counter_locked = false;
+        global_counter = 0;
+        apply_correction = parameters.contains("apply_correction") ? parameters["apply_correction"].get<bool>() : false;
+        backwardScan = false;
+
+        fsfsm_enable_output = false;
+
+        vissrImageReader.reset();
+    }
+
+    SVISSRImageDecoderModule::~SVISSRImageDecoderModule()
+    {
+        delete[] frame;
+
+        if (textureID != 0)
+        {
+            delete[] textureBuffer;
+            // deleteImageTexture(textureID);
+        }
+
+        subcommunication_frames.clear();
+        // delete[] minor_frame;
+        group_retransmissions.clear();
+    }
+
     std::string SVISSRImageDecoderModule::getSvissrFilename(std::tm *timeReadable, std::string channel)
     {
         std::string utc_filename = sat_name + "_" + channel + "_" +                                                                                             // Satellite name and channel
@@ -26,41 +72,90 @@ namespace fengyun_svissr
         return utc_filename;
     }
 
+    /**
+     * Extracts a specific block from the subcommunication minor frame
+     * @param subcom_frame The minor frame to get the block from
+     * @param block_type The SVISSRSubCommunicaitonBlockType to get
+     */
+    std::vector<uint8_t> get_subcom_block(MinorFrame subcom_frame, SVISSRSubCommunicaitonBlockType block_type)
+    {
+        // Subcommunication frames are ALWAYS the same size, if we don't have the size, something went very wrong!
+        if (subcom_frame.size() != SUBCOM_GROUP_SIZE * 25)
+        {
+            logger->critical("SUBCOM FRAME SIZE IS NOT CORRECT!!! Was a group missed? ABORTING!");
+            abort();
+        }
+
+        std::vector<uint8_t> output;
+
+        // Data is transmitted in 25 groups, all of which have a piece of every block type
+        for (int group = 0; group < 25; group++)
+        {
+            for (int byte = subcom_blocks[block_type].start_offset; byte <= subcom_blocks[block_type].end_offset; byte++)
+            {
+                output.push_back(subcom_frame[group * SUBCOM_GROUP_SIZE + byte]);
+            }
+        }
+
+        return output;
+    };
+
+    /**
+     * Countrs the amount of errors in a subcommunication frame's 179-byte spare. Helps us ensure we are not looking at junk.
+     * This works because it is supposed to be all zeroes. Helpful for determining SNR (ruoughly)
+     * Max errors: 1435 (theory), 716 (realstic for BPSK, 50% chance)
+     *
+     *  @param subcom_Frame The minor frame to check the spare of
+     */
+    int get_spare_errors(MinorFrame subcom_frame)
+    {
+        std::vector<uint8_t> spare = get_subcom_block(subcom_frame, Spare);
+        int errors = 0;
+
+        // The spare is 4475 bytes long (179 * 25 groups)
+        for (int byte = 0; byte < 4475; byte++)
+        {
+            uint8_t cur_byte = spare[byte];
+            for (int bit = 0; bit < 8; bit++)
+            {
+                if (((cur_byte >> bit) & 0x1) == 1)
+                {
+                    // All bits should be zero
+                    errors++;
+                }
+            }
+        }
+
+        return errors;
+    }
+
+    void SVISSRImageDecoderModule::save_minor_frame()
+    {
+        if (minor_frame.size() / SUBCOM_GROUP_SIZE == 24)
+        {
+
+            // Process the last group
+            Group last_group = majority_law(group_retransmissions, false);
+            group_retransmissions.clear();
+
+            // Add group to the frame
+            minor_frame.insert(minor_frame.end(), last_group.begin(), last_group.end());
+
+            // Save the frame
+            logger->info("Saved a subcom frame!");
+            subcommunication_frames.push_back(minor_frame);
+            minor_frame.clear();
+        }
+        else
+        {
+            logger->critical("Minor frame size is not valid! %d bytes, %f groups", minor_frame.size(), minor_frame.size() / SUBCOM_GROUP_SIZE);
+            minor_frame.clear();
+        }
+    }
+
     void SVISSRImageDecoderModule::writeImages(SVISSRBuffer &buffer)
     {
         writingImage = true;
-
-        logger->info("Found SCID " + std::to_string(buffer.scid));
-
-        if (buffer.timestamp == 0)
-        {
-            logger->warn("No timestamps were pulled! Was the reception too short? Defaulting to system time");
-            buffer.timestamp = time(0);
-        }
-        // Sanity check, if the timestamp isn't between 2000 and 2050, consider it to be incorrect
-        // (I don't think the Fengyun 2 satellites will live for another 25 years)
-        else if (buffer.timestamp < 946681200 || buffer.timestamp > 2524604400)
-        {
-            logger->warn("The pulled timestamp looks erroneous! Was the SNR too low? Defaulting to system time");
-            buffer.timestamp = time(0);
-        }
-
-        const time_t timevalue = buffer.timestamp;
-        // Copies the gmtime result since it gets modified elsewhere
-
-        std::tm timeReadable = *gmtime(&timevalue);
-        std::string timestamp = std::to_string(timeReadable.tm_year + 1900) + "-" +
-                                (timeReadable.tm_mon + 1 > 9 ? std::to_string(timeReadable.tm_mon + 1) : "0" + std::to_string(timeReadable.tm_mon + 1)) + "-" +
-                                (timeReadable.tm_mday > 9 ? std::to_string(timeReadable.tm_mday) : "0" + std::to_string(timeReadable.tm_mday)) + "_" +
-                                (timeReadable.tm_hour > 9 ? std::to_string(timeReadable.tm_hour) : "0" + std::to_string(timeReadable.tm_hour)) + "-" +
-                                (timeReadable.tm_min > 9 ? std::to_string(timeReadable.tm_min) : "0" + std::to_string(timeReadable.tm_min));
-
-        logger->info("Full disk finished, saving at " + timestamp + "...");
-
-        std::filesystem::create_directory(buffer.directory + "/" + timestamp);
-
-        std::string disk_folder = buffer.directory + "/" + timestamp;
-
         // Save products
         satdump::products::ImageProduct svissr_product;
 
@@ -105,9 +200,173 @@ namespace fengyun_svissr
             svissr_product.set_product_source("Unknown FengYun-2");
         }
 
-
         svissr_product.instrument_name = "fy2-svissr";
         svissr_product.set_product_timestamp(buffer.timestamp);
+
+        // -> SUBCOMMUNICATION BLOCK HANDLING <-
+
+        // calib lut
+        std::vector<std::pair<int, float>> lut;
+        if (!subcommunication_frames.empty())
+        {
+            std::vector<uint8_t> minor_frame = majority_law(subcommunication_frames, false);
+
+            // ----> Integrity check <----
+            int errors = get_spare_errors(minor_frame);
+            if (errors > 32)
+            {
+                logger->warn("Subcommunication data is too damaged, NOT Using! Errors: %d", errors);
+            }
+            else
+            {
+                logger->debug("Subcom data errors: %d", errors);
+                logger->debug("Pulled %d subcommunication frames", subcommunication_frames.size());
+
+                // Prepare config
+                nlohmann::json proj_cfg;
+
+                // ----> Simplified mapping (GCP) <----
+
+                // TODO: GCP loading not implemented yet
+                /*
+                std::vector<uint8_t> simplified_mapping = get_subcom_block(minor_frame, Simplified_mapping);
+
+                std::vector<satdump::projection::GCP> raw;
+                nlohmann::json gcps;
+                int gcp_count = 0;
+
+                for (int index = 0, longitude = 45, latitude = 60; index < simplified_mapping.size(); index += 4)
+                {
+                    // LONGITUDE 45°E through 165°E
+                    // LATITUDE 60°N through 60°S
+
+                    uint16_t x_offset = (uint16_t)simplified_mapping[index] << 8 | (uint16_t)simplified_mapping[index + 1];
+                    uint16_t y_offset = (uint16_t)simplified_mapping[index + 2] << 8 | (uint16_t)simplified_mapping[index + 3];
+
+                    gcps[gcp_count]["x"] = static_cast<double>(x_offset);
+                    gcps[gcp_count]["y"] = static_cast<double>(y_offset);
+                    gcps[gcp_count]["lat"] = static_cast<double>(latitude);
+                    gcps[gcp_count]["lon"] = static_cast<double>(longitude);
+                    gcp_count++;
+
+                    // just for debugging
+                    raw.push_back({static_cast<double>(x_offset), static_cast<double>(y_offset), static_cast<double>(longitude), static_cast<double>(latitude)});
+
+                    // End of a line
+                    if (longitude == 165)
+                    {
+                        latitude -= 5;
+                        longitude = 45;
+                    }
+                    else
+                    {
+                        longitude += 5;
+                    }
+                }
+                proj_cfg["type"] = "gcps_timestamps_line";
+                proj_cfg["gcp_cnt"] = gcp_count;
+                proj_cfg["gcps"] = gcps;
+                proj_cfg["gcp_spacing_x"] = 200;
+                proj_cfg["gcp_spacing_y"] = 200;
+
+
+                // SHIM
+
+                std::vector<double> timestamps;
+                timestamps.insert(timestamps.end(), buffer.image1.height(), buffer.timestamp);
+                proj_cfg["timestamps"] = timestamps;
+                svissr_product.set_proj_cfg(proj_cfg);
+                */
+
+                // ----> Orbit & Attitude block <----
+
+                std::vector<uint8_t> orbit_attitude_block = get_subcom_block(minor_frame, Orbit_and_attitude);
+
+                // - Timestamp handling -
+
+                // R6*8 -> Big endian 6 byte integer, needs 10^-8 to read the value
+                uint64_t raw_timestamp = ((uint64_t)orbit_attitude_block[0] << 40 | (uint64_t)orbit_attitude_block[1] << 32 | (uint64_t)orbit_attitude_block[2] << 24 |
+                                          (uint64_t)orbit_attitude_block[3] << 16 | (uint64_t)orbit_attitude_block[4] << 8 | (uint64_t)orbit_attitude_block[5]);
+
+                // note for future developers that will save you 6 hours of your life debugging
+                // 10x10^-8 != 10^-8
+                // i hate myself
+                double timestamp = raw_timestamp * 1e-8;
+
+                // Converts the MJD timestamp to a unix timestamp
+                buffer.timestamp = (timestamp - 40587) * 86400;
+
+                // TODOREWORK this does not work, is the offset wrong?
+
+                // ----> MANAM <----
+
+                std::vector<uint8_t> manam_data = get_subcom_block(minor_frame, MANAM);
+
+                std::string manam_path = d_output_file_hint.substr(0, d_output_file_hint.rfind('/')) + "/MANAM.txt";
+                std::ofstream outfile(manam_path, std::ios::out | std::ios::binary);
+
+                // Writes MANAM
+                outfile.write(reinterpret_cast<const char *>(&manam_data[0]), 10250);
+                outfile.close();
+
+                // ----> Calibration 1 <----
+
+                // TODO: still broken
+                /*
+                std::vector<uint8_t> Calib_1_block = get_subcom_block(minor_frame, Calibration_1);
+
+                // calibration
+                for (int index = 256; index < 512; index += 4)
+                {
+                    uint32_t value = ((uint32_t)Calib_1_block[index] << 24 | (uint32_t)Calib_1_block[index + 1] << 16 | (uint32_t)Calib_1_block[index + 2] << 8 | (uint32_t)Calib_1_block[index + 3]);
+
+                    std::string strvalue = "word: " + std::to_string(index) + " value: " + std::to_string(value * 1e-8) + "\n";
+                    outfile << strvalue;
+
+                    lut.push_back({((index - 256) / 4) + 1, value * 1e-8});
+                }
+                nlohmann::json calib_cfg = svissr_product.get_calibration_raw();
+                calib_cfg["0"] = lut;
+                svissr_product.set_calibration("generic_xrit", calib_cfg);
+                svissr_product.set_channel_unit(0, CALIBRATION_ID_ALBEDO);
+
+                */
+            }
+        }
+        else
+        {
+            logger->warn("Reception was too short or SNR was too low, projections and calibration will be disabled!");
+        }
+
+        // TODOREWORK: maybe add old timestamp handling as a backup?
+        if (buffer.timestamp == 0)
+        {
+            logger->warn("No timestamps were pulled! Was the reception too short? Defaulting to system time");
+            buffer.timestamp = time(0);
+        }
+        // Sanity check, if the timestamp isn't between 2000 and 2050, consider it to be incorrect
+        // (I don't think the Fengyun 2 satellites will live for another 25 years)
+        else if (buffer.timestamp < 946681200 || buffer.timestamp > 2524604400)
+        {
+            logger->warn("The pulled timestamp looks erroneous! Was the SNR too low? Defaulting to system time");
+            buffer.timestamp = time(0);
+        }
+
+        const time_t timevalue = buffer.timestamp;
+
+        // Copies the gmtime result since it gets modified elsewhere
+        std::tm timeReadable = *gmtime(&timevalue);
+        std::string timestamp = std::to_string(timeReadable.tm_year + 1900) + "-" +
+                                (timeReadable.tm_mon + 1 > 9 ? std::to_string(timeReadable.tm_mon + 1) : "0" + std::to_string(timeReadable.tm_mon + 1)) + "-" +
+                                (timeReadable.tm_mday > 9 ? std::to_string(timeReadable.tm_mday) : "0" + std::to_string(timeReadable.tm_mday)) + "_" +
+                                (timeReadable.tm_hour > 9 ? std::to_string(timeReadable.tm_hour) : "0" + std::to_string(timeReadable.tm_hour)) + "-" +
+                                (timeReadable.tm_min > 9 ? std::to_string(timeReadable.tm_min) : "0" + std::to_string(timeReadable.tm_min));
+
+        logger->info("Full disk finished, saving at " + timestamp + "...");
+
+        std::filesystem::create_directory(buffer.directory + "/" + timestamp);
+
+        std::string disk_folder = buffer.directory + "/" + timestamp;
 
         // Raw Images
         svissr_product.images.push_back({0, getSvissrFilename(&timeReadable, "1"), "1", buffer.image5, 10, satdump::ChannelTransform().init_none()});
@@ -116,7 +375,6 @@ namespace fengyun_svissr
         svissr_product.images.push_back({3, getSvissrFilename(&timeReadable, "4"), "4", buffer.image1, 10, satdump::ChannelTransform().init_affine(4, 4, 0, 0)});
         svissr_product.images.push_back({4, getSvissrFilename(&timeReadable, "5"), "5", buffer.image2, 10, satdump::ChannelTransform().init_affine(4, 4, 0, 0)});
 
-        // Set the channel wavelengths
         svissr_product.set_channel_wavenumber(0, freq_to_wavenumber(SPEED_OF_LIGHT_M_S / 0.65e-6));
         svissr_product.set_channel_wavenumber(1, freq_to_wavenumber(SPEED_OF_LIGHT_M_S / 3.75e-6));
         svissr_product.set_channel_wavenumber(2, freq_to_wavenumber(SPEED_OF_LIGHT_M_S / 7.15e-6));
@@ -136,33 +394,6 @@ namespace fengyun_svissr
         writingImage = false;
     }
 
-    SVISSRImageDecoderModule::SVISSRImageDecoderModule(std::string input_file, std::string output_file_hint, nlohmann::json parameters)
-        : satdump::pipeline::base::FileStreamToFileStreamModule(input_file, output_file_hint, parameters)
-    {
-        frame = new uint8_t[FRAME_SIZE * 2];
-
-        // Counter related vars
-        counter_locked = false;
-        global_counter = 0;
-        apply_correction = parameters.contains("apply_correction") ? parameters["apply_correction"].get<bool>() : false;
-        backwardScan = false;
-
-        fsfsm_enable_output = false;
-
-        vissrImageReader.reset();
-    }
-
-    SVISSRImageDecoderModule::~SVISSRImageDecoderModule()
-    {
-        delete[] frame;
-
-        if (textureID != 0)
-        {
-            delete[] textureBuffer;
-            // deleteImageTexture(textureID);
-        }
-    }
-
     void SVISSRImageDecoderModule::process()
     {
         std::string directory = d_output_file_hint.substr(0, d_output_file_hint.rfind('/')) + "/IMAGE";
@@ -175,6 +406,8 @@ namespace fengyun_svissr
 
         uint8_t last_status[20];
         memset(last_status, 0, 20);
+
+        int last_group_id = 0;
 
         valid_lines = 0;
 
@@ -191,159 +424,187 @@ namespace fengyun_svissr
             // Read a buffer
             read_data((uint8_t *)frame, FRAME_SIZE);
 
-            // Do the actual work
+            // Parse counter
+            int counter = frame[67] << 8 | frame[68];
+
+            // Does correction logic if specified by the user
+            if (apply_correction)
             {
-                // Parse counter
-                int counter = frame[67] << 8 | frame[68];
-
-                // Does correction logic if specified by the user
-                if (apply_correction)
-                {
-                    // Unlocks if we are starting a new series
-                    if (counter_locked && (counter == 1 || counter == 2))
-                    {
-                        counter_locked = false;
-                    }
-                    else if (!counter_locked)
-                    {
-                        // Can we lock?
-                        if (counter == global_counter + 1)
-                        {
-                            // LOCKED!
-                            logger->debug("Counter correction LOCKED! Counter: " + std::to_string(counter));
-                            counter_locked = true;
-                        }
-                        else
-                        {
-                            // We can't lock, save this counter for a check on the next one
-                            global_counter = counter;
-                        }
-                    }
-
-                    // We are locked, assume this frame's counter is the previous one plus one.
-                    if (counter_locked)
-                    {
-                        counter = global_counter + 1;
-                        global_counter = counter;
-
-                        // The counter used in the decoding process is pulled from the frame,
-                        // so we rewrite it here.
-                        frame[67] = (counter >> 8) & 0xFF;
-                        frame[68] = counter & 0xFF;
-                    }
-                }
-
-                // ID of the block group: Simplified mapping, Orbit and attitude data, MANAM,
-                // Calibration block 1 and 2 are all sent in 25 separate groups because of their
-                // size. The group ID defines which group is sent. Every group gets transmitted
-                // 8 times every 200 lines, the retransmission counter is at the 195th byte
-                int group_id = frame[193];
-
-                // First 6 bytes from the Orbit and Attitude header, which is sent in 25 100-byte pieces
-                // We need the first piece -> GID = 0
-                if (group_id == 0)
-                {
-
-                    // R6*8 -> Big endian 6 byte integer, needs 10^-8 to read the value
-                    uint64_t raw =
-                        ((uint64_t)frame[296] << 40 | (uint64_t)frame[297] << 32 | (uint64_t)frame[298] << 24 | (uint64_t)frame[299] << 16 | (uint64_t)frame[300] << 8 | (uint64_t)frame[301]);
-
-                    // note for future developers that will save you 6 hours of your life debugging
-                    // 10x10^-8 != 10^-8
-                    // i hate myself
-                    double timestamp = raw * 1e-8;
-
-                    // Converts the MJD timestamp to a unix timestamp
-                    timestamp_stats.push_back(((timestamp - 40587) * 86400));
-                }
-
-                // Parse SCID
-                int scid = frame[91];
-
-                scid_stats.push_back(scid);
-
-                // Safeguard
-                if (counter > 2500)
-                    continue;
-
-                // Parse scan status
-                int status = frame[3] & 0b11; // Decoder scan status
-
-                // We only want forward scan data
-                backwardScan = status == 0;
-
-                memmove(last_status, &last_status[1], 19);
-                last_status[19] = backwardScan;
-
-                // std::cout << counter << std::endl;
-
-                // Try to detect a new scan
-                uint8_t is_back = satdump::most_common(&last_status[0], &last_status[20], 0);
-
-                // Ensures the counter doesn't lock during rollback
-                // Situation:
-                //   Image ends -> Rollback starts -> Corrector erroneously locks during rollback
-                //   -> Corrector shows "LOCKED" until 40 rollback lines are scanned
-                if (is_back && valid_lines < 5)
+                // Unlocks if we are starting a new series
+                if (counter_locked && (counter == 1 || counter == 2))
                 {
                     counter_locked = false;
                 }
-
-                if (is_back && valid_lines > 40)
+                else if (!counter_locked)
                 {
-                    logger->info("Full disk end detected!");
-
-                    // Image has ended, unlock the corrector (if it was enabled)
-                    counter_locked = false;
-
-                    std::shared_ptr<SVISSRBuffer> buffer = std::make_shared<SVISSRBuffer>();
-
-                    // Backup images
-                    buffer->image1 = vissrImageReader.getImageIR1();
-                    buffer->image2 = vissrImageReader.getImageIR2();
-                    buffer->image3 = vissrImageReader.getImageIR3();
-                    buffer->image4 = vissrImageReader.getImageIR4();
-                    buffer->image5 = vissrImageReader.getImageVIS();
-
-                    buffer->scid = satdump::most_common(scid_stats.begin(), scid_stats.end(), 0);
-                    scid_stats.clear();
-
-                    // TODOREWORK majority law would be incredibly useful here, but needs N-element
-                    // implementation because we might sync less frames than intended
-                    // Please note that the timestamps are already converted to unix timestamps,
-                    // this would have to happen on the raw JD one (see where the the stats are pushed to)
-
-                    buffer->timestamp = satdump::most_common(timestamp_stats.begin(), timestamp_stats.end(), 0);
-                    timestamp_stats.clear();
-
-                    buffer->directory = directory;
-
-                    // Write those
-                    if (is_live)
+                    // Can we lock?
+                    if (counter == global_counter + 1)
                     {
-                        images_queue_mtx.lock();
-                        images_queue.push_back(buffer);
-                        images_queue_mtx.unlock();
+                        // LOCKED!
+                        logger->debug("Counter correction LOCKED! Counter: " + std::to_string(counter));
+                        counter_locked = true;
                     }
                     else
                     {
-                        writeImages(*buffer);
+                        // We can't lock, save this counter for a check on the next one
+                        global_counter = counter;
                     }
-
-                    // Reset readers
-                    vissrImageReader.reset();
-                    valid_lines = 0;
                 }
 
-                if (backwardScan)
-                    continue;
+                // We are locked, assume this frame's counter is the previous one plus one.
+                if (counter_locked)
+                {
+                    counter = global_counter + 1;
+                    global_counter = counter;
 
-                // Process it
-                vissrImageReader.pushFrame(frame);
-                valid_lines++;
-
-                approx_progess = round(((float)counter / 2500.0f) * 1000.0f) / 10.0f;
+                    // The counter used in the decoding process is pulled from the frame,
+                    // so we rewrite it here.
+                    frame[67] = (counter >> 8) & 0xFF;
+                    frame[68] = counter & 0xFF;
+                }
             }
+
+            // ID of the block group: Simplified mapping, Orbit and attitude data, MANAM,
+            // Calibration block 1 and 2 are all sent in 25 separate groups because of their
+            // size. The group ID defines which group is sent. Every group gets transmitted
+            // 8 times every 200 lines
+            // Masked since max GID is 25. Increases reliability
+            int group_id = frame[193] & 0x1f;
+
+            // Each group is transmitted 8 subsequent times
+            // int repeat_id = frame[195];
+
+            if (group_id != last_group_id)
+            {
+
+                // Subcom frame finished, we should have 24 saved (1 still in buffer)
+                if (group_id == 0 && last_group_id == 24)
+                {
+                    save_minor_frame();
+                }
+                // We have finished this group, save it. If we didn't get the previous groups, do NOT Proceed!!!
+                else if (group_retransmissions.size() < 9 && (minor_frame.size() / SUBCOM_GROUP_SIZE) == group_id - 1 //&& group_id-last_group_id==1
+                )
+                {
+                    // TODO: how to avoid junk? if we lose sync within a group we screw the whole thing over
+                    // has to be more robust when it comes to frame drops too!!!
+                    if (!group_retransmissions.empty())
+                    { // The group is finished, push back the result of majority law to the minor frame set
+                        Group group = majority_law(group_retransmissions, false);
+                        minor_frame.insert(minor_frame.end(), group.begin(), group.end());
+
+                        group_retransmissions.clear();
+                    }
+                    else
+                    {
+                        // Can happen if we sync 1/8 frames
+                        logger->debug("TRIED SAVING EMPTY RETRANSMISSION GROUP!!!");
+                    }
+                }
+                else if (group_retransmissions.size() > 8)
+                {
+                    logger->critical("GROUP RETRANSMISSIONS OVERFLOW!!!!");
+                    group_retransmissions.clear();
+                }
+            }
+            else
+            {
+                // We are in the middle of a group repetition, save it
+
+                // If we have a group saved, we are in a new frame!!! Save it too
+                // ONLY save it if we got the previous ones already
+                if ((minor_frame.size() / SUBCOM_GROUP_SIZE) == group_id)
+                {
+                    Group current_retransmission(frame + SUBCOM_START_OFFSET, frame + SUBCOM_START_OFFSET + SUBCOM_GROUP_SIZE);
+                    group_retransmissions.push_back(current_retransmission);
+                }
+                else
+                {
+                    // We missed the beginning of the frame, discard the rest as it is useless
+                    group_retransmissions.clear();
+                }
+            }
+
+            // Store the last GID to make sure we can parse the retransmission groups
+            last_group_id = group_id;
+
+            // Parse Spacecraft ID (SC/ID)
+            int scid = frame[91];
+
+            scid_stats.push_back(scid);
+
+            // Safeguard
+            if (counter > 2500)
+                continue;
+
+            // We only want forward scan data
+            backwardScan = (frame[3] & 0b11) == 0;
+
+            memmove(last_status, &last_status[1], 19);
+            last_status[19] = backwardScan;
+
+            // Try to detect a new scan
+            uint8_t backward_scanning = satdump::most_common(&last_status[0], &last_status[20], 0);
+
+            // Ensures the counter doesn't lock during rollback
+            // Situation:
+            //   Image ends -> Rollback starts -> Corrector erroneously locks during rollback
+            //   -> Corrector shows "LOCKED" until 40 rollback lines are scanned
+            if (backward_scanning && valid_lines < 5)
+            {
+                counter_locked = false;
+            }
+
+            if (backward_scanning && valid_lines > 40)
+            {
+                logger->info("Full disk end detected!");
+
+                // Image has ended, unlock the corrector (if it was enabled)
+                counter_locked = false;
+
+                std::shared_ptr<SVISSRBuffer> buffer = std::make_shared<SVISSRBuffer>();
+
+                // Backup images
+                buffer->image1 = vissrImageReader.getImageIR1();
+                buffer->image2 = vissrImageReader.getImageIR2();
+                buffer->image3 = vissrImageReader.getImageIR3();
+                buffer->image4 = vissrImageReader.getImageIR4();
+                buffer->image5 = vissrImageReader.getImageVIS();
+
+                buffer->scid = satdump::most_common(scid_stats.begin(), scid_stats.end(), 0);
+                scid_stats.clear();
+
+                // TODOREWORK majority law would be incredibly useful here, but needs N-element
+                // implementation because we might sync less frames than intended
+                // Please note that the timestamps are already converted to unix timestamps,
+                // this would have to happen on the raw JD one (see where the the stats are pushed to)
+
+                buffer->directory = directory;
+
+                // Write those
+                if (is_live)
+                {
+                    images_queue_mtx.lock();
+                    images_queue.push_back(buffer);
+                    images_queue_mtx.unlock();
+                }
+                else
+                {
+                    writeImages(*buffer);
+                }
+
+                // Reset readers
+                vissrImageReader.reset();
+                valid_lines = 0;
+            }
+
+            if (backwardScan)
+                continue;
+
+            // Process it
+            vissrImageReader.pushFrame(frame);
+            valid_lines++;
+            approx_progess = round(((float)counter / 2500.0f) * 1000.0f) / 10.0f;
         }
 
         cleanup();
@@ -363,14 +624,6 @@ namespace fengyun_svissr
 
             buffer->scid = satdump::most_common(scid_stats.begin(), scid_stats.end(), 0);
             scid_stats.clear();
-
-            // TODOREWORK majority law would be incredibly useful here, but needs N-element
-            // implementation because we might sync less frames than intended
-            // Please note that the timestamps are already converted to unix timestamps,
-            // this would have to happen on the raw JD one (see where the the stats are pushed to)
-
-            buffer->timestamp = satdump::most_common(timestamp_stats.begin(), timestamp_stats.end(), 0);
-            timestamp_stats.clear();
 
             buffer->directory = directory;
 
@@ -397,14 +650,6 @@ namespace fengyun_svissr
 
             buffer->scid = satdump::most_common(scid_stats.begin(), scid_stats.end(), 0);
             scid_stats.clear();
-
-            // TODOREWORK majority law would be incredibly useful here, but needs N-element
-            // implementation because we might sync less frames than intended
-            // Please note that the timestamps are already converted to unix timestamps,
-            // this would have to happen on the raw JD one (see where the the stats are pushed to)
-
-            buffer->timestamp = satdump::most_common(timestamp_stats.begin(), timestamp_stats.end(), 0);
-            timestamp_stats.clear();
 
             buffer->directory = directory;
 

--- a/src-core/common/majority_law.cpp
+++ b/src-core/common/majority_law.cpp
@@ -1,0 +1,79 @@
+#include "logger.h"
+#include <unordered_map>
+#include <vector>
+
+/**
+ * Applies majority law between input elements on a bit level, returns a vector of the corrected value
+ * @param elements A vector of vectors of bytes to apply majority law between. ALL ELEMENT VECTORS SHOULD BE THE SAME SIZE!!!
+ * @param big_endian If the data should be interpreted in big endian order (back to front)
+ */
+std::vector<unsigned char> majority_law(std::vector<std::vector<unsigned char>> input, bool big_endian)
+{
+    std::vector<unsigned char> output;
+    std::unordered_map<int, int> votes = {{0, 0}, {1, 0}};
+    int byte_count = input[0].size();
+    int stop_byte_count = byte_count;
+    
+    if (byte_count == 0)
+    {
+        logger->error("Majority law was attempted with an empty vector!");
+        return output;
+    }
+
+    int cur_byte_position = 0;
+    if (big_endian)
+    {
+        cur_byte_position = byte_count - 1;
+        stop_byte_count = 0;
+        
+    }
+
+    while (cur_byte_position != stop_byte_count)
+    {
+        unsigned char output_byte = 0;
+
+        for (int bit = 7; bit >= 0; bit--)
+        {
+            // Gets the bit value from each element
+            for (int element = 0; element < input.size(); element++)
+            {
+                unsigned char byte = input[element][cur_byte_position];
+
+                if (((byte >> bit) & 1) == 0)
+                {
+                    votes[0]++;
+                }
+                else
+                {
+                    votes[1]++;
+                }
+            }
+
+            // Push new bit
+            output_byte = output_byte << 1;
+
+            if (votes[1] >= votes[0])
+            {
+                // If it is meant to be one, set it to one
+                output_byte |= 1;
+            }
+
+            // Reset the votes for the next bit
+            votes[0] = 0;
+            votes[1] = 0;
+        }
+        // Add to output
+        output.push_back(output_byte);
+
+        // Big endian means we are going from the end
+        if (big_endian)
+        {
+            cur_byte_position--;
+        }
+        else
+        {
+            cur_byte_position++;
+        }
+    }
+    return output;
+}

--- a/src-core/common/majority_law.h
+++ b/src-core/common/majority_law.h
@@ -1,0 +1,3 @@
+#include <vector>
+
+std::vector<unsigned char> majority_law(std::vector<std::vector<unsigned char>> input, bool big_endian);


### PR DESCRIPTION
WIP - GCPs and calibration are not implemented yet, lotsa shims still in there

S-VISSR transmits a lot of documentation data that has never been touched before because of the way it is sent - "Sub-communication technique". It splits down the whole 52425-byte data into 25 groups, then transmits those instead, slowly building up a whole Subcommunication frame. Every group is sent 8 consecutive times, which allows us to apply majority law both between separate groups and between minor frames - we have a near guaranteed chance of getting good data even as low as 3 dB

Subcommunication block parsing gets us:
- Calibration data
- 25x25 GCPs (Projections)
- Satellite attitude data
- A rudimentary text schedule (MANAM)