### PR TITLE
Fixes android builds

### DIFF
--- a/src-core/angelscript/scriptstdstring/scriptstdstring.cpp
+++ b/src-core/angelscript/scriptstdstring/scriptstdstring.cpp
@@ -394,7 +394,7 @@ static int StringRegexFind(const string& rex, asUINT start, asUINT& outLengthOfM
 	// https://www.regular-expressions.info/stdregex.html
 	// 
 	//  std::wregex pattern(L"[[:alpha:]]+");
-	//  bool result = std::regex_match(std::wstring(L"abcdéfg"), pattern);
+	//  bool result = std::regex_match(std::wstring(L"abcdï¿½fg"), pattern);
 	//
 	// The solution from stack overflow doesn't work with MSVC
 	// https://stackoverflow.com/questions/11254232/do-c11-regular-expressions-work-with-utf-8-strings
@@ -402,7 +402,7 @@ static int StringRegexFind(const string& rex, asUINT start, asUINT& outLengthOfM
 	//  std::locale old;
 	//  std::locale::global(std::locale("en_US.UTF-8"));
 	//  std::regex pattern("[[:alpha:]]+", std::regex_constants::extended);
-	//  bool result = std::regex_match(std::string(u8"abcdéfg"), pattern);
+	//  bool result = std::regex_match(std::string(u8"abcdï¿½fg"), pattern);
 	//
 	// I've tried setting the manifest to use utf8 code page but it also doesn't work with MSVC
 	// https://learn.microsoft.com/en-us/windows/apps/design/globalizing/use-utf8-code-page
@@ -939,9 +939,9 @@ double parseFloat(const string &val, asUINT *byteCount)
 #endif
 #else
 #if !defined(ANDROID) && !defined(__psp2__)
-#endif
 	uselocale(orig_locale);
 	freelocale(locale);
+#endif
 #endif
 
 	if( byteCount )

--- a/src-core/dsp/block_simple.h
+++ b/src-core/dsp/block_simple.h
@@ -31,7 +31,7 @@ namespace satdump
                     return true;
                 }
 
-                DSPBuffer oblk = outputs[0].fifo->newBufferSamples<To>(iblk.max_size);
+                DSPBuffer oblk = outputs[0].fifo->template newBufferSamples<To>(iblk.max_size);
 
                 oblk.size = process(iblk.getSamples<Ti>(), iblk.size, oblk.getSamples<To>());
 

--- a/src-core/dsp/clock_recovery/clock_recovery_mm.cpp
+++ b/src-core/dsp/clock_recovery/clock_recovery_mm.cpp
@@ -80,7 +80,7 @@ namespace satdump
                 init();
             }
 
-            DSPBuffer oblk = outputs[0].fifo->newBufferSamples<T>(iblk.max_size);
+            DSPBuffer oblk = outputs[0].fifo->template newBufferSamples<T>(iblk.max_size);
             T *ibuf = iblk.getSamples<T>();
             T *obuf = oblk.getSamples<T>();
 

--- a/src-core/dsp/filter/fir.cpp
+++ b/src-core/dsp/filter/fir.cpp
@@ -51,7 +51,7 @@ namespace satdump
 
             while (lbuf_offset < iblk.size)
             {
-                DSPBuffer oblk = outputs[0].fifo->newBufferSamples<T>(lbuf_size);
+                DSPBuffer oblk = outputs[0].fifo->template newBufferSamples<T>(lbuf_size);
                 T *obuf = oblk.getSamples<T>();
 
                 memcpy(&buffer[ntaps], ibuf + lbuf_offset, lbuf_size * sizeof(T));

--- a/src-core/dsp/path/splitter.cpp
+++ b/src-core/dsp/path/splitter.cpp
@@ -43,7 +43,7 @@ namespace satdump
             {
                 IOInfo *i = ((IOInfo *)o.blkdata.get());
 
-                DSPBuffer oblk = o.fifo->newBufferSamples<T>(iblk.max_size);
+                DSPBuffer oblk = o.fifo->template newBufferSamples<T>(iblk.max_size);
                 memcpy(oblk.getSamples<T>(), iblk.getSamples<T>(), iblk.size * sizeof(T));
                 oblk.size = iblk.size;
                 o.fifo->wait_enqueue(oblk);


### PR DESCRIPTION
Android action has failed for the last month following this [commit](https://github.com/SatDump/SatDump/actions/runs/16916236180)

MacOS silicone also started working for some reason, can't complain

I have found two issues:

1. Angelscript if statement mishap
```
2025-09-14T21:56:40.1517364Z C/C++: /home/owner/actions-runner/_work/SatDump/SatDump/src-core/angelscript/scriptstdstring/scriptstdstring.cpp:943:12: error: use of undeclared identifier 'orig_locale'
2025-09-14T21:56:40.1521786Z C/C++: /home/owner/actions-runner/_work/SatDump/SatDump/src-core/angelscript/scriptstdstring/scriptstdstring.cpp:944:13: error: 'locale' does not refer to a value
```


The problematic code:
```cpp
#if defined(_WIN32)
    // WinCE doesn't have setlocale. Some quick testing on my current platform
    // still manages to parse the numbers such as "3.14" even if the decimal for the
    // locale is ",".
        #if !defined(ANDROID) && !defined(__psp2__)
            // On Linux and other similar systems the threadsafe option is uselocale
            // ref: https://stackoverflow.com/questions/4057319/is-setlocale-thread-safe-function
            locale_t locale = newlocale(LC_NUMERIC_MASK, "C", NULL);
            locale_t orig_locale = uselocale(locale);
        #endif
#endif

    double res = strtod(val.c_str(), &end);
    // Restore the original locale

#if defined(_WIN32)
  #if !defined(_WIN32_WCE)
      setlocale(LC_NUMERIC, orig.c_str());
      _configthreadlocale(oldConfig);
  #endif
#else 
  #if !defined(ANDROID) && !defined(__psp2__)
  #endif
  uselocale(orig_locale);  // FAILS HERE
  freelocale(locale);   // FAILS HERE
#endif
```

Issue appears to have been the penultimate #endif being above instead of below the uselocale and freelocale statements

---

2. Missing 'template' keyword in a few of the new DSP sections

```
2025-09-15T11:10:11.1483761Z C/C++: /home/owner/actions-runner/_work/SatDump/SatDump/src-core/./dsp/block_simple.h:34:51: error: use 'template' keyword to treat 'newBufferSamples' as a dependent template name
```
I won't lie I do not know c++ well enough to actually understand what the error means, clang was just angry at it and the suggested fix (adding the template keyword) appears to have made it work again.