### PR TITLE
android: Extract pipelines alongside resources

### DIFF
--- a/android/app/src/main/java/MainActivity.kt
+++ b/android/app/src/main/java/MainActivity.kt
@@ -124,6 +124,7 @@ class MainActivity : NativeActivity(), TextWatcher {
 
         // Extract all resources to the app directory
         val aman = getAssets();
+        extractDir(aman, fdir + "/pipelines", "pipelines");
         extractDir(aman, fdir + "/resources", "resources");
         // extractDir(aman, fdir + "/plugins", "plugins");
         extractFile(aman, fdir + "/satdump_cfg.json", "satdump_cfg.json");


### PR DESCRIPTION
Extract both resources and pipelines, otherwise SatDump won't start on android and complain about missing pipelines directory.