### PR TITLE
android: Lower Android version to 8.1

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 27
     buildToolsVersion "30.0.3"
     ndkVersion "25.2.9519653"
 
@@ -14,7 +14,7 @@ android {
         applicationId "org.satdump.SatDump"
         namespace "org.satdump.SatDump"
         minSdkVersion 26
-        targetSdkVersion 28
+        targetSdkVersion 27
         versionCode 9
         versionName "1.2.3"
     }
@@ -85,7 +85,7 @@ repositories {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.0.2'
+    implementation 'com.android.support:appcompat-v7:27.1.1'
 }
 
 copyResources.dependsOn deleteTempAssets

--- a/android/app/src/main/java/MainActivity.kt
+++ b/android/app/src/main/java/MainActivity.kt
@@ -18,8 +18,8 @@ import android.net.Uri;
 import RealPathUtil;
 
 import android.Manifest;
-import androidx.core.content.PermissionChecker;
-import androidx.core.app.ActivityCompat;
+import android.support.v4.content.PermissionChecker;
+import android.support.v4.app.ActivityCompat;
 import android.content.pm.PackageManager;
 import android.provider.DocumentsContract;
 


### PR DESCRIPTION
Reduce the Android version further, so SatDump can be used on Android 8.1 which is the latest version on Gemini PDA. This makes the device at least somewhat usable for portable setup.