### PR TITLE
Transit te support

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -192,6 +192,13 @@ if(PLUGIN_ANALOG OR PLUGINS_ALL)
   add_subdirectory(analog_support)
 endif()
 
+option(PLUGIN_TRANSIT
+       "Enable the support plugin for Transit 5b-5" ON)
+
+if(PLUGIN_TRANSIT OR PLUGINS_ALL)
+  add_subdirectory(transit_support)
+endif()
+
 option(PLUGIN_ORBCOMM "Enable the support plugin for the Orbcomm constellation"
        OFF)
 

--- a/plugins/transit_support/CMakeLists.txt
+++ b/plugins/transit_support/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.12)
+project(transit_support)
+
+
+file(GLOB_RECURSE transit_support_CPPS *.cpp)
+add_library(transit_support SHARED ${transit_support_CPPS})
+target_link_libraries(transit_support PUBLIC satdump_core)
+target_include_directories(transit_support PUBLIC src)
+
+install(TARGETS transit_support DESTINATION ${CMAKE_INSTALL_LIBDIR}/satdump/plugins)

--- a/plugins/transit_support/main.cpp
+++ b/plugins/transit_support/main.cpp
@@ -1,0 +1,27 @@
+#include "core/plugin.h"
+#include "logger.h"
+
+#include "module_transit_demod.h"
+#include "module_transit_decoder.h"
+#include "module_transit_data.h"
+
+class TransitSupport : public satdump::Plugin
+{
+public:
+    std::string getID() { return "transit_support"; }
+
+    void init()
+    {
+        satdump::eventBus->register_handler<satdump::pipeline::RegisterModulesEvent>(registerPluginsHandler);
+        // satdump::eventBus->register_handler<satdump::projection::RequestSatelliteRaytracerEvent>(provideSatProjHandler);
+    }
+
+    static void registerPluginsHandler(const satdump::pipeline::RegisterModulesEvent &evt)
+    {
+        REGISTER_MODULE_EXTERNAL(evt.modules_registry, transit::TransitDemodModule);
+        REGISTER_MODULE_EXTERNAL(evt.modules_registry, transit::TransitDecoderModule);
+        REGISTER_MODULE_EXTERNAL(evt.modules_registry, transit::TransitDataDecoderModule);
+    }
+};
+
+PLUGIN_LOADER(TransitSupport)

--- a/plugins/transit_support/module_transit_data.cpp
+++ b/plugins/transit_support/module_transit_data.cpp
@@ -1,0 +1,130 @@
+#include "module_transit_data.h"
+#include "common/repack.h"
+#include "common/tracking/tle.h"
+#include "common/utils.h"
+#include "core/resources.h"
+#include "imgui/imgui.h"
+#include "logger.h"
+#include "products/dataset.h"
+#include "products/punctiform_product.h"
+#include "utils/stats.h"
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+
+namespace transit
+{
+    TransitDataDecoderModule::TransitDataDecoderModule(std::string input_file, std::string output_file_hint, nlohmann::json parameters)
+        : satdump::pipeline::base::FileStreamToFileStreamModule(input_file, output_file_hint, parameters)
+    {
+        fsfsm_enable_output = false;
+    }
+
+    void TransitDataDecoderModule::process()
+    {
+        uint8_t buffer[32] = {0};
+
+        uint16_t subcom[21];
+
+        // This is bad, C++ify it instead
+        std::string tlm_csv_filename = d_output_file_hint.substr(0, d_output_file_hint.rfind('/')) + "/tlm.csv";
+        debug_f = fopen(tlm_csv_filename.c_str(), "w+");
+
+        while (should_run())
+        {
+            read_data((uint8_t *)buffer, 32);
+
+            // get FC
+            uint16_t fc = (buffer[16] << 8) | buffer[17];
+            uint32_t fc_fake = fc << 1; // make frame counter for checking coherence
+            int subframe = buffer[1] & 1;
+            fc_fake |= subframe;
+
+            // last frame was coherent
+            // this process will always miss the last frame
+            if(fc_fake == last_fc + 1)
+            {
+                // process last frame
+
+                // Assuming the telemetry follows that of 1963 38c, The satellite telemetry frame should contain 14 16 bit data registers, 1 16 bit sync word, and 1 16 bit frame counter.
+                // a full frame is composed of 2 subframes, both subframes have the same value in the frame counter and are distinguished by the sync word
+                // 12 of the 14 data registers are used for detector data (likely broken) and one of the remaining register contains telltales and and a digitised version of the PAM telemetry
+                // I don't know whether any of this is still functional, given the look of the frames it's probably mostly not, but there are clear repeating patterns in the words
+
+                // if(subframe == 0)
+                {
+                    uint16_t words[16];
+
+                    for(int word=0; word < 16; word++)
+                    {
+                        words[word] = buffer[word*2] << 8 | buffer[word*2 + 1];
+                        fprintf(debug_f, "%u,", words[word]);
+                    }
+
+                    // temp1 = words[13];
+                    // subcom[fc % 21] = temp1;
+
+                    // if(!(fc % 21))
+                    // {
+                    //     for(int i=0; i < 21; i++)
+                    //     {
+                    //         fprintf(debug_f, "%u,", subcom[i]);
+                    //     }
+                    //     fprintf(debug_f, "\n");
+                    // }
+
+                    fprintf(debug_f, "\n");
+                }
+            }
+    
+            last_fc = fc_fake;
+            memcpy(last_frame, buffer, 32);
+        }
+
+        // done with the frames
+        cleanup();
+
+        int norad = 965;
+        std::string sat_name = "Transit 5B-5";
+
+        // Products dataset
+        // satdump::products::DataSet dataset;
+        // dataset.satellite_name = sat_name;
+        // dataset.timestamp = ?;
+
+        // std::optional<satdump::TLE> satellite_tle = satdump::general_tle_registry->get_from_norad_time(norad, dataset.timestamp);
+
+        // dataset.save(d_output_file_hint.substr(0, d_output_file_hint.rfind('/')));
+
+        fclose(debug_f);
+    }
+
+    void TransitDataDecoderModule::drawUI(bool window)
+    {
+        ImGui::Begin("Transit Decoder", NULL, window ? 0 : NOWINDOW_FLAGS);
+
+        if (ImGui::BeginTable("##transitinstrumentstable", 3, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg))
+        {
+            ImGui::TableNextRow();
+            ImGui::TableSetColumnIndex(0);
+            ImGui::Text("Instrument");
+            ImGui::TableSetColumnIndex(1);
+            ImGui::Text("Lines / Frames");
+            ImGui::TableSetColumnIndex(2);
+            ImGui::Text("Status");
+
+            ImGui::EndTable();
+        }
+
+        drawProgressBar();
+
+        ImGui::End();
+    }
+
+    std::string TransitDataDecoderModule::getID() { return "transit_data"; }
+
+    std::shared_ptr<satdump::pipeline::ProcessingModule> TransitDataDecoderModule::getInstance(std::string input_file, std::string output_file_hint, nlohmann::json parameters)
+    {
+        return std::make_shared<TransitDataDecoderModule>(input_file, output_file_hint, parameters);
+    }
+} // namespace transit

--- a/plugins/transit_support/module_transit_data.h
+++ b/plugins/transit_support/module_transit_data.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "pipeline/modules/base/filestream_to_filestream.h"
+#include "pipeline/modules/instrument_utils.h"
+
+#include <stdio.h>
+
+namespace transit
+{
+    class TransitDataDecoderModule : public satdump::pipeline::base::FileStreamToFileStreamModule
+    {
+    protected:
+        uint8_t last_frame[32]; 
+        uint32_t last_fc = 0;
+        FILE* debug_f;
+
+    public:
+        TransitDataDecoderModule(std::string input_file, std::string output_file_hint, nlohmann::json parameters);
+        void process();
+        void drawUI(bool window);
+
+    public:
+        static std::string getID();
+        virtual std::string getIDM() { return getID(); };
+        static nlohmann::json getParams() { return {}; }
+        static std::shared_ptr<ProcessingModule> getInstance(std::string input_file, std::string output_file_hint, nlohmann::json parameters);
+    };
+} // namespace transit

--- a/plugins/transit_support/module_transit_decoder.cpp
+++ b/plugins/transit_support/module_transit_decoder.cpp
@@ -73,7 +73,7 @@ namespace transit
     {
         auto v = satdump::pipeline::base::FileStreamToFileStreamModule::getModuleStats();
         v["frame_count"] = frame_count;
-        v["frame_count_coherent"] = framecounter_coherent;
+        v["frame_count_coherent"] = coherent_frames;
 
         std::string deframer_state = def->getState() == 1 ? "SYNCED" : "NOSYNC";
         v["deframer_state"] = deframer_state;

--- a/plugins/transit_support/module_transit_decoder.cpp
+++ b/plugins/transit_support/module_transit_decoder.cpp
@@ -1,0 +1,163 @@
+#include "module_transit_decoder.h"
+#include "imgui/imgui.h"
+#include "logger.h"
+#include <cstdint>
+#include <volk/volk.h>
+
+// Return filesize
+uint64_t getFilesize(std::string filepath);
+
+#define BUFFER_SIZE 8192
+
+namespace transit
+{
+    TransitDecoderModule::TransitDecoderModule(std::string input_file, std::string output_file_hint, nlohmann::json parameters)
+        : satdump::pipeline::base::FileStreamToFileStreamModule(input_file, output_file_hint, parameters), constellation(1.0, 0.15, demod_constellation_size)
+    {;
+        def = std::make_shared<TransitDeframer>(0);
+
+        soft_buffer = new int8_t[BUFFER_SIZE];
+
+        fsfsm_file_ext = ".frm";
+    }
+
+    TransitDecoderModule::~TransitDecoderModule() { delete[] soft_buffer; }
+
+    void TransitDecoderModule::process()
+    {
+        while (should_run())
+        {
+            // Read a buffer
+            read_data((uint8_t *)soft_buffer, BUFFER_SIZE);
+
+            std::vector<std::vector<uint8_t>> frames = def->work(soft_buffer, BUFFER_SIZE/8);
+
+            // Count frames
+            int framen = frames.size();
+            frame_count += framen;
+
+            // Write to file
+            if (framen > 0)
+            {
+                for (int i = 0; i < framen; i++)
+                {
+                    // get frame counter
+                    uint16_t fc = (frames[i][16] << 8) | frames[i][17];
+                    uint32_t fc_fake = fc << 1;
+                    uint8_t  subframe = frames[i][1] & 1;
+                    fc_fake |= subframe;
+
+                    if(fc_fake == last_framecounter + 1)
+                    {
+                        coherent_frames++;
+                        framecounter_coherent = true;
+                    }
+                    else
+                    {
+                        framecounter_coherent = false;
+                    }
+
+                    last_framecounter = fc_fake;
+
+                    write_data((uint8_t *)frames[i].data(), 32);
+                }
+            }
+        }
+
+        logger->info("Decoding finished");
+
+        cleanup();
+    }
+
+    nlohmann::json TransitDecoderModule::getModuleStats()
+    {
+        auto v = satdump::pipeline::base::FileStreamToFileStreamModule::getModuleStats();
+        v["frame_count"] = frame_count;
+        v["frame_count_coherent"] = framecounter_coherent;
+
+        std::string deframer_state = def->getState() == 1 ? "SYNCED" : "NOSYNC";
+        v["deframer_state"] = deframer_state;
+        
+        std::string satellite_state;
+        if(def->getState() == 1)
+        {
+            if (framecounter_coherent)
+                satellite_state = "Coherent";
+            else
+                satellite_state = "Incoherent";
+        }
+        else
+        {
+            satellite_state = "N/A";
+        }
+        v["satellite_state"] = satellite_state;
+        return v;
+    }
+
+    void TransitDecoderModule::drawUI(bool window)
+    {
+        ImGui::Begin("Transit Decoder", NULL, window ? 0 : NOWINDOW_FLAGS);
+
+        ImGui::BeginGroup();
+        constellation.pushSofttAndGaussian(soft_buffer, 127, BUFFER_SIZE);
+        constellation.draw();
+        ImGui::EndGroup();
+
+        ImGui::SameLine();
+
+        ImGui::BeginGroup();
+        {
+            ImGui::Button("Deframer", {200 * ui_scale, 20 * ui_scale});
+            {
+                ImGui::Text("State : ");
+
+                ImGui::SameLine();
+
+                if (def->getState() == 1)
+                    ImGui::TextColored(style::theme.green, "SYNCED");
+                else
+                    ImGui::TextColored(style::theme.red, "NOSYNC");
+
+                ImGui::Text("Sat State : ");
+
+                ImGui::SameLine();
+
+                if(def->getState() == 1)
+                {
+                    if (framecounter_coherent)
+                        ImGui::TextColored(style::theme.green, "Coherent");
+                    else
+                        ImGui::TextColored(style::theme.red, "Incoherent");
+                }
+                else
+                {
+                    ImGui::TextColored(style::theme.red, "N/A");
+                }
+
+                ImGui::Text("Frames : ");
+
+                ImGui::SameLine();
+
+                ImGui::TextColored(style::theme.green, UITO_C_STR(frame_count));
+
+                ImGui::Text("Coherent Frames : ");
+
+                ImGui::SameLine();
+
+                ImGui::TextColored(style::theme.green, UITO_C_STR(coherent_frames));
+            }
+        }
+        ImGui::EndGroup();
+
+        drawProgressBar();
+
+        ImGui::End();
+    }
+
+    std::string TransitDecoderModule::getID() { return "transit_decoder"; }
+
+    std::shared_ptr<satdump::pipeline::ProcessingModule> TransitDecoderModule::getInstance(std::string input_file, std::string output_file_hint, nlohmann::json parameters)
+    {
+        return std::make_shared<TransitDecoderModule>(input_file, output_file_hint, parameters);
+    }
+} // namespace noaa

--- a/plugins/transit_support/module_transit_decoder.h
+++ b/plugins/transit_support/module_transit_decoder.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "transit_deframer.h"
+
+#include "common/repack_bits_byte.h"
+#include "common/widgets/constellation.h"
+#include "pipeline/modules/base/filestream_to_filestream.h"
+
+namespace transit
+{
+    class TransitDecoderModule : public satdump::pipeline::base::FileStreamToFileStreamModule
+    {
+    protected:
+        std::shared_ptr<TransitDeframer> def;
+
+        int8_t *soft_buffer;
+
+        int frame_count = 0;
+        uint32_t last_framecounter = 0;
+        int coherent_frames = 0;
+        bool framecounter_coherent = false;
+
+        // UI Stuff
+        widgets::ConstellationViewer constellation;
+
+    public:
+        TransitDecoderModule(std::string input_file, std::string output_file_hint, nlohmann::json parameters);
+        ~TransitDecoderModule();
+        void process();
+        void drawUI(bool window);
+
+        nlohmann::json getModuleStats();
+
+    public:
+        static std::string getID();
+        virtual std::string getIDM() { return getID(); };
+        static nlohmann::json getParams() { return {}; }
+        static std::shared_ptr<ProcessingModule> getInstance(std::string input_file, std::string output_file_hint, nlohmann::json parameters);
+    };
+} // namespace transit

--- a/plugins/transit_support/module_transit_demod.cpp
+++ b/plugins/transit_support/module_transit_demod.cpp
@@ -103,7 +103,8 @@ namespace transit
         fsk_lpf = std::make_shared<dsp::FIRBlock<complex_t>>(fsk_fsb->output_stream, dsp::firdes::low_pass(1.0, d_symbolrate, 1200, 1000));
         fsk_qua = std::make_shared<dsp::QuadratureDemodBlock>(fsk_lpf->output_stream, dsp::hz_to_rad(600*2, d_symbolrate));
         fsk_rrc = std::make_shared<dsp::FIRBlock<float>>(fsk_qua->output_stream, dsp::firdes::root_raised_cosine(1/(2*M_PI*630/d_symbolrate), d_symbolrate, fsk_sym_rate, 0.35, 401));
-        fsk_rec = std::make_shared<dsp::GardnerClockRecoveryBlock<float>>(fsk_rrc->output_stream, fsk_sps, d_clock_gain_omega, d_clock_mu, d_clock_gain_mu, d_clock_omega_relative_limit);
+        // fsk_rec = std::make_shared<dsp::GardnerClockRecoveryBlock<float>>(fsk_rrc->output_stream, fsk_sps, d_clock_gain_omega, d_clock_mu, d_clock_gain_mu, d_clock_omega_relative_limit);
+        fsk_rec = std::make_shared<dsp::MMClockRecoveryBlock<float>>(fsk_rrc->output_stream, fsk_sps, d_clock_gain_omega, d_clock_mu, d_clock_gain_mu, d_clock_omega_relative_limit);
 
         // USB demod to play the "music" to the user
         // values picked to make PAM sound best

--- a/plugins/transit_support/module_transit_demod.cpp
+++ b/plugins/transit_support/module_transit_demod.cpp
@@ -1,0 +1,436 @@
+#include "module_transit_demod.h"
+#include "common/audio/audio_sink.h"
+#include "common/dsp/filter/firdes.h"
+#include "common/dsp/io/wav_writer.h"
+#include "core/config.h"
+#include "imgui/imgui.h"
+#include "logger.h"
+#include <volk/volk.h>
+
+namespace transit
+{
+    TransitDemodModule::TransitDemodModule(std::string input_file, std::string output_file_hint, nlohmann::json parameters) : BaseDemodModule(input_file, output_file_hint, parameters)
+    {
+        sym_buffer = new int8_t[d_buffer_size * 4];
+        
+        // Parse params
+        if (parameters.count("save_wav") > 0)
+            save_wav = parameters["save_wav"].get<bool>();
+        if (parameters.count("save_soft") > 0)
+            save_soft = parameters["save_soft"].get<bool>();
+
+        if (parameters.count("clock_gain_omega") > 0)
+            d_clock_gain_omega = parameters["clock_gain_omega"].get<float>();
+
+        if (parameters.count("clock_mu") > 0)
+            d_clock_mu = parameters["clock_mu"].get<float>();
+
+        if (parameters.count("clock_gain_mu") > 0)
+            d_clock_gain_mu = parameters["clock_gain_mu"].get<float>();
+
+        if (parameters.count("clock_omega_relative_limit") > 0)
+            d_clock_omega_relative_limit = parameters["clock_omega_relative_limit"].get<float>();
+
+        name = "Transit Demodulator";
+        play_audio = satdump::satdump_cfg.shouldPlayAudio();
+
+        // constellation.d_hscale = 0.75; // 80.0 / 100.0;
+        // constellation.d_vscale = 0.25; // 20.0 / 100.0;
+
+        constellation.d_hscale = 0.1; // 80.0 / 100.0;
+        constellation.d_vscale = 0.2; // 20.0 / 100.0;
+
+        MIN_SPS = 1;
+        MAX_SPS = 1000.0;
+    }
+
+    void TransitDemodModule::init()
+    {
+        BaseDemodModule::initb();
+
+        // DSP implemented as per Xerbos blog posts, mostly the Part 1.5 GNU radio flowchart
+        // https://xerbo.net/posts/investigating-transit-pt1/
+        // https://xerbo.net/posts/investigating-transit-pt15/
+        // Cannot currently be completely implemented due to lack of PLL Frequency Detector block in SatDump DSP, Quadrature demod gives practically identical results
+        // The clock recovery tweaks could also not be completely replicated, but it still works alright
+        /* DSP chain (old)
+         * (c) = complex, (f) = float
+         *                    [Audio output]<-(f)[Complex to Real]<-[Band pass filter]<─[Frequency shift PAM]<┐
+         *                                                             ┌─>[Wav sink]                          │
+         *  [input IQ](c)─>[Rational Resampler]─>[Quadrature demod](f)─┴─>[Real to complex](c)────────────────┤
+         *                                                                                                    │
+         *                 ┌─[Clock recovery]<─(f)[Quadrature demod]<-[Low pass filter]<─[Frequency shift FSK]┘
+         *                 │
+         *                 └─>[Soft Symbol output]
+         */
+
+        /* DSP chain (new)
+         * (c) = complex, (f) = float
+         *                      [Audio output]<-(f)[Complex to Real]<-[Band pass filter]<─[Frequency shift PAM]<─┐
+         *                                                                                ┌─>[Wav sink]          │
+         *  [input IQ](c)─>[Rational Resampler]─>[Carrier PLL]─>[complex to imaginary](f)─┴─>[Real to complex](c)┤
+         *                                                                                                       │
+         *        ┌─[Root Raised Cosine filter]<─(f)[Quadrature demod]<-[Low pass filter]<─[Frequency shift FSK]─┘
+         *        │
+         *        └─>[Clock recovery]─>[Soft Symbol output]
+         */
+
+        // Resampler to BW
+        res = std::make_shared<dsp::RationalResamplerBlock<complex_t>>(agc->output_stream, d_symbolrate, final_samplerate);
+
+        // PLL
+        float d_carrier_pll_bw = 0.01;
+        float d_carrier_pll_max_offset = 2*M_PI*10000/d_symbolrate;
+        carrier_pll = std::make_shared<dsp::PLLCarrierTrackingBlock>(res->output_stream, d_carrier_pll_bw, d_carrier_pll_max_offset, -d_carrier_pll_max_offset);
+
+        // Quadrature demod
+        // qua = std::make_shared<dsp::QuadratureDemodBlock>(carrier_pll->output_stream, dsp::hz_to_rad(12000, d_symbolrate));
+
+        // split real demod portion to wav and demod
+        demod_stream = std::make_shared<dsp::stream<float>>();
+
+        // Convert demod'd audio back to complex for FSK demodulation
+        rtc = std::make_shared<dsp::RealToComplexBlock>(demod_stream);
+
+        double fsk_sym_rate = 4999600/12800;
+        double fsk_sps = d_symbolrate / fsk_sym_rate;
+
+        logger->info("FSK SPS: %f", fsk_sps);
+
+        // FSK demod
+        fsk_stream = std::make_shared<dsp::stream<complex_t>>();
+        fsk_fsb = std::make_shared<dsp::FreqShiftBlock>(fsk_stream, d_symbolrate, -10640);
+        fsk_lpf = std::make_shared<dsp::FIRBlock<complex_t>>(fsk_fsb->output_stream, dsp::firdes::low_pass(1.0, d_symbolrate, 1200, 1000));
+        fsk_qua = std::make_shared<dsp::QuadratureDemodBlock>(fsk_lpf->output_stream, dsp::hz_to_rad(600*2, d_symbolrate));
+        fsk_rrc = std::make_shared<dsp::FIRBlock<float>>(fsk_qua->output_stream, dsp::firdes::root_raised_cosine(1/(2*M_PI*630/d_symbolrate), d_symbolrate, fsk_sym_rate, 0.35, 401));
+        fsk_rec = std::make_shared<dsp::GardnerClockRecoveryBlock<float>>(fsk_rrc->output_stream, fsk_sps, d_clock_gain_omega, d_clock_mu, d_clock_gain_mu, d_clock_omega_relative_limit);
+
+        // USB demod to play the "music" to the user
+        // values picked to make PAM sound best
+        usb_stream = std::make_shared<dsp::stream<complex_t>>();
+        usb_fsb = std::make_shared<dsp::FreqShiftBlock>(usb_stream, d_symbolrate, -4600);
+        usb_bpf = std::make_shared<dsp::FIRBlock<complex_t>>(usb_fsb->output_stream, dsp::firdes::band_pass(1, d_symbolrate, 0, 4000, 500, dsp::fft::window::WIN_KAISER));
+    }
+
+    TransitDemodModule::~TransitDemodModule() { delete[] sym_buffer; }
+
+    void TransitDemodModule::process()
+    {
+        if (input_data_type == satdump::pipeline::DATA_FILE)
+            filesize = file_source->getFilesize();
+        else
+            filesize = 0;
+
+        logger->info("Using input baseband " + d_input_file);
+
+        if (save_wav)
+        {
+            wav_out = std::ofstream(d_output_file_hint + ".wav", std::ios::binary);
+            d_output_file = d_output_file_hint + ".wav";
+            logger->info("Demodulating to " + d_output_file_hint + ".wav");
+        }
+
+        if (save_soft || output_data_type == satdump::pipeline::DATA_FILE)
+        {
+            data_out = std::ofstream(d_output_file_hint + ".soft", std::ios::binary);
+            d_output_file = d_output_file_hint + ".soft";
+            logger->info("Demodulating to " + d_output_file_hint + ".soft");
+        }
+
+        logger->info("Buffer size : " + std::to_string(d_buffer_size));
+
+        time_t lastTime = 0;
+
+        // Start
+        BaseDemodModule::start();
+        res->start();
+        carrier_pll->start();
+        rtc->start();
+
+        fsk_fsb->start();
+        fsk_lpf->start();
+        fsk_qua->start();
+        fsk_rrc->start();
+        fsk_rec->start();
+
+        std::shared_ptr<audio::AudioSink> audio_sink;
+        if (input_data_type != satdump::pipeline::DATA_FILE && audio::has_sink())
+        {
+            enable_audio = true;
+            audio_sink = audio::get_default_sink();
+            audio_sink->set_samplerate(d_symbolrate);
+            audio_sink->start();
+
+            usb_fsb->start();
+            usb_bpf->start();
+        }
+
+        // Buffers to wav
+        float *output_real = new float[d_buffer_size * 100];
+
+        // zero buffer for interlacing real to complex
+        float *zero_buf = new float[d_buffer_size * 100];
+        memset(zero_buf, 0, d_buffer_size * 100 * sizeof(float));
+
+        complex_t *output_snr_complex = new complex_t[d_buffer_size * 100];
+
+        // these could be deduplicated
+        int16_t *output_wav_buffer = new int16_t[d_buffer_size * 100];
+        int16_t *output_audio_buffer = new int16_t[d_buffer_size * 100];
+        
+        uint64_t final_wav_size = 0;
+
+        dsp::WavWriter wave_writer(wav_out);
+        if (save_wav)
+            wave_writer.write_header(d_symbolrate, 1);
+
+        int dat_size = 0;
+        while (demod_should_run())
+        {
+            // handle DSP
+            {
+                // demod split/Wav save
+                int dat_size = carrier_pll->output_stream->read();
+
+                if(dat_size <= 0)
+                {
+                    carrier_pll->output_stream->flush();
+                }
+                else
+                {
+                    // convert complex to imaginary
+                    volk_32fc_deinterleave_imag_32f(demod_stream->writeBuf, (lv_32fc_t*)carrier_pll->output_stream->readBuf, dat_size);
+
+                    // save WAV
+                    if (save_wav)
+                    {
+                        for (int i = 0; i < dat_size; i++)
+                        {
+                            if (fsk_rec->output_stream->readBuf[i] > 1.0f)
+                                fsk_rec->output_stream->readBuf[i] = 1.0f;
+                            if (fsk_rec->output_stream->readBuf[i] < -1.0f)
+                                fsk_rec->output_stream->readBuf[i] = -1.0f;
+                        }
+
+                        volk_32f_s32f_convert_16i(output_wav_buffer, demod_stream->writeBuf, 32767, dat_size);
+
+                        wav_out.write((char *)output_wav_buffer, dat_size * sizeof(int16_t));
+                        final_wav_size += dat_size * sizeof(int16_t);
+                    }
+
+                    // forward to demods
+                    // memcpy(demod_stream->writeBuf, output_real_pam, dat_size * sizeof(float));
+                    demod_stream->swap(dat_size);
+                    carrier_pll->output_stream->flush();
+                }
+
+                // FSK/USB split
+                dat_size = rtc->output_stream->read();
+
+                if(dat_size <= 0)
+                {
+                    rtc->output_stream->flush();
+                }
+                else
+                {
+                    // forward to FSK
+                    memcpy(fsk_stream->writeBuf, rtc->output_stream->readBuf, dat_size * sizeof(complex_t));
+                    fsk_stream->swap(dat_size);
+
+                    // forward to USB
+                    if(enable_audio)
+                    {
+                        memcpy(usb_stream->writeBuf, rtc->output_stream->readBuf, dat_size * sizeof(complex_t));
+                        usb_stream->swap(dat_size);
+                    }
+                    
+                    rtc->output_stream->flush();
+                }
+            }
+
+            // FSK demod
+            dat_size = fsk_rec->output_stream->read();
+
+            if (dat_size <= 0)
+            {
+                fsk_rec->output_stream->flush();
+            }
+            else
+            {
+                // Into const
+                constellation.pushFloatAndGaussian(fsk_rec->output_stream->readBuf, dat_size);
+
+                volk_32f_x2_interleave_32fc((lv_32fc_t*)output_snr_complex, fsk_rec->output_stream->readBuf, zero_buf, dat_size);
+                snr_estimator.update(output_snr_complex, dat_size);
+                snr = snr_estimator.snr();
+
+                if (snr > peak_snr)
+                    peak_snr = snr;
+
+                display_freq = dsp::rad_to_hz(carrier_pll->getFreq(), d_symbolrate);
+
+                for (int i = 0; i < dat_size; i++)
+                {
+                    sym_buffer[i] = clamp(fsk_rec->output_stream->readBuf[i] * 5); // TODO
+                }
+
+                fsk_rec->output_stream->flush();
+
+                if (save_soft || output_data_type == satdump::pipeline::DATA_FILE)
+                    data_out.write((char *)sym_buffer, dat_size);
+                if (output_data_type != satdump::pipeline::DATA_FILE)
+                    output_fifo->write((uint8_t *)sym_buffer, dat_size);
+
+                if (input_data_type == satdump::pipeline::DATA_FILE)
+                    progress = file_source->getPosition();
+
+                if (time(NULL) % 10 == 0 && lastTime != time(NULL))
+                {
+                    lastTime = time(NULL);
+                    logger->info("Progress " + std::to_string(round(((double)progress / (double)filesize) * 1000.0) / 10.0) + "%%");
+                }
+            }
+
+            // audio output
+            if(enable_audio)
+            {
+                int dat_size_audio = usb_bpf->output_stream->read();
+                if (dat_size_audio <= 0)
+                {
+                    usb_bpf->output_stream->flush();
+                }
+                else
+                {
+                    if (play_audio)
+                    {
+                        volk_32fc_deinterleave_real_32f(output_real, (lv_32fc_t *)usb_bpf->output_stream->readBuf, dat_size_audio);
+                        volk_32f_s32f_convert_16i(output_audio_buffer, output_real, 32767, dat_size_audio);
+                        audio_sink->push_samples(output_audio_buffer, dat_size_audio);
+                    }
+                    usb_bpf->output_stream->flush();
+                }
+            }
+        }
+
+        if (enable_audio)
+            audio_sink->stop();
+
+        // Finish up WAV
+        if (save_wav)
+        {
+            wave_writer.finish_header(final_wav_size);
+            wav_out.close();
+        }
+        delete[] output_wav_buffer;
+
+        // close soft sym file
+        if(save_soft || output_data_type == satdump::pipeline::DATA_FILE)
+        {
+            data_out.close();
+        }
+
+        logger->info("Demodulation finished");
+
+        if (input_data_type == satdump::pipeline::DATA_FILE)
+            stop();
+    }
+
+    nlohmann::json TransitDemodModule::getModuleStats()
+    {
+        nlohmann::json v;
+        v["progress"] = ((double)progress / (double)filesize);
+        v["snr"] = snr;
+        v["peak_snr"] = peak_snr;
+        return v;
+    }
+
+    void TransitDemodModule::stop()
+    {
+        // Stop
+        BaseDemodModule::stop();
+        res->stop();
+        carrier_pll->stop();
+        carrier_pll->output_stream->stopReader();
+        rtc->stop();
+        rtc->output_stream->stopReader();
+
+        fsk_fsb->stop();
+        fsk_lpf->stop();
+        fsk_qua->stop();
+        fsk_rrc->stop();
+        fsk_rec->stop();
+        fsk_rec->output_stream->stopReader();
+
+        if(enable_audio)
+        {
+            usb_fsb->stop();
+            usb_bpf->stop();
+            usb_bpf->output_stream->stopReader();
+        }
+    }
+
+    void TransitDemodModule::drawUI(bool window)
+    {
+        ImGui::Begin(name.c_str(), NULL, window ? 0 : NOWINDOW_FLAGS);
+
+        ImGui::BeginGroup();
+        constellation.draw(); // Constellation
+        ImGui::EndGroup();
+
+        ImGui::SameLine();
+
+        ImGui::BeginGroup();
+        {
+            ImGui::Button("Signal", {200 * ui_scale, 20 * ui_scale});
+
+            ImGui::Text("Freq : ");
+            ImGui::SameLine();
+            ImGui::TextColored(style::theme.orange, "%.0f Hz", display_freq);
+
+            if (enable_audio)
+            {
+                const char *btn_icon, *label;
+                ImVec4 color;
+                if (play_audio)
+                {
+                    color = style::theme.green.Value;
+                    btn_icon = u8"\uF028##aptaudio";
+                    label = "Audio Playing";
+                }
+                else
+                {
+                    color = style::theme.red.Value;
+                    btn_icon = u8"\uF026##aptaudio";
+                    label = "Audio Muted";
+                }
+
+                ImGui::PushStyleColor(ImGuiCol_Text, color);
+                if (ImGui::Button(btn_icon))
+                    play_audio = !play_audio;
+                ImGui::PopStyleColor();
+                ImGui::SameLine();
+                ImGui::TextUnformatted(label);
+            }
+
+            snr_plot.draw(snr, peak_snr);
+            if (!d_is_streaming_input)
+                if (ImGui::Checkbox("Show FFT", &show_fft))
+                    fft_splitter->set_enabled("fft", show_fft);
+        }
+        ImGui::EndGroup();
+
+        if (!d_is_streaming_input)
+            ImGui::ProgressBar((double)progress / (double)filesize, ImVec2(ImGui::GetContentRegionAvail().x, 20 * ui_scale));
+
+        drawStopButton();
+        ImGui::End();
+        drawFFT();
+    }
+
+    std::string TransitDemodModule::getID() { return "transit_demod"; }
+
+    std::shared_ptr<satdump::pipeline::ProcessingModule> TransitDemodModule::getInstance(std::string input_file, std::string output_file_hint, nlohmann::json parameters)
+    {
+        return std::make_shared<TransitDemodModule>(input_file, output_file_hint, parameters);
+    }
+} // namespace transit

--- a/plugins/transit_support/module_transit_demod.cpp
+++ b/plugins/transit_support/module_transit_demod.cpp
@@ -199,17 +199,17 @@ namespace transit
                 else
                 {
                     // convert complex to imaginary
-                    volk_32fc_deinterleave_imag_32f(demod_stream->writeBuf, (lv_32fc_t*)carrier_pll->output_stream->readBuf, dat_size);
+                    volk_32fc_deinterleave_imag_32f(output_real, (lv_32fc_t*)carrier_pll->output_stream->readBuf, dat_size);
 
                     // save WAV
                     if (save_wav)
                     {
                         for (int i = 0; i < dat_size; i++)
                         {
-                            if (fsk_rec->output_stream->readBuf[i] > 1.0f)
-                                fsk_rec->output_stream->readBuf[i] = 1.0f;
-                            if (fsk_rec->output_stream->readBuf[i] < -1.0f)
-                                fsk_rec->output_stream->readBuf[i] = -1.0f;
+                            if (output_real[i] > 1.0f)
+                                output_real[i] = 1.0f;
+                            if (output_real[i] < -1.0f)
+                                output_real[i] = -1.0f;
                         }
 
                         volk_32f_s32f_convert_16i(output_wav_buffer, demod_stream->writeBuf, 32767, dat_size);
@@ -219,7 +219,7 @@ namespace transit
                     }
 
                     // forward to demods
-                    // memcpy(demod_stream->writeBuf, output_real_pam, dat_size * sizeof(float));
+                    memcpy(demod_stream->writeBuf, output_real, dat_size * sizeof(float));
                     demod_stream->swap(dat_size);
                     carrier_pll->output_stream->flush();
                 }

--- a/plugins/transit_support/module_transit_demod.h
+++ b/plugins/transit_support/module_transit_demod.h
@@ -29,7 +29,8 @@ namespace transit
         std::shared_ptr<dsp::FIRBlock<complex_t>> fsk_lpf;
         std::shared_ptr<dsp::QuadratureDemodBlock> fsk_qua;
         std::shared_ptr<dsp::FIRBlock<float>> fsk_rrc;
-        std::shared_ptr<dsp::GardnerClockRecoveryBlock<float>> fsk_rec;
+        // std::shared_ptr<dsp::GardnerClockRecoveryBlock<float>> fsk_rec;
+        std::shared_ptr<dsp::MMClockRecoveryBlock<float>> fsk_rec;
 
         std::shared_ptr<dsp::stream<complex_t>> usb_stream;
         std::shared_ptr<dsp::FreqShiftBlock> usb_fsb;

--- a/plugins/transit_support/module_transit_demod.h
+++ b/plugins/transit_support/module_transit_demod.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "common/dsp/demod/quadrature_demod.h"
+#include "common/dsp/pll/pll_carrier_tracking.h"
+#include "common/dsp/utils/real_to_complex.h"
+#include "common/dsp/utils/freq_shift.h"
+#include "common/dsp/utils/complex_to_mag.h"
+#include "common/dsp/filter/firdes.h"
+#include "common/dsp/filter/fir.h"
+#include "common/dsp/clock_recovery/clock_recovery_mm.h"
+#include "common/dsp/clock_recovery/clock_recovery_gardner.h"
+#include "pipeline/modules/demod/module_demod_base.h"
+
+// Handle the FM demodulation part of APT
+
+namespace transit
+{
+    class TransitDemodModule : public satdump::pipeline::demod::BaseDemodModule
+    {
+    protected:
+        std::shared_ptr<dsp::RationalResamplerBlock<complex_t>> res;
+        std::shared_ptr<dsp::PLLCarrierTrackingBlock> carrier_pll;
+        std::shared_ptr<dsp::QuadratureDemodBlock> qua;
+        std::shared_ptr<dsp::stream<float>> demod_stream;
+        std::shared_ptr<dsp::RealToComplexBlock> rtc;
+
+        std::shared_ptr<dsp::stream<complex_t>> fsk_stream;
+        std::shared_ptr<dsp::FreqShiftBlock> fsk_fsb;
+        std::shared_ptr<dsp::FIRBlock<complex_t>> fsk_lpf;
+        std::shared_ptr<dsp::QuadratureDemodBlock> fsk_qua;
+        std::shared_ptr<dsp::FIRBlock<float>> fsk_rrc;
+        std::shared_ptr<dsp::GardnerClockRecoveryBlock<float>> fsk_rec;
+
+        std::shared_ptr<dsp::stream<complex_t>> usb_stream;
+        std::shared_ptr<dsp::FreqShiftBlock> usb_fsb;
+        std::shared_ptr<dsp::FIRBlock<complex_t>> usb_bpf;
+        
+        std::ofstream wav_out;
+        
+        bool play_audio;
+        bool save_wav = false;
+        bool save_soft = false;
+
+        float display_freq = 0;
+
+        // manually tuned, still not quite as good as Xerbos flowchart, but pretty close
+        float d_clock_gain_omega = 0.0005;
+        float d_clock_mu = 0.5f;
+        float d_clock_gain_mu = 0.8;
+        float d_clock_omega_relative_limit = 0.005f;
+
+        int8_t *sym_buffer;
+
+    public:
+        TransitDemodModule(std::string input_file, std::string output_file_hint, nlohmann::json parameters);
+        ~TransitDemodModule();
+        void init();
+        void stop();
+        void process();
+        void drawUI(bool window);
+
+        bool enable_audio = false;
+
+    public:
+        static std::string getID();
+        virtual std::string getIDM() { return getID(); };
+        static nlohmann::json getParams() { return {}; }
+        static std::shared_ptr<ProcessingModule> getInstance(std::string input_file, std::string output_file_hint, nlohmann::json parameters);
+
+        nlohmann::json getModuleStats();
+    };
+} // namespace transit

--- a/plugins/transit_support/transit_deframer.h
+++ b/plugins/transit_support/transit_deframer.h
@@ -1,0 +1,144 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+#include <cmath>
+
+// Modified version of SimpleDeframer for transit syncword system
+
+// Transit 5B-5 appears to use a syncword of 11100010010xxxxx where x is 1 of 0 depending on the subframe, there are only 2 subframes in a frame
+
+namespace transit
+{
+    class TransitDeframer
+    {
+    private:
+        const int d_thresold;
+
+        bool in_frame = false;
+        bool synced = false;
+        std::vector<uint8_t> current_frame;
+
+        const uint16_t syncword_shared = 0xE240;
+        const uint16_t sync_mask = 0xFFFF;
+        const int frame_length = 32*8;
+        const int syncword_length = 16;
+
+        uint16_t asm_shifter = 0;
+
+        uint8_t byte_shifter;
+        int in_byte_buffer = 0;
+
+        void push_bit(uint8_t bit)
+        {
+            byte_shifter = (byte_shifter << 1) | bit;
+            in_byte_buffer++;
+            if (in_byte_buffer == 8)
+            {
+                current_frame.push_back(byte_shifter);
+                in_byte_buffer = 0;
+            }
+        }
+
+        bool check_syncword(uint16_t buffer)
+        {
+            int sf1_errors = 0;
+            int sf2_errors = 0;
+
+            // shared part
+            for(int i=syncword_length - 1; i >= 5; i--)
+            {
+                bool bit = (buffer >> i) & 0x1;
+                bool correct_bit = (syncword_shared >> i) & 0x1;
+                if(bit != correct_bit)
+                {
+                    sf1_errors++;
+                    sf2_errors++;
+                }
+            }
+
+            // unique part
+            for(int i=syncword_length - 11 - 1; i >= 0; i--)
+            {
+                bool bit = (buffer >> i) & 0x1;
+                if(bit)
+                    sf1_errors++;
+                else
+                    sf2_errors++;
+            }
+
+            int errors = sf1_errors > sf2_errors ? sf2_errors : sf1_errors;
+
+            return errors <= d_thresold;
+        }
+
+    public:
+        TransitDeframer(int thresold)
+            : d_thresold(thresold)
+        {
+            
+        }
+
+        // get deframer state 0: not synced, 1 = synced
+        int getState()
+        {
+            return synced;
+        }
+
+        std::vector<std::vector<uint8_t>> work(int8_t *soft, int size)
+        {
+            std::vector<std::vector<uint8_t>> output_frames;
+
+            for (int byten = 0; byten < size; byten++)
+            {
+                for (int i = 7; i >= 0; i--)
+                {
+                    uint8_t bit = ((soft)[byten * 8 + (7 - i)] > 0);
+                    asm_shifter = (asm_shifter << 1 | bit) & sync_mask;
+
+                    if (in_frame)
+                    {
+                        push_bit(bit);
+
+                        if ((int)current_frame.size() * 8 == frame_length)
+                        {
+                            output_frames.push_back(current_frame);
+                            in_frame = false;
+                        }
+                    }
+
+                    if(check_syncword(asm_shifter))
+                    {
+                        if (in_frame)
+                        {
+                            // Fill up what we're missing
+                            while ((int)current_frame.size() * 8 < frame_length)
+                                push_bit(0);
+                            output_frames.push_back(current_frame);
+                        }
+
+                        synced = true;
+                        in_frame = true;
+                        current_frame.clear();
+
+                        // push ASM
+                        for(int i=syncword_length - 1; i >= 0; i--)
+                        {
+                            uint8_t bit = (asm_shifter >> i) & 0x1;
+                            push_bit(bit);
+                        }
+                    }
+                    else
+                    {
+                        if(!in_frame)
+                        {
+                            synced = false;
+                        }
+                    }
+                }
+            }
+
+            return output_frames;
+        }
+    };
+};

--- a/resources/pipelines/transit.json
+++ b/resources/pipelines/transit.json
@@ -1,0 +1,45 @@
+{
+    "transit_tlm": {
+        "name": "Transit TLM",
+        "live": [
+            1,
+            2
+        ],
+        "frequencies": [
+            [
+                "main",
+                136.658e6
+            ]
+        ],
+        "parameters": {
+            "samplerate": {
+                "value": 1e6
+            }
+        },
+        "work": {
+            "baseband": {},
+            "audio_wav": {
+                "module": "transit_demod",
+                "parameters": {
+                    "symbolrate": 48e3,
+                    "save_wav": true,
+                    "save_soft": true,
+                    "clock_gain_omega": 0.0005,
+                    "clock_mu": 0.5,
+                    "clock_gain_mu": 0.8,
+                    "clock_omega_relative_limit": 0.005 
+                }
+            },
+            "frm": {
+                "module": "transit_decoder",
+                "parameters": {
+                }
+            },
+            "products": {
+                "module": "transit_data",
+                "parameters": {
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a decoder for Transit 5B-5s 136MHz telemetry downlink.  

## Features
- Demodulated PM to wav  
- Plays "musical" PAM telemetry to user via audio sink and USB demodulator  
- Decodes FSK to soft  
- Deframes FSK based on guessed syncword (backed up by documentation of similar satellites)  
- Detects when frame counter is counting coherently
- Dumps CSV of decoded telemety (to rework)