### PR TITLE
Fixes RTLSDR PLL not locking when tuning above 1 GHz

### DIFF
--- a/plugins/sdr_sources/rtlsdr_sdr_support/rtlsdr_dev.cpp
+++ b/plugins/sdr_sources/rtlsdr_sdr_support/rtlsdr_dev.cpp
@@ -34,9 +34,9 @@ namespace satdump
                     // This is a dirty patch! PLL might not lock on the first attempt if the frequency
                     // is above ~1 GHz, tuning down then back up locks it! This is a librtlsdr bug,
                     // because the return code should show that it wasn't successful, but it doesn't.
-                    if (p_frequency > 1e6)
+                    if (p_frequency > 1e9)
                     {
-                        rtlsdr_set_center_freq(rtlsdr_dev_obj, p_frequency - 1e6);
+                        rtlsdr_set_center_freq(rtlsdr_dev_obj, p_frequency - 1e9);
                         rtlsdr_set_center_freq(rtlsdr_dev_obj, p_frequency);
                         logger->debug("Frequency was above 1 GHz, retuning to lock the PLL");
                     }

--- a/plugins/sdr_sources/rtlsdr_sdr_support/rtlsdr_sdr.cpp
+++ b/plugins/sdr_sources/rtlsdr_sdr_support/rtlsdr_sdr.cpp
@@ -240,9 +240,9 @@ void RtlSdrSource::set_frequency(uint64_t frequency)
             // This is a dirty patch! PLL might not lock on the first attempt if the frequency
             // is above ~1 GHz, tuning down then back up locks it! This is a librtlsdr bug,
             // because the return code should show that it wasn't successful, but it doesn't.
-            if (frequency > 1e6)
+            if (frequency > 1e9)
             {
-                rtlsdr_set_center_freq(rtlsdr_dev_obj, frequency - 1e6);
+                rtlsdr_set_center_freq(rtlsdr_dev_obj, frequency - 1e9);
                 rtlsdr_set_center_freq(rtlsdr_dev_obj, frequency);
                 logger->debug("Frequency was above 1 GHz, retuning to lock the PLL");
             }


### PR DESCRIPTION
When tuning above cca 1 GHz, RTLSDR based SDR receivers might not have the PLL lock, making the FFT appear deceptively empty. This has been tested and happens on all platforms.

This happens because of a bug with librtlsdr - the return code for the frequency setting function should be 1 since it failed with the `[R82XX] PLL not locked!` message,  but it still returns the successful code (0) regardless.

The PLL locks fine if the SDR is set to tune to 1 GHz lower then back up to the target frequency. Tested on Nooelec Smart SDR V5, the patch works

This is not an optimal solution, but it makes RTLSDRs work in SatDump while the bug isn't fixed in the library while providing no harm to end users.