### PR TITLE
Fixes ICER decomp not working on Stereo

### DIFF
--- a/plugins/stereo_support/stereo/instruments/secchi/secchi_reader.cpp
+++ b/plugins/stereo_support/stereo/instruments/secchi/secchi_reader.cpp
@@ -1,37 +1,32 @@
 #include "secchi_reader.h"
-#include <filesystem>
-#include "common/utils.h"
 #include "core/resources.h"
 #include "utils/time.h"
+#include <cstdlib>
+#include <filesystem>
 
 #include "rice_decomp.h"
 
+#include "image/io.h"
 #include "image/processing.h"
 #include "image/text.h"
-#include "image/io.h"
 
 namespace stereo
 {
     namespace secchi
     {
-        SECCHIReader::SECCHIReader(std::string icer_path, std::string output_directory)
-            : icer_path(icer_path), output_directory(output_directory)
+        SECCHIReader::SECCHIReader(std::string icer_path, std::string output_directory) : icer_path(icer_path), output_directory(output_directory)
         {
             decompression_status_out = std::ofstream(output_directory + "/image_status.txt", std::ios::binary);
         }
 
-        SECCHIReader::~SECCHIReader()
-        {
-            decompression_status_out.close();
-        }
+        SECCHIReader::~SECCHIReader() { decompression_status_out.close(); }
 
         std::string filename_timestamp(double timestamp)
         {
             const time_t timevalue = timestamp;
             std::tm *timeReadable = gmtime(&timevalue);
-            return std::to_string(timeReadable->tm_year + 1900) + "-" +
-                   (timeReadable->tm_mon + 1 > 9 ? std::to_string(timeReadable->tm_mon + 1) : "0" + std::to_string(timeReadable->tm_mon + 1)) + "-" +
-                   (timeReadable->tm_mday > 9 ? std::to_string(timeReadable->tm_mday) : "0" + std::to_string(timeReadable->tm_mday)) + "_" +
+            return std::to_string(timeReadable->tm_year + 1900) + "-" + (timeReadable->tm_mon + 1 > 9 ? std::to_string(timeReadable->tm_mon + 1) : "0" + std::to_string(timeReadable->tm_mon + 1)) +
+                   "-" + (timeReadable->tm_mday > 9 ? std::to_string(timeReadable->tm_mday) : "0" + std::to_string(timeReadable->tm_mday)) + "_" +
                    (timeReadable->tm_hour > 9 ? std::to_string(timeReadable->tm_hour) : "0" + std::to_string(timeReadable->tm_hour)) + "-" +
                    (timeReadable->tm_min > 9 ? std::to_string(timeReadable->tm_min) : "0" + std::to_string(timeReadable->tm_min)) + "-" +
                    (timeReadable->tm_sec > 9 ? std::to_string(timeReadable->tm_sec) : "0" + std::to_string(timeReadable->tm_sec));
@@ -92,7 +87,8 @@ namespace stereo
                             image::save_img(img, output_directory + "/" + channel_name + "/" + std::to_string(unknown_cnt++));
 
                         if (last_filename_0.size() > 0)
-                            decompression_status_out << channel_name << "     " << last_filename_0 << " " << satdump::timestamp_to_string(last_timestamp_0) << " " << ((img.size() > 0) ? "PASS" : "FAIL") << "\n";
+                            decompression_status_out << channel_name << "     " << last_filename_0 << " " << satdump::timestamp_to_string(last_timestamp_0) << " "
+                                                     << ((img.size() > 0) ? "PASS" : "FAIL") << "\n";
                         last_filename_0 = "";
                         last_timestamp_0 = 0;
                     }
@@ -137,7 +133,8 @@ namespace stereo
                         image::save_img(img, output_directory + "/" + channel_name + "/" + std::to_string(unknown_cnt++));
 
                         if (last_filename_1.size() > 0)
-                            decompression_status_out << channel_name << "      " << last_filename_1 << " " << satdump::timestamp_to_string(last_timestamp_1) << " " << ((img.size() > 0) ? "PASS" : "FAIL") << "\n";
+                            decompression_status_out << channel_name << "      " << last_filename_1 << " " << satdump::timestamp_to_string(last_timestamp_1) << " "
+                                                     << ((img.size() > 0) ? "PASS" : "FAIL") << "\n";
                         last_filename_1 = "";
                         last_timestamp_1 = 0;
                     }
@@ -179,7 +176,8 @@ namespace stereo
                         image::save_img(img, output_directory + "/" + channel_name + "/" + std::to_string(unknown_cnt++));
 
                         if (last_filename_2.size() > 0)
-                            decompression_status_out << channel_name << "      " << last_filename_2 << " " << satdump::timestamp_to_string(last_timestamp_2) << " " << ((img.size() > 0) ? "PASS" : "FAIL") << "\n";
+                            decompression_status_out << channel_name << "      " << last_filename_2 << " " << satdump::timestamp_to_string(last_timestamp_2) << " "
+                                                     << ((img.size() > 0) ? "PASS" : "FAIL") << "\n";
                         last_filename_2 = "";
                         last_timestamp_2 = 0;
                     }
@@ -235,7 +233,8 @@ namespace stereo
                             image::save_img(img, output_directory + "/" + channel_name + "/" + std::to_string(unknown_cnt++));
 
                         if (last_filename_3.size() > 0)
-                            decompression_status_out << channel_name << " " << last_filename_3 << " " << satdump::timestamp_to_string(last_timestamp_3) << " " << ((img.size() > 0) ? "PASS" : "FAIL") << "\n";
+                            decompression_status_out << channel_name << " " << last_filename_3 << " " << satdump::timestamp_to_string(last_timestamp_3) << " " << ((img.size() > 0) ? "PASS" : "FAIL")
+                                                     << "\n";
                         last_filename_3 = "";
                         last_timestamp_3 = 0;
                         last_polarization_3 = 0;
@@ -255,13 +254,20 @@ namespace stereo
 
             if (!std::filesystem::exists(icer_path))
             {
-                logger->error("No ICER Decompressor provided. Can't decompress SECCHI!");
+                logger->error("Couldn't find ICER Decompressor, can't process SECCHI data! You can download it from here: https://stereo-ssc.nascom.nasa.gov/instruments/software/secchi/utils/icer/");
                 return image::Image();
             }
 
-            int ret = system(cmd.data());
-
-            if (ret == 0 && std::filesystem::exists("./stereo_secchi_out.tmp"))
+            int status = system(cmd.data());
+#ifdef _WIN32
+            // Windows returns raw error code
+            int return_code = status;
+#else
+            // POSIX returns a WEXITSTATUS
+            int return_code = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+#endif
+            // Return code 192 appears to be successful as well?
+            if ((return_code == 0 || return_code == 192) && std::filesystem::exists("./stereo_secchi_out.tmp"))
             {
                 logger->trace("SECCHI Decompression OK!");
 
@@ -278,7 +284,7 @@ namespace stereo
             }
             else
             {
-                logger->error("Failed decompressing SECCHI!");
+                logger->error("Failed decompressing SECCHI with return code %i!", return_code);
 
                 if (std::filesystem::exists("./stereo_secchi_out.tmp"))
                     std::filesystem::remove("./stereo_secchi_out.tmp");
@@ -370,5 +376,5 @@ namespace stereo
             }
 #endif
         }
-    }
-}
+    } // namespace secchi
+} // namespace stereo

--- a/plugins/stereo_support/stereo/module_stereo_instruments.h
+++ b/plugins/stereo_support/stereo/module_stereo_instruments.h
@@ -17,6 +17,7 @@ namespace stereo
         image::Image decompress_icer_tool(uint8_t *data, int dsize, int size);
 
         secchi::SECCHIReader *secchi_reader;
+        std::string icer_path;
 
     public:
         StereoInstrumentsDecoderModule(std::string input_file, std::string output_file_hint, nlohmann::json parameters);


### PR DESCRIPTION
The return code appears to also be 192 when successful for some reason. Also made it a bit more user friendly (as if anyone will use this for amateur purposes anyways)

Might work on Windows as well, since you can set the ICER decomp path yourself and I added the required compile time if statements for the return code handling.

Some stale code was removed as well, the function was moved but the original copy was forgotten. I was wondering why my debug breakpoints weren't triggering!