### PR TITLE
gate LRPT digital telemetry by lower nibble

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 27
     buildToolsVersion "30.0.3"
     ndkVersion "25.2.9519653"
 
@@ -14,7 +14,7 @@ android {
         applicationId "org.satdump.SatDump"
         namespace "org.satdump.SatDump"
         minSdkVersion 26
-        targetSdkVersion 28
+        targetSdkVersion 27
         versionCode 9
         versionName "1.2.3"
     }
@@ -85,7 +85,7 @@ repositories {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.0.2'
+    implementation 'com.android.support:appcompat-v7:27.1.1'
 }
 
 copyResources.dependsOn deleteTempAssets

--- a/android/app/src/main/java/MainActivity.kt
+++ b/android/app/src/main/java/MainActivity.kt
@@ -18,8 +18,8 @@ import android.net.Uri;
 import RealPathUtil;
 
 import android.Manifest;
-import androidx.core.content.PermissionChecker;
-import androidx.core.app.ActivityCompat;
+import android.support.v4.content.PermissionChecker;
+import android.support.v4.app.ActivityCompat;
 import android.content.pm.PackageManager;
 import android.provider.DocumentsContract;
 


### PR DESCRIPTION
In my previous commit, I said applying the low-nibble rule to digital telemetry produces nonsensical output. But it appears I was wrong after taking a second look. I may have made a simple mistake that led me to believe this, but after properly masking the lower nibble, it is clear that it's properly gating digital telemetry.

I checked a handful of CADUs, some including digital telemetry and others analog, and this change appears to work without issue.