### PR TITLE
Correct HRPT telemetry type check

### DIFF
--- a/plugins/meteor_support/meteor/instruments/msumr/module_meteor_msumr_lrpt.cpp
+++ b/plugins/meteor_support/meteor/instruments/msumr/module_meteor_msumr_lrpt.cpp
@@ -163,7 +163,7 @@ namespace meteor
 
                             if (pkt.payload.size() >= 62)
                             {
-                                parseMSUMRTelemetry(msu_mr_telemetry, msu_mr_telemetry_calib, msumr_ids.size() - 1, &pkt.payload[8]);
+                                parseMSUMRTelemetry(msu_mr_telemetry, msu_mr_telemetry_calib, msumr_ids.size() - 1, &pkt.payload[8], LRPT);
 
                                 // Convert calibration data
                                 uint16_t words10_bits[12];

--- a/plugins/meteor_support/meteor/instruments/msumr/msumr_tlm.h
+++ b/plugins/meteor_support/meteor/instruments/msumr/msumr_tlm.h
@@ -3,11 +3,17 @@
 #include <cstdint>
 #include "nlohmann/json.hpp"
 
+enum DownlinkMode : int
+{
+    LRPT,
+    HRPT
+};
+
 // This is most likely temporary to some extent until
 // more of this is figured out for calibration.
 // Translations from Russians are definitely very imperfect,
 // and this will need to be more data-oriented later!
-inline void parseMSUMRTelemetry(nlohmann::json &msu_mr_telemetry, nlohmann::json &msu_mr_telemetry_calib, int linecnt, uint8_t *msumr_frame)
+inline void parseMSUMRTelemetry(nlohmann::json &msu_mr_telemetry, nlohmann::json &msu_mr_telemetry_calib, int linecnt, uint8_t *msumr_frame, DownlinkMode mode)
 {
     if ((msumr_frame[12] & 0xF) == 0b0000)
         msu_mr_telemetry[linecnt]["msu_mr_set"] = "primary";
@@ -19,7 +25,7 @@ inline void parseMSUMRTelemetry(nlohmann::json &msu_mr_telemetry, nlohmann::json
     int mid = msumr_frame[12] >> 4;
     msu_mr_telemetry[linecnt]["msu_mr_id"] = mid;
 
-    if ((msumr_frame[13] & 0x0F) == 0x0F) // Analog TLM
+    if ((mode == LRPT && (msumr_frame[13] & 0x0F) == 0x0F) || (mode == HRPT && msumr_frame[13] == 0b00001111)) // Analog TLM
     {
         const char *names[16 + 5] = {
             "Detector Temperature Channel 5", //"AF temperature of the 5th channel",
@@ -61,7 +67,7 @@ inline void parseMSUMRTelemetry(nlohmann::json &msu_mr_telemetry, nlohmann::json
         for (int i = 14; i < 16 /*+ 5*/; i++)
             msu_mr_telemetry[linecnt]["analog_tlm"][names[15 - i]] = ((uint8_t *)msumr_frame)[14 + i];
     }
-    else if ((msumr_frame[13] & 0x0F) == 0x00) // Digital TLM
+    else if ((mode == LRPT && (msumr_frame[13] & 0x0F) == 0x00) || (mode == HRPT && msumr_frame[13] == 0b00000000)) // Digital TLM
     {
         uint8_t *ptr = &msumr_frame[14];
 

--- a/plugins/meteor_support/meteor/module_meteor_instruments.cpp
+++ b/plugins/meteor_support/meteor/module_meteor_instruments.cpp
@@ -100,7 +100,7 @@ namespace meteor
                     }
 
                     msumr_ids.push_back(msumr_frame[12] >> 4);
-                    parseMSUMRTelemetry(msu_mr_telemetry, msu_mr_telemetry_calib, msumr_timestamps.size() - 1, msumr_frame.data());
+                    parseMSUMRTelemetry(msu_mr_telemetry, msu_mr_telemetry_calib, msumr_timestamps.size() - 1, msumr_frame.data(), HRPT);
                 }
 
                 // MTVZA Deframing


### PR DESCRIPTION
The lower-nibble check does not apply to HRPT; use a full-byte check for HRPT and the lower nibble for LRPT.