### PR TITLE
Fix Windows builds - Python path

### DIFF
--- a/src-core/init.cpp
+++ b/src-core/init.cpp
@@ -1,12 +1,3 @@
-// TODOREWORK?
-extern "C"
-{
-#include "libs/supernovas/novas.h"
-
-#include "libs/calceph/calceph.h"
-#include "libs/supernovas/novas-calceph.h"
-}
-
 #include "db/db_handler.h"
 #include "db/iers/iers_handler.h"
 #include "db/tle/tle_handler.h"
@@ -31,6 +22,15 @@ extern "C"
 #include "common/dsp/buffer.h"
 
 #include "products/product.h"
+
+// TODOREWORK?
+extern "C"
+{
+#include "libs/supernovas/novas.h"
+
+#include "libs/calceph/calceph.h"
+#include "libs/supernovas/novas-calceph.h"
+}
 
 namespace satdump
 {


### PR DESCRIPTION
Currently, UHD tries to install its own python 3.14 toolchain instead of the global 3.13 install set up and configured by actions. This should point it to the right install.