### PR TITLE
Adjust image view grid and fix ImGui crash

### DIFF
--- a/src-core/explorer/explorer.cpp
+++ b/src-core/explorer/explorer.cpp
@@ -394,6 +394,7 @@ namespace satdump
             drawMenuBar();
 
             ImVec2 explorer_size = ImGui::GetContentRegionAvail();
+            if (explorer_size.x < 0.0f || explorer_size.y < 0.0f) return;
 
             if (show_panel)
             {


### PR DESCRIPTION
This changes the behavior of the image view grid by manually setting grid ticks.

A crash relating to the window size being zero was also fixed.