### PR TITLE
Fix the build with volk 3.3

### DIFF
--- a/src-core/common/calibration.cpp
+++ b/src-core/common/calibration.cpp
@@ -3,9 +3,9 @@
 #include <vector>
 #include <ctime>
 
-double temperature_to_radiance(double t, double v) { return (c1 * v * v * v) / (pow(e_num, c2 * v / t) - 1); }
+double temperature_to_radiance(double t, double v) { return (1.1910427e-05 * v * v * v) / (pow(e_num, 1.4387752 * v / t) - 1); }
 
-double radiance_to_temperature(double L, double v) { return (c2 * v) / (log(c1 * v * v * v / L + 1)); }
+double radiance_to_temperature(double L, double v) { return (1.4387752 * v) / (log(1.1910427e-05 * v * v * v / L + 1)); }
 
 double freq_to_wavenumber(double freq) { return 1e7 / ((299792458.0 / freq) / 10e-10); }
 

--- a/src-core/common/calibration.h
+++ b/src-core/common/calibration.h
@@ -4,8 +4,6 @@
 #include <map>
 #include <ctime>
 
-#define c1 1.1910427e-05
-#define c2 1.4387752
 #define e_num 2.7182818
 
 double temperature_to_radiance(double t, double v);


### PR DESCRIPTION
https://buildd.debian.org/status/fetch.php?pkg=satdump&arch=arm64&ver=1.2.2%2Bgb79af48-1%2Bb2&stamp=1771060232&raw=0

```
In file included from /build/reproducible-path/satdump-1.2.2+gb79af48/src-interface/viewer/image_handler.cpp:2:
/usr/include/volk/volk_common.h: In function ‘float volk_cos_poly(float)’:
/build/reproducible-path/satdump-1.2.2+gb79af48/src-interface/../src-core/common/calibration.h:7:12: error: expected unqualified-id before numeric constant
    7 | #define c1 1.1910427e-05
      |            ^~~~~~~~~~~~~
/build/reproducible-path/satdump-1.2.2+gb79af48/src-interface/../src-core/common/calibration.h:8:12: error: expected unqualified-id before numeric constant
    8 | #define c2 1.4387752
      |            ^~~~~~~~~
/usr/include/volk/volk_common.h: In function ‘float volk_arcsin_poly(float)’:
/build/reproducible-path/satdump-1.2.2+gb79af48/src-interface/../src-core/common/calibration.h:7:12: error: expected unqualified-id before numeric constant
    7 | #define c1 1.1910427e-05
      |            ^~~~~~~~~~~~~
/build/reproducible-path/satdump-1.2.2+gb79af48/src-interface/../src-core/common/calibration.h:8:12: error: expected unqualified-id before numeric constant
    8 | #define c2 1.4387752
      |            ^~~~~~~~~
```

the relevant change in volk is https://github.com/gnuradio/volk/commit/5ba6643e4845b56fd26fbf34ff1eeafead312157#diff-92e7a9648c7721918392f95b8c2522e12d51cfc83eb32490e1f1deec71f064e4R235-R236

`c1` and `c2` are too generic identifiers for being used in a define.