### PR TITLE
Separated EMWIN into dirs, added option to discard text and NWS files

### DIFF
--- a/plugins/goes_support/goes/hrit/module_goes_lrit_data_decoder.cpp
+++ b/plugins/goes_support/goes/hrit/module_goes_lrit_data_decoder.cpp
@@ -1,13 +1,11 @@
 #include "module_goes_lrit_data_decoder.h"
 #include "core/plugin.h"
 #include "imgui/imgui.h"
-#include "imgui/imgui_image.h"
 #include "logger.h"
 #include "lrit_header.h"
 #include "xrit/processor/xrit_channel_processor_render.h"
 #include "xrit/transport/xrit_demux.h"
 #include <filesystem>
-#include <fstream>
 
 namespace goes
 {
@@ -21,6 +19,8 @@ namespace goes
             fill_missing = parameters.contains("fill_missing") ? parameters["fill_missing"].get<bool>() : false;
             parse_dcs = parameters.contains("parse_dcs") ? parameters["parse_dcs"].get<bool>() : false;
             write_lrit = parameters.contains("write_lrit") ? parameters["write_lrit"].get<bool>() : false;
+            write_emwin_text = parameters.contains("write_emwin_text") ? parameters["write_emwin_text"].get<bool>() : false;
+            write_emwin_nws = parameters.contains("write_emwin_nws") ? parameters["write_emwin_nws"].get<bool>() : true;
 
             if (parse_dcs && parameters.contains("tracked_addresses") && parameters["tracked_addresses"].is_string())
             {

--- a/plugins/goes_support/goes/hrit/module_goes_lrit_data_decoder.h
+++ b/plugins/goes_support/goes/hrit/module_goes_lrit_data_decoder.h
@@ -29,6 +29,10 @@ namespace goes
             bool write_unknown;
             bool write_lrit;
 
+            // EMWIN-specific
+            bool write_emwin_text;
+            bool write_emwin_nws;
+
             bool fill_missing;
             int max_fill_lines;
 
@@ -57,6 +61,7 @@ namespace goes
             std::map<std::string, SZ_com_t> rice_parameters_all;
 
             void initDCS();
+            void saveEMWINFile(std::string directory, std::string filename, char *buffer, size_t size);
             void processLRITFile(satdump::xrit::XRITFile &file);
             void saveLRITFile(satdump::xrit::XRITFile &file, std::string path);
 

--- a/plugins/goes_support/goes/hrit/module_goes_lrit_data_decoder_proc.cpp
+++ b/plugins/goes_support/goes/hrit/module_goes_lrit_data_decoder_proc.cpp
@@ -1,12 +1,9 @@
 #include "image/io.h"
-#include "image/processing.h"
-#include "imgui/imgui_image.h"
 #include "libs/miniz/miniz.h"
 #include "libs/miniz/miniz_zip.h"
 #include "logger.h"
 #include "lrit_header.h"
 #include "module_goes_lrit_data_decoder.h"
-#include "utils/string.h"
 #include <filesystem>
 #include <memory>
 
@@ -26,7 +23,87 @@ namespace goes
             return utc_filename;
         }
 
-        const int ID_HIMAWARI = 43;
+        /**
+         * @brief Generic function to save EMWIN files in appropriate directories
+         *
+         * @param directory Base EMWIN directory
+         * @param filename Filename to save as
+         * @param buffer Pointer to the data buffer
+         * @param size How many bytes to write
+         */
+        void GOESLRITDataDecoderModule::saveEMWINFile(std::string directory, std::string filename, char *buffer, size_t size)
+        {
+            if (!std::filesystem::exists(directory + "/EMWIN"))
+                std::filesystem::create_directory(directory + "/EMWIN");
+
+            std::string subdirectory;
+            std::string extension = filename.substr(filename.size() - 3, filename.size());
+            
+            // Only proceed if we are meant to process text files
+            if ((extension == "TXT" || extension == "txt") && !write_emwin_text)
+                return;
+
+            // All files appear to feature an 8-character ID before the extension, proceed if it looks like it
+            if (filename.size() >= 10 && !filename.compare(filename.size() - 13, 1, "-"))
+            {
+                std::string ID = filename.substr(filename.size() - 12, 8);
+                // clang-format off
+
+                // Some standard subdirs
+                // (compare returning 0 on success is so stupid bruh I hate c++)
+                if (
+                    !ID.compare(0, 3, "RAD") || !ID.compare(0, 5, "IMGWW") || 
+                    !ID.compare(0, 4, "GPHJ") || !ID.compare(0, 3, "MOD") || 
+                    !ID.compare(0, 4, "USHZ") || !ID.compare(0, 4, "USHZ") ||
+                    !ID.compare(0, 6, "IMGFNT") || !ID.compare(0, 3, "CSA") ||
+                    !ID.compare(0, 4, "NPSA") || !ID.compare(0, 3, "NPI"))
+                {
+                    if (!write_emwin_nws)
+                        return;
+
+                    subdirectory = "/NWS/";
+                }
+                // Sat imagery: MSG
+                else if (!ID.compare(0, 3, "IND")) {
+                    subdirectory = "/Meteosat/";
+                }
+                // Sat imagery: Himawari
+                else if (!ID.compare(0, 3, "GMS")) {
+                    subdirectory = "/Himawari/";
+                }
+                // Sat imagery: GOES
+                else if(
+                    
+                    !ID.compare(0, 3, "G02") || !ID.compare(0, 3, "G10") || 
+                    !ID.compare(0, 3, "G16") || !ID.compare(0, 3, "MOD") || 
+                    !ID.compare(0, 8, "IMGSJUPR"))
+                {
+                    subdirectory = "/GOES/";
+                }
+                else if (extension == "TXT" || extension == "txt") {
+                    subdirectory = "/Text/";
+                }
+                // Catch-all for crap I don't have from these 
+                else {
+                    subdirectory = "/Other/";
+                }
+                // clang-format on
+            }
+            // We can't use the ID because the filename structure is different, default to "Other"
+            else
+            {
+                subdirectory = "/Other/";
+            }
+
+            if (!std::filesystem::exists(directory + "/EMWIN" + subdirectory))
+                std::filesystem::create_directory(directory + "/EMWIN" + subdirectory);
+
+            // Write file out
+            logger->info("Writing file " + directory + "/EMWIN/" + subdirectory + filename + "...");
+            std::ofstream fileo(directory + "/EMWIN" + subdirectory + filename, std::ios::binary);
+            fileo.write(buffer, size);
+            fileo.close();
+        }
 
         void GOESLRITDataDecoderModule::saveLRITFile(satdump::xrit::XRITFile &file, std::string path)
         {
@@ -134,18 +211,13 @@ namespace goes
                     if (!std::filesystem::exists(directory + "/EMWIN"))
                         std::filesystem::create_directory(directory + "/EMWIN");
 
-                    logger->info("Writing file " + directory + "/EMWIN/" + clean_filename + ".txt" + "...");
-
                     int offset = primary_header.total_header_length;
 
-                    // Write file out
-                    std::ofstream fileo(directory + "/EMWIN/" + clean_filename + ".txt", std::ios::binary);
-                    fileo.write((char *)&file.lrit_data[offset], file.lrit_data.size() - offset);
-                    fileo.close();
+                    saveEMWINFile(directory, clean_filename + ".txt", (char *)&file.lrit_data[offset], file.lrit_data.size() - offset);
                 }
                 else if (noaa_header.noaa_specific_compression == 10) // ZIP Files
                 {
-                    if (!std::filesystem::exists(directory + "/EMWIN"))
+                    if (!std::filesystem::exists(directory + "/EMWIN/"))
                         std::filesystem::create_directory(directory + "/EMWIN");
 
                     int offset = primary_header.total_header_length;
@@ -169,10 +241,7 @@ namespace goes
                     uint8_t *outBuffer = (uint8_t *)mz_zip_reader_extract_to_heap(&zipFile, 0, &outSize, 0);
 
                     // Write out
-                    logger->info("Writing file " + directory + "/EMWIN/" + filename + "...");
-                    std::ofstream file(directory + "/EMWIN/" + filename, std::ios::binary);
-                    file.write((char *)outBuffer, outSize);
-                    file.close();
+                    saveEMWINFile(directory, filename, (char *)outBuffer, outSize);
 
                     // Free memory
                     zipFile.m_pFree(&zipFile, outBuffer);

--- a/resources/pipelines/GOES.json
+++ b/resources/pipelines/GOES.json
@@ -94,7 +94,20 @@
                 "value": "",
                 "name": "Tracked DCS Addresses",
                 "description": "Only process DCS messages from the specified addresses (comma separated).\n\nExample: DE4CB498, DE4704BE"
+            },
+            "write_emwin_nws": {
+                "type": "bool",
+                "value": true,
+                "name": "Save EMWIN NWS image files",
+                "description": "Whether NWS advisories and weather charts should be saved"
+            },
+            "write_emwin_text": {
+                "type": "bool",
+                "value": false,
+                "name": "Save EMWIN text files",
+                "description": "EMWIN sends down a lot of raw text data including METAR reports, station readings, and written forecasts. These usually use up a lot of space because of their quantity, you can use this setting to toggle saving them."
             }
+
         },
         "work": {
             "baseband": {},


### PR DESCRIPTION
Before now the EMWIN directory contained every file type next to one another without any meaningful separation, now they are nicely separated.
<img width="885" height="199" alt="image" src="https://github.com/user-attachments/assets/e2eea3c6-3be0-49c1-9479-a2a221cc7afd" />

Also added the option to discard text and NWS files, as they often pile up very quickly, with few people actually using them.