### PR TITLE
Make replacing of spaces in filenames optional

### DIFF
--- a/satdump_cfg.json
+++ b/satdump_cfg.json
@@ -309,11 +309,11 @@
             "name": "Default Proj Output Directory",
             "description": "Path to the default folder to open when saving a projection in the explorer."
         },
-        "sanitise_image_filenames": {
+        "replace_spaces_in_filenames": {
             "type": "bool",
             "value": true,
-            "name": "Sanitise Image Filenames",
-            "description": "If enabled, image filenames will be sanitised. This may affect other file types. Some characters (e.g. '/') will be replaced regardless of the state of this setting."
+            "name": "Replace Spaces",
+            "description": "If enabled, spaces will be replaced with underscores in image filenames."
         },
         "image_filename_template": {
             "type": "labeled_options",

--- a/satdump_cfg.json
+++ b/satdump_cfg.json
@@ -309,6 +309,12 @@
             "name": "Default Proj Output Directory",
             "description": "Path to the default folder to open when saving a projection in the explorer."
         },
+        "image_filename_sanitise": {
+            "type": "bool",
+            "value": true,
+            "name": "Sanitise Image Filenames",
+            "description": "If enabled, image filenames will be sanitised. For example, spaces will be replaced with underscores."
+        },
         "image_filename_template": {
             "type": "labeled_options",
             "value": "$i_$c",

--- a/satdump_cfg.json
+++ b/satdump_cfg.json
@@ -313,7 +313,7 @@
             "type": "bool",
             "value": true,
             "name": "Sanitise Image Filenames",
-            "description": "If enabled, image filenames will be sanitised. For example, spaces will be replaced with underscores."
+            "description": "If enabled, image filenames will be sanitised. This may affect other file types. Some characters (e.g. '/') will be replaced regardless of the state of this setting."
         },
         "image_filename_template": {
             "type": "labeled_options",

--- a/satdump_cfg.json
+++ b/satdump_cfg.json
@@ -309,7 +309,7 @@
             "name": "Default Proj Output Directory",
             "description": "Path to the default folder to open when saving a projection in the explorer."
         },
-        "image_filename_sanitise": {
+        "sanitise_image_filenames": {
             "type": "bool",
             "value": true,
             "name": "Sanitise Image Filenames",

--- a/src-core/handlers/image/image_handler.cpp
+++ b/src-core/handlers/image/image_handler.cpp
@@ -191,13 +191,7 @@ namespace satdump
                     std::string save_type = "png";
                     satdump_cfg.tryAssignValueFromSatDumpGeneral(save_type, "image_format");
                     std::string default_path = satdump_cfg.getValueFromSatDumpDirectories<std::string>("default_image_output_directory");
-                    std::string image_filename;
-                    if (satdump_cfg.getValueFromSatDumpDirectories<bool>("sanitise_image_filenames")) {
-                        image_filename = getSaneName();
-                    } else {
-                        image_filename = image_name;
-                    }
-                    std::string saved_at = save_image_dialog(image_filename, default_path, "Save Image", &getImage(), &save_type);
+                    std::string saved_at = save_image_dialog(getSaneName(), default_path, "Save Image", &getImage(), &save_type);
                     if (saved_at == "")
                         logger->info("Save cancelled");
                     else
@@ -354,7 +348,9 @@ namespace satdump
         std::string ImageHandler::getSaneName()
         {
             std::string img_name = image_name;
-            replaceAllStr(img_name, " ", "_");
+            if (satdump_cfg.getValueFromSatDumpDirectories<bool>("replace_spaces_in_filenames")) {
+                replaceAllStr(img_name, " ", "_");
+            }
             replaceAllStr(img_name, "/", "_");
             replaceAllStr(img_name, "\\", "_");
             return img_name;

--- a/src-core/handlers/image/image_handler.cpp
+++ b/src-core/handlers/image/image_handler.cpp
@@ -192,7 +192,7 @@ namespace satdump
                     satdump_cfg.tryAssignValueFromSatDumpGeneral(save_type, "image_format");
                     std::string default_path = satdump_cfg.getValueFromSatDumpDirectories<std::string>("default_image_output_directory");
                     std::string image_filename;
-                    if (satdump_cfg.getValueFromSatDumpDirectories<bool>("image_filename_sanitise")) {
+                    if (satdump_cfg.getValueFromSatDumpDirectories<bool>("sanitise_image_filenames")) {
                         image_filename = getSaneName();
                     } else {
                         image_filename = image_name;

--- a/src-core/handlers/image/image_handler.cpp
+++ b/src-core/handlers/image/image_handler.cpp
@@ -191,7 +191,13 @@ namespace satdump
                     std::string save_type = "png";
                     satdump_cfg.tryAssignValueFromSatDumpGeneral(save_type, "image_format");
                     std::string default_path = satdump_cfg.getValueFromSatDumpDirectories<std::string>("default_image_output_directory");
-                    std::string saved_at = save_image_dialog(getSaneName(), default_path, "Save Image", &getImage(), &save_type);
+                    std::string image_filename;
+                    if (satdump_cfg.getValueFromSatDumpDirectories<bool>("image_filename_sanitise")) {
+                        image_filename = getSaneName();
+                    } else {
+                        image_filename = image_name;
+                    }
+                    std::string saved_at = save_image_dialog(image_filename, default_path, "Save Image", &getImage(), &save_type);
                     if (saved_at == "")
                         logger->info("Save cancelled");
                     else

--- a/src-core/handlers/product/product_handler.cpp
+++ b/src-core/handlers/product/product_handler.cpp
@@ -207,7 +207,7 @@ namespace satdump
             for (char &name_char : product_name)
                 if ((name_char >= 'A' && name_char <= 'Z') || (name_char >= '-' && name_char <= '9'))
                     product_name_abbr += name_char;
-            if (satdump_cfg.getValueFromSatDumpDirectories<bool>("sanitise_image_filenames")) { 
+            if (satdump_cfg.getValueFromSatDumpDirectories<bool>("replace_spaces_in_filenames")) { 
                 std::replace(instrument_name_upper.begin(), instrument_name_upper.end(), ' ', '_');
                 std::replace(product_source_upper.begin(), product_source_upper.end(), ' ', '_');
                 std::replace(product_name_upper.begin(), product_name_upper.end(), ' ', '_');

--- a/src-core/handlers/product/product_handler.cpp
+++ b/src-core/handlers/product/product_handler.cpp
@@ -207,9 +207,11 @@ namespace satdump
             for (char &name_char : product_name)
                 if ((name_char >= 'A' && name_char <= 'Z') || (name_char >= '-' && name_char <= '9'))
                     product_name_abbr += name_char;
-            std::replace(instrument_name_upper.begin(), instrument_name_upper.end(), ' ', '_');
-            std::replace(product_source_upper.begin(), product_source_upper.end(), ' ', '_');
-            std::replace(product_name_upper.begin(), product_name_upper.end(), ' ', '_');
+            if (satdump_cfg.getValueFromSatDumpDirectories<bool>("sanitise_image_filenames")) { 
+                std::replace(instrument_name_upper.begin(), instrument_name_upper.end(), ' ', '_');
+                std::replace(product_source_upper.begin(), product_source_upper.end(), ' ', '_');
+                std::replace(product_name_upper.begin(), product_name_upper.end(), ' ', '_');
+            }
 
             file_name = std::regex_replace(file_name, std::regex("\\$t"), std::to_string(timevalue));
             file_name = std::regex_replace(file_name, std::regex("\\$y"), std::to_string(timeReadable->tm_year + 1900));


### PR DESCRIPTION
SatDump now replaces all spaces with underscores when e.g. saving a processed image. This PR makes that logic optional, however it is still enabled by default.

Other sanitisation features (e.g. replacing slashes with underscores) are unaffected by the setting. Only (image) filenames, product names and instrument names are.