### PR TITLE
Add webhooks triggered by the event bus

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -508,3 +508,9 @@ option(PLUGIN_WIPSETTINGS_EDITOR_APP "Enable WIP Settings Editor Application"
 if(PLUGIN_WIPSETTINGS_EDITOR_APP)
   add_subdirectory(wip_settings_editor_app)
 endif()
+
+option(PLUGIN_WEBHOOK_APP "Enable Webhook Application" ON)
+
+if(PLUGIN_WEBHOOK_APP)
+  add_subdirectory(webhook_app)
+endif()

--- a/plugins/sample/main.cpp
+++ b/plugins/sample/main.cpp
@@ -1,4 +1,4 @@
-#include "plugin.h"
+#include "core/plugin.h"
 #include "logger.h"
 
 class Sample : public satdump::Plugin

--- a/plugins/webhook_app/CMakeLists.txt
+++ b/plugins/webhook_app/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.12)
+project(webhook_app)
+
+
+file(GLOB_RECURSE webhook_app_CPPS *.cpp)
+add_library(webhook_app SHARED ${webhook_app_CPPS})
+target_link_libraries(webhook_app PUBLIC satdump_core satdump_interface)
+target_include_directories(webhook_app PUBLIC . ../../src-interface)
+
+install(TARGETS webhook_app DESTINATION ${CMAKE_INSTALL_LIBDIR}/satdump/plugins)

--- a/plugins/webhook_app/main.cpp
+++ b/plugins/webhook_app/main.cpp
@@ -1,0 +1,121 @@
+#include "core/config.h"
+#include "core/plugin.h"
+#include "logger.h"
+#include "common/rimgui.h"
+#include "nlohmann/json.hpp"
+
+#include "webhook.h"
+
+static std::vector<webhook_app::WebhookConfig> webhook_configs;
+
+class Webhook : public satdump::Plugin
+{
+private:
+    std::vector<std::unique_ptr<webhook_app::WebhookSender>> senders;
+
+    static void renderConfig()
+    {
+        if (ImGui::Button("+ Add Webhook"))
+            webhook_configs.push_back({});
+
+        for (int i = 0; i < (int)webhook_configs.size(); i++)
+        {
+            ImGui::PushID(i);
+
+            ImGui::AlignTextToFramePadding();
+            ImGui::Text("Webhook %d", i + 1);
+            ImGui::SameLine();
+            ImGui::BeginDisabled(!webhook_app::WebhookSender::is_valid_url(webhook_configs[i].url));
+            if (ImGui::Button("Test"))
+                webhook_app::WebhookSender::test(webhook_configs[i]);
+            ImGui::EndDisabled();
+            ImGui::SameLine();
+            if (ImGui::Button("Remove"))
+            {
+                webhook_configs.erase(webhook_configs.begin() + i);
+                ImGui::PopID();
+                i--;
+                continue;
+            }
+
+            ImGui::InputText("URL", &webhook_configs[i].url);
+            ImGui::Checkbox("Pipeline Done", &webhook_configs[i].events.pipeline_done);
+            ImGui::SameLine();
+            ImGui::Checkbox("TLEs Updated", &webhook_configs[i].events.tles_updated);
+            ImGui::SameLine();
+            ImGui::Checkbox("Tracking AOS", &webhook_configs[i].events.tracking_aos);
+            ImGui::SameLine();
+            ImGui::Checkbox("Tracking LOS", &webhook_configs[i].events.tracking_los);
+
+            ImGui::Separator();
+            ImGui::PopID();
+        }
+    }
+
+    static void save()
+    {
+        nlohmann::json webhooks = nlohmann::json::array();
+        for (auto &cfg : webhook_configs)
+        {
+            if (!webhook_app::WebhookSender::is_valid_url(cfg.url))
+                continue;
+            webhooks.push_back({
+                {"url", cfg.url},
+                {"events", {
+                    {"pipeline_done", cfg.events.pipeline_done},
+                    {"tles_updated", cfg.events.tles_updated},
+                    {"tracking_aos", cfg.events.tracking_aos},
+                    {"tracking_los", cfg.events.tracking_los},
+                }},
+            });
+        }
+        satdump::satdump_cfg.main_cfg["plugin_settings"]["webhook_app"]["webhooks"] = webhooks;
+    }
+
+    static void registerConfigHandler(const satdump::config::RegisterPluginConfigHandlersEvent &evt)
+    {
+        evt.plugin_config_handlers.push_back({"Event Webhooks", Webhook::renderConfig, Webhook::save});
+    }
+
+public:
+    std::string getID() { return "webhook_app"; }
+
+    void init()
+    {
+        satdump::eventBus->register_handler<satdump::config::RegisterPluginConfigHandlersEvent>(registerConfigHandler);
+
+        auto &cfg = satdump::satdump_cfg.main_cfg["plugin_settings"]["webhook_app"];
+        if (cfg.contains("webhooks") && cfg["webhooks"].is_array())
+        {
+            for (auto &entry : cfg["webhooks"])
+            {
+                webhook_app::WebhookConfig wc;
+                if (entry.contains("url") && entry["url"].is_string())
+                    wc.url = entry["url"].get<std::string>();
+                if (entry.contains("events"))
+                {
+                    auto &ev = entry["events"];
+                    if (ev.contains("pipeline_done") && ev["pipeline_done"].is_boolean())
+                        wc.events.pipeline_done = ev["pipeline_done"].get<bool>();
+                    if (ev.contains("tles_updated") && ev["tles_updated"].is_boolean())
+                        wc.events.tles_updated = ev["tles_updated"].get<bool>();
+                    if (ev.contains("tracking_aos") && ev["tracking_aos"].is_boolean())
+                        wc.events.tracking_aos = ev["tracking_aos"].get<bool>();
+                    if (ev.contains("tracking_los") && ev["tracking_los"].is_boolean())
+                        wc.events.tracking_los = ev["tracking_los"].get<bool>();
+                }
+                webhook_configs.push_back(wc);
+            }
+        }
+
+        for (auto &hook : webhook_configs)
+        {
+            if (webhook_app::WebhookSender::is_valid_url(hook.url))
+                senders.push_back(std::make_unique<webhook_app::WebhookSender>(hook));
+        }
+
+        logger->info("Webhook plugin!");
+    }
+};
+
+PLUGIN_LOADER(Webhook)

--- a/plugins/webhook_app/webhook.cpp
+++ b/plugins/webhook_app/webhook.cpp
@@ -1,0 +1,116 @@
+#include "webhook.h"
+
+#include <regex>
+#include <sstream>
+#include <iomanip>
+
+#include "init.h"
+#include "logger.h"
+#include "utils/http.h"
+#include "utils/time.h"
+#include "nlohmann/json.hpp"
+
+namespace webhook_app
+{
+    bool WebhookSender::is_valid_url(const std::string &url)
+    {
+        static const std::regex url_regex(R"(^https?://\S+$)", std::regex::icase);
+        return std::regex_match(url, url_regex);
+    }
+
+    std::string WebhookSender::get_payload_key(const std::string &url)
+    {
+        static const std::pair<std::string_view, std::string_view> platform_keys[] = {
+            {"discord.com/api/webhooks/", "content"},
+            {"discordapp.com/api/webhooks/", "content"},
+            {"hooks.slack.com/services/",    "text"},
+        };
+
+        for (auto &[substr, key] : platform_keys)
+            if (url.find(substr) != std::string::npos)
+                return std::string(key);
+
+        return "message";
+    }
+
+    WebhookSender::WebhookSender(const WebhookConfig &config)
+        : url(config.url), payload_key(get_payload_key(config.url)), events(config.events)
+    {
+
+#ifdef BUILD_IS_DEBUG
+        satdump::eventBus->register_handler<satdump::SatDumpStartedEvent>(
+            [this](const satdump::SatDumpStartedEvent &evt) { handle_event(evt); });
+#endif
+
+        if (events.pipeline_done)
+            satdump::eventBus->register_handler<satdump::pipeline::events::PipelineDoneProcessingEvent>(
+                [this](const satdump::pipeline::events::PipelineDoneProcessingEvent &evt) { handle_event(evt); });
+
+        if (events.tles_updated)
+            satdump::eventBus->register_handler<satdump::TLEsUpdatedEvent>(
+                [this](const satdump::TLEsUpdatedEvent &evt) { handle_event(evt); });
+
+        if (events.tracking_aos)
+            satdump::eventBus->register_handler<satdump::events::TrackingSchedulerAOSEvent>(
+                [this](const satdump::events::TrackingSchedulerAOSEvent &evt) { handle_event(evt); });
+
+        if (events.tracking_los)
+            satdump::eventBus->register_handler<satdump::events::TrackingSchedulerLOSEvent>(
+                [this](const satdump::events::TrackingSchedulerLOSEvent &evt) { handle_event(evt); });
+    }
+
+    void WebhookSender::send_webhook(const std::string &url, const std::string &payload_key, const std::string &message)
+    {
+        nlohmann::json payload;
+        payload[payload_key] = message;
+
+        std::string json = payload.dump();
+        logger->debug("Sending webhook: \"" + json + "\"");
+
+        std::string response;
+        satdump::perform_http_request_post(url, response, json, "Content-Type: application/json");
+    }
+
+    void WebhookSender::test(const WebhookConfig &config)
+    {
+        send_webhook(config.url, get_payload_key(config.url), "Hello from SatDump!");
+    }
+
+    void WebhookSender::handle_event(const satdump::SatDumpStartedEvent &)
+    {
+        send_webhook(url, payload_key, "Started SatDump");
+    }
+
+    void WebhookSender::handle_event(const satdump::TLEsUpdatedEvent &)
+    {
+        send_webhook(url, payload_key, "TLEs Updated");
+    }
+
+    void WebhookSender::handle_event(const satdump::pipeline::events::PipelineDoneProcessingEvent &evt)
+    {
+        satdump::pipeline::Pipeline pipeline = satdump::pipeline::getPipelineFromID(evt.pipeline_id);
+        send_webhook(url, payload_key, "Finished processing **" + pipeline.name + "** pipeline");
+    }
+
+    void WebhookSender::handle_event(const satdump::events::TrackingSchedulerAOSEvent &evt)
+    {
+        std::string object_name = satdump::db_tle->get_from_norad(evt.pass.norad)->name;
+
+        std::stringstream elevation;
+        elevation << std::fixed << std::setprecision(2) << evt.pass.max_elevation;
+
+        std::string timestamp = satdump::timestamp_to_string(evt.pass.los_time, true);
+        auto timestamp_delim = timestamp.find(" ");
+        std::string los_time = timestamp.substr(timestamp_delim + 1);
+
+        std::stringstream message;
+        message << "AOS **" << object_name << "**: Tracking " << elevation.str() << "° pass until " << los_time;
+        send_webhook(url, payload_key, message.str());
+    }
+
+    void WebhookSender::handle_event(const satdump::events::TrackingSchedulerLOSEvent &evt)
+    {
+        std::string object_name = satdump::db_tle->get_from_norad(evt.pass.norad)->name;
+        send_webhook(url, payload_key, "LOS **" + object_name + "**");
+    }
+}

--- a/plugins/webhook_app/webhook.h
+++ b/plugins/webhook_app/webhook.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <string>
+
+#include "core/plugin.h"
+#include "common/tracking/tle.h"
+#include "pipeline/pipeline.h"
+#include "common/tracking/scheduler/scheduler.h"
+
+namespace webhook_app
+{
+    struct WebhookEvents
+    {
+        bool pipeline_done = true;
+        bool tles_updated = true;
+        bool tracking_aos = true;
+        bool tracking_los = true;
+    };
+
+    struct WebhookConfig
+    {
+        std::string url;
+        WebhookEvents events;
+    };
+
+    class WebhookSender
+    {
+    private:
+        std::string url;
+        std::string payload_key;
+        WebhookEvents events;
+
+        static std::string get_payload_key(const std::string &url);
+        static void send_webhook(const std::string &url, const std::string &payload_key, const std::string &message);
+
+        void handle_event(const satdump::SatDumpStartedEvent &evt);
+        void handle_event(const satdump::pipeline::events::PipelineDoneProcessingEvent &evt);
+        void handle_event(const satdump::TLEsUpdatedEvent &evt);
+        void handle_event(const satdump::events::TrackingSchedulerAOSEvent &evt);
+        void handle_event(const satdump::events::TrackingSchedulerLOSEvent &evt);
+
+    public:
+        WebhookSender(const WebhookConfig &config);
+
+        static bool is_valid_url(const std::string &url);
+        static void test(const WebhookConfig &config);
+    };
+}

--- a/src-core/common/tracking/scheduler/scheduler.cpp
+++ b/src-core/common/tracking/scheduler/scheduler.cpp
@@ -64,6 +64,7 @@ namespace satdump
                             vfo_mode_norads_vis.insert({pass.norad, pass});
 
                             logger->critical("AOS!!!!!!!!!!!!!! %d", pass.norad);
+                            eventBus->fire_event<events::TrackingSchedulerAOSEvent>({upcoming_satellite_passes_sel[0]});
                             TrackedObject obj;
                             for (auto &v : enabled_satellites)
                                 if (v.norad == pass.norad)
@@ -79,6 +80,7 @@ namespace satdump
                     if (curr_time > p.second.los_time)
                     {
                         logger->critical("LOS!!!!!!!!!!!!!! %d ", p.first);
+                        eventBus->fire_event<events::TrackingSchedulerLOSEvent>({upcoming_satellite_passes_sel[0]});
                         TrackedObject obj;
                         for (auto &v : enabled_satellites)
                             if (v.norad == p.first)
@@ -108,6 +110,7 @@ namespace satdump
                     if (!autotrack_pass_has_started && curr_time > upcoming_satellite_passes_sel[0].aos_time)
                     {
                         logger->critical("AOS!!!!!!!!!!!!!! %d", upcoming_satellite_passes_sel[0].norad);
+                        eventBus->fire_event<events::TrackingSchedulerAOSEvent>({upcoming_satellite_passes_sel[0]});
                         TrackedObject obj;
                         for (auto &v : enabled_satellites)
                             if (v.norad == upcoming_satellite_passes_sel[0].norad)
@@ -122,6 +125,7 @@ namespace satdump
                     if (autotrack_pass_has_started)
                     {
                         logger->critical("LOS!!!!!!!!!!!!!! %d", upcoming_satellite_passes_sel[0].norad);
+                        eventBus->fire_event<events::TrackingSchedulerLOSEvent>({upcoming_satellite_passes_sel[0]});
                         TrackedObject obj;
                         for (auto &v : enabled_satellites)
                             if (v.norad == upcoming_satellite_passes_sel[0].norad)

--- a/src-core/common/tracking/scheduler/scheduler.h
+++ b/src-core/common/tracking/scheduler/scheduler.h
@@ -214,4 +214,16 @@ namespace satdump
 
         image::Image getScheduleImage(int width, double curr_time);
     };
+
+    namespace events
+    {
+        struct TrackingSchedulerAOSEvent
+        {
+            SatellitePass pass;
+        };
+        struct TrackingSchedulerLOSEvent
+        {
+            SatellitePass pass;
+        };
+    } // namespace events
 } // namespace satdump

--- a/src-interface/main_ui.cpp
+++ b/src-interface/main_ui.cpp
@@ -168,18 +168,28 @@ namespace satdump
             }
 
             if (settings_en)
+            {
                 ImGui::OpenPopup("Settings");
+                ImVec2 center = ImGui::GetIO().DisplaySize * 0.5f;
+                ImGui::SetNextWindowPos({center.x, 50 * ui_scale}, ImGuiCond_Appearing, ImVec2(0.5f, 0.0f));
+                ImGui::SetNextWindowSize({750 * ui_scale, 0});
+            }
 
-            if (ImGui::BeginPopupModal("Settings", &settings_en, /*ImGuiWindowFlags_AlwaysAutoResize |*/ ImGuiWindowFlags_AlwaysVerticalScrollbar))
+            if (ImGui::BeginPopupModal("Settings", &settings_en, ImGuiWindowFlags_AlwaysVerticalScrollbar))
             {
                 settings::render();
                 ImGui::EndPopup();
             }
 
             if (about_en)
+            {
                 ImGui::OpenPopup("About");
+                ImVec2 center = ImGui::GetIO().DisplaySize * 0.5f;
+                ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+                ImGui::SetNextWindowSize({750 * ui_scale, 0});
+            }
 
-            if (ImGui::BeginPopupModal("About", &about_en, /*ImGuiWindowFlags_AlwaysAutoResize |*/ ImGuiWindowFlags_AlwaysVerticalScrollbar))
+            if (ImGui::BeginPopupModal("About", &about_en, ImGuiWindowFlags_AlwaysVerticalScrollbar))
             {
                 credits_md.render();
                 ImGui::Dummy({400 * ui_scale, 0});


### PR DESCRIPTION
Add `webhook_app` plugin to fire webhooks from event bus events. Supports multiple webhook URLs and each event type can be toggled per-URL. Has specific handling for Discord and Slack payloads, and will default to `{"message": str}` for any other URLs.

New events `TrackingSchedulerAOSEvent` and `TrackingSchedulerLOSEvent` have also been added.

<img width="570" height="312" alt="image" src="https://github.com/user-attachments/assets/1439ed89-861c-4501-b57c-bb8da27f6356" />

Debug builds register an extra event bus handler for `SatDumpStartedEvent` which is not in the settings UI or plugin config.

Unrelated change: Tweaks UI size and position for Settings and About modals.