### PR TITLE
fix build issue on debian (missing define of uint32_t in geotiff_*.cpp)

### DIFF
--- a/src-core/image/geotiff/geotiff.h
+++ b/src-core/image/geotiff/geotiff.h
@@ -6,6 +6,7 @@
 
 #include "projection/standard/proj.h"
 #include <tiffio.h>
+#include <cstdint>
 
 namespace satdump
 {


### PR DESCRIPTION
Was not compiling on debian-11 (all description is in title)