### PR TITLE
Fix minimized/zero-size window render loop

### DIFF
--- a/src-core/explorer/explorer.cpp
+++ b/src-core/explorer/explorer.cpp
@@ -438,11 +438,11 @@ namespace satdump
 
         void ExplorerApplication::draw()
         {
-            drawMenuBar();
-
             ImVec2 explorer_size = ImGui::GetContentRegionAvail();
-            if (explorer_size.x < 0.0f || explorer_size.y < 0.0f)
+            if (explorer_size.x <= 0.0f || explorer_size.y <= 0.0f)
                 return;
+
+            drawMenuBar();
 
             if (show_panel)
             {

--- a/src-interface/main_ui.cpp
+++ b/src-interface/main_ui.cpp
@@ -138,8 +138,8 @@ namespace satdump
 
         // On Windows minimizing makes the window dimensions 0,
         // which of course cause a whole lot of issues...
-        // Simply abort any further rendering of this happens!
-        if (dims.first == 0 && dims.second == 0)
+        // Simply abort any further rendering if this happens!
+        if (dims.first <= 0 && dims.second <= 0)
         {
             backend::endFrame();
             return;

--- a/src-ui/main.cpp
+++ b/src-ui/main.cpp
@@ -271,10 +271,26 @@ int main(int argc, char *argv[])
     signal(SIGTERM, sig_handler_ui);
 
     // Main loop
-    do
+    while (!glfwWindowShouldClose(window) && !signal_caught)
     {
+        glfwPollEvents();
+
+        int win_w = 0, win_h = 0;
+        int fb_w = 0, fb_h = 0;
+
+        glfwGetWindowSize(window, &win_w, &win_h);
+        glfwGetFramebufferSize(window, &fb_w, &fb_h);
+
+        const bool drawable = !glfwGetWindowAttrib(window, GLFW_ICONIFIED) && win_w > 0 && win_h > 0 && fb_w > 0 && fb_h > 0;
+
+        if (!drawable)
+        {
+            glfwWaitEventsTimeout(0.05);
+            continue;
+        }
+
         satdump::renderMainUI();
-    } while (!glfwWindowShouldClose(window) && !signal_caught);
+    }
 
     // Avoid getting stuck
     bool killThread_cancel = false;


### PR DESCRIPTION
Skip UI rendering when the GLFW window is minimized or has a 0x0 window/framebuffer, while still processing events so it can be restored. Also harden UI guards against <= 0 layout dimensions.