### PR TITLE
Add GGAK decoder for Elektro-L / Arktika-M

### DIFF
--- a/plugins/elektro_arktika_support/elektro_arktika/instruments/ggak/ggak_product.cpp
+++ b/plugins/elektro_arktika_support/elektro_arktika/instruments/ggak/ggak_product.cpp
@@ -1,0 +1,141 @@
+#include "ggak_product.h"
+#include "logger.h"
+
+#include <filesystem>
+#include <fstream>
+
+namespace elektro_arktika
+{
+    namespace ggak
+    {
+        namespace
+        {
+            void save_channels_binary(const std::string &path,
+                                      const std::vector<GGAKChannel> &channels)
+            {
+                std::ofstream f(path, std::ios::binary);
+                if (!f.is_open())
+                    return;
+                uint32_t n_ch = static_cast<uint32_t>(channels.size());
+                f.write(reinterpret_cast<const char *>(&n_ch), sizeof(n_ch));
+                for (auto &ch : channels)
+                {
+                    uint32_t n = static_cast<uint32_t>(ch.values.size());
+                    f.write(reinterpret_cast<const char *>(&n), sizeof(n));
+                    f.write(reinterpret_cast<const char *>(ch.timestamps.data()),
+                            n * sizeof(double));
+                    f.write(reinterpret_cast<const char *>(ch.values.data()),
+                            n * sizeof(double));
+                }
+            }
+
+            std::vector<GGAKChannel> load_channels_binary(const std::string &path,
+                                                           const nlohmann::json &meta)
+            {
+                std::vector<GGAKChannel> channels;
+                std::ifstream f(path, std::ios::binary);
+                if (!f.is_open())
+                    return channels;
+
+                uint32_t n_ch = 0;
+                f.read(reinterpret_cast<char *>(&n_ch), sizeof(n_ch));
+
+                for (uint32_t i = 0; i < n_ch && i < meta.size(); i++)
+                {
+                    GGAKChannel ch;
+                    ch.name = meta[i]["name"].get<std::string>();
+                    ch.unit = meta[i]["unit"].get<std::string>();
+                    if (meta[i].contains("group"))
+                        ch.group = meta[i]["group"].get<std::string>();
+
+                    uint32_t n = 0;
+                    f.read(reinterpret_cast<char *>(&n), sizeof(n));
+                    ch.timestamps.resize(n);
+                    ch.values.resize(n);
+                    f.read(reinterpret_cast<char *>(ch.timestamps.data()),
+                           n * sizeof(double));
+                    f.read(reinterpret_cast<char *>(ch.values.data()),
+                           n * sizeof(double));
+                    ch.updateMinMax();
+                    channels.push_back(std::move(ch));
+                }
+                return channels;
+            }
+
+            nlohmann::json make_channel_meta(const std::vector<GGAKChannel> &channels)
+            {
+                nlohmann::json j = nlohmann::json::array();
+                for (auto &ch : channels)
+                {
+                    nlohmann::json jc;
+                    jc["name"] = ch.name;
+                    jc["unit"] = ch.unit;
+                    if (!ch.group.empty())
+                        jc["group"] = ch.group;
+                    jc["count"] = ch.values.size();
+                    j.push_back(jc);
+                }
+                return j;
+            }
+        } // anonymous namespace
+
+        void GGAKProduct::save(std::string directory)
+        {
+            save_channels_binary(directory + "/mag.bin", mag_channels);
+            save_channels_binary(directory + "/particles.bin", particle_channels);
+            save_channels_binary(directory + "/subpackets.bin", subpacket_channels);
+
+            contents["channel_format"] = "binary";
+            contents["mag_channels"] = make_channel_meta(mag_channels);
+            contents["particle_channels"] = make_channel_meta(particle_channels);
+            contents["subpacket_channels"] = make_channel_meta(subpacket_channels);
+            contents["stats"] = stats;
+            Product::save(directory);
+        }
+
+        void GGAKProduct::load(std::string file)
+        {
+            Product::load(file);
+            std::string directory = std::filesystem::path(file).parent_path().string();
+
+            try
+            {
+                bool binary = contents.contains("channel_format") &&
+                              contents["channel_format"] == "binary";
+
+                if (binary)
+                {
+                    if (contents.contains("mag_channels"))
+                        mag_channels = load_channels_binary(
+                            directory + "/mag.bin", contents["mag_channels"]);
+                    if (contents.contains("particle_channels"))
+                        particle_channels = load_channels_binary(
+                            directory + "/particles.bin", contents["particle_channels"]);
+                    if (contents.contains("subpacket_channels"))
+                        subpacket_channels = load_channels_binary(
+                            directory + "/subpackets.bin", contents["subpacket_channels"]);
+                }
+                else
+                {
+                    if (contents.contains("mag_channels"))
+                        mag_channels = contents["mag_channels"].get<std::vector<GGAKChannel>>();
+                    if (contents.contains("particle_channels"))
+                        particle_channels = contents["particle_channels"].get<std::vector<GGAKChannel>>();
+                    if (contents.contains("subpacket_channels"))
+                        subpacket_channels = contents["subpacket_channels"].get<std::vector<GGAKChannel>>();
+                }
+
+                if (contents.contains("stats"))
+                    stats = contents["stats"].get<GGAKFrameStats>();
+            }
+            catch (const std::exception &e)
+            {
+                logger->error("GGAKProduct::load failed to parse: %s", e.what());
+                mag_channels.clear();
+                particle_channels.clear();
+                subpacket_channels.clear();
+                stats = {};
+            }
+        }
+    } // namespace ggak
+} // namespace elektro_arktika

--- a/plugins/elektro_arktika_support/elektro_arktika/instruments/ggak/ggak_product.cpp
+++ b/plugins/elektro_arktika_support/elektro_arktika/instruments/ggak/ggak_product.cpp
@@ -1,94 +1,83 @@
 #include "ggak_product.h"
 #include "logger.h"
 
+#include <algorithm>
 #include <filesystem>
-#include <fstream>
 
 namespace elektro_arktika
 {
     namespace ggak
     {
-        namespace
+        GGAKChannel with_gap_markers(const GGAKChannel &src)
         {
-            void save_channels_binary(const std::string &path,
-                                      const std::vector<GGAKChannel> &channels)
+            GGAKChannel ch = src;
+            if (ch.timestamps.size() < 2)
+                return ch;
+
+            std::vector<double> deltas;
+            deltas.reserve(ch.timestamps.size());
+            for (size_t i = 1; i < ch.timestamps.size(); i++)
             {
-                std::ofstream f(path, std::ios::binary);
-                if (!f.is_open())
-                    return;
-                uint32_t n_ch = static_cast<uint32_t>(channels.size());
-                f.write(reinterpret_cast<const char *>(&n_ch), sizeof(n_ch));
-                for (auto &ch : channels)
+                double dt = ch.timestamps[i] - ch.timestamps[i - 1];
+                if (dt > 0.01)
+                    deltas.push_back(dt);
+            }
+            if (deltas.empty())
+                return ch;
+
+            std::sort(deltas.begin(), deltas.end());
+            double cadence = deltas[deltas.size() / 2];
+            double gap_threshold = 1.5 * cadence;
+
+            std::vector<double> new_ts, new_vals;
+            new_ts.reserve(ch.timestamps.size() * 2);
+            new_vals.reserve(new_ts.capacity());
+
+            new_ts.push_back(ch.timestamps[0]);
+            new_vals.push_back(ch.values[0]);
+
+            for (size_t i = 1; i < ch.timestamps.size(); i++)
+            {
+                double dt = ch.timestamps[i] - ch.timestamps[i - 1];
+                if (dt > gap_threshold)
                 {
-                    uint32_t n = static_cast<uint32_t>(ch.values.size());
-                    f.write(reinterpret_cast<const char *>(&n), sizeof(n));
-                    f.write(reinterpret_cast<const char *>(ch.timestamps.data()),
-                            n * sizeof(double));
-                    f.write(reinterpret_cast<const char *>(ch.values.data()),
-                            n * sizeof(double));
+                    double nan = std::numeric_limits<double>::quiet_NaN();
+                    new_ts.push_back(nan);
+                    new_vals.push_back(nan);
                 }
+                new_ts.push_back(ch.timestamps[i]);
+                new_vals.push_back(ch.values[i]);
             }
 
-            std::vector<GGAKChannel> load_channels_binary(const std::string &path,
-                                                           const nlohmann::json &meta)
-            {
-                std::vector<GGAKChannel> channels;
-                std::ifstream f(path, std::ios::binary);
-                if (!f.is_open())
-                    return channels;
+            ch.timestamps = std::move(new_ts);
+            ch.values = std::move(new_vals);
+            return ch;
+        }
 
-                uint32_t n_ch = 0;
-                f.read(reinterpret_cast<char *>(&n_ch), sizeof(n_ch));
-
-                for (uint32_t i = 0; i < n_ch && i < meta.size(); i++)
-                {
-                    GGAKChannel ch;
-                    ch.name = meta[i]["name"].get<std::string>();
-                    ch.unit = meta[i]["unit"].get<std::string>();
-                    if (meta[i].contains("group"))
-                        ch.group = meta[i]["group"].get<std::string>();
-
-                    uint32_t n = 0;
-                    f.read(reinterpret_cast<char *>(&n), sizeof(n));
-                    ch.timestamps.resize(n);
-                    ch.values.resize(n);
-                    f.read(reinterpret_cast<char *>(ch.timestamps.data()),
-                           n * sizeof(double));
-                    f.read(reinterpret_cast<char *>(ch.values.data()),
-                           n * sizeof(double));
-                    ch.updateMinMax();
-                    channels.push_back(std::move(ch));
-                }
-                return channels;
-            }
-
-            nlohmann::json make_channel_meta(const std::vector<GGAKChannel> &channels)
-            {
-                nlohmann::json j = nlohmann::json::array();
-                for (auto &ch : channels)
-                {
-                    nlohmann::json jc;
-                    jc["name"] = ch.name;
-                    jc["unit"] = ch.unit;
-                    if (!ch.group.empty())
-                        jc["group"] = ch.group;
-                    jc["count"] = ch.values.size();
-                    j.push_back(jc);
-                }
-                return j;
-            }
-        } // anonymous namespace
+        std::vector<GGAKChannel> with_gap_markers(const std::vector<GGAKChannel> &src)
+        {
+            std::vector<GGAKChannel> out;
+            out.reserve(src.size());
+            for (const auto &ch : src)
+                out.push_back(with_gap_markers(ch));
+            return out;
+        }
 
         void GGAKProduct::save(std::string directory)
         {
-            save_channels_binary(directory + "/mag.bin", mag_channels);
-            save_channels_binary(directory + "/particles.bin", particle_channels);
-            save_channels_binary(directory + "/subpackets.bin", subpacket_channels);
+            auto warn_inconsistent = [](const std::vector<GGAKChannel> &channels, const char *group) {
+                for (auto &ch : channels)
+                    if (!ch.isConsistent())
+                        logger->warn("GGAKProduct::save: channel '%s' in %s has mismatched sizes (ts=%zu, vals=%zu)",
+                                     ch.name.c_str(), group, ch.timestamps.size(), ch.values.size());
+            };
+            warn_inconsistent(mag_channels, "mag_channels");
+            warn_inconsistent(particle_channels, "particle_channels");
+            warn_inconsistent(subpacket_channels, "subpacket_channels");
 
-            contents["channel_format"] = "binary";
-            contents["mag_channels"] = make_channel_meta(mag_channels);
-            contents["particle_channels"] = make_channel_meta(particle_channels);
-            contents["subpacket_channels"] = make_channel_meta(subpacket_channels);
+            contents["mag_channels"] = mag_channels;
+            contents["particle_channels"] = particle_channels;
+            contents["subpacket_channels"] = subpacket_channels;
             contents["stats"] = stats;
             Product::save(directory);
         }
@@ -96,34 +85,15 @@ namespace elektro_arktika
         void GGAKProduct::load(std::string file)
         {
             Product::load(file);
-            std::string directory = std::filesystem::path(file).parent_path().string();
 
             try
             {
-                bool binary = contents.contains("channel_format") &&
-                              contents["channel_format"] == "binary";
-
-                if (binary)
-                {
-                    if (contents.contains("mag_channels"))
-                        mag_channels = load_channels_binary(
-                            directory + "/mag.bin", contents["mag_channels"]);
-                    if (contents.contains("particle_channels"))
-                        particle_channels = load_channels_binary(
-                            directory + "/particles.bin", contents["particle_channels"]);
-                    if (contents.contains("subpacket_channels"))
-                        subpacket_channels = load_channels_binary(
-                            directory + "/subpackets.bin", contents["subpacket_channels"]);
-                }
-                else
-                {
-                    if (contents.contains("mag_channels"))
-                        mag_channels = contents["mag_channels"].get<std::vector<GGAKChannel>>();
-                    if (contents.contains("particle_channels"))
-                        particle_channels = contents["particle_channels"].get<std::vector<GGAKChannel>>();
-                    if (contents.contains("subpacket_channels"))
-                        subpacket_channels = contents["subpacket_channels"].get<std::vector<GGAKChannel>>();
-                }
+                if (contents.contains("mag_channels"))
+                    mag_channels = contents["mag_channels"].get<std::vector<GGAKChannel>>();
+                if (contents.contains("particle_channels"))
+                    particle_channels = contents["particle_channels"].get<std::vector<GGAKChannel>>();
+                if (contents.contains("subpacket_channels"))
+                    subpacket_channels = contents["subpacket_channels"].get<std::vector<GGAKChannel>>();
 
                 if (contents.contains("stats"))
                     stats = contents["stats"].get<GGAKFrameStats>();

--- a/plugins/elektro_arktika_support/elektro_arktika/instruments/ggak/ggak_product.h
+++ b/plugins/elektro_arktika_support/elektro_arktika/instruments/ggak/ggak_product.h
@@ -1,0 +1,144 @@
+#pragma once
+
+#include "products/product.h"
+#include "nlohmann/json.hpp"
+#include <cmath>
+#include <limits>
+#include <map>
+#include <vector>
+
+namespace elektro_arktika
+{
+    namespace ggak
+    {
+        struct GGAKChannel
+        {
+            std::string name;
+            std::string unit;
+            std::string group;
+            std::vector<double> timestamps;
+            std::vector<double> values;
+
+            double cached_min = 0;
+            double cached_max = 0;
+            int cached_valid_count = 0;
+
+            void updateMinMax()
+            {
+                cached_min = std::numeric_limits<double>::max();
+                cached_max = -std::numeric_limits<double>::max();
+                cached_valid_count = 0;
+                for (double v : values)
+                {
+                    if (std::isnan(v))
+                        continue;
+                    cached_valid_count++;
+                    if (v < cached_min) cached_min = v;
+                    if (v > cached_max) cached_max = v;
+                }
+                if (cached_valid_count == 0)
+                    cached_min = cached_max = 0;
+            }
+
+            friend void to_json(nlohmann::json &j, const GGAKChannel &c)
+            {
+                j = nlohmann::json{{"name", c.name}, {"unit", c.unit},
+                                   {"timestamps", c.timestamps}, {"values", c.values}};
+                if (!c.group.empty())
+                    j["group"] = c.group;
+            }
+
+            friend void from_json(const nlohmann::json &j, GGAKChannel &c)
+            {
+                j.at("name").get_to(c.name);
+                j.at("unit").get_to(c.unit);
+                j.at("timestamps").get_to(c.timestamps);
+                j.at("values").get_to(c.values);
+                if (j.contains("group"))
+                    j.at("group").get_to(c.group);
+                c.updateMinMax();
+            }
+        };
+
+        struct GGAKFrameStats
+        {
+            int total_frames = 0;
+            int data_frames = 0;
+            int fill_frames = 0;
+            int checksum_pass = 0;
+            int checksum_fail = 0;
+            int counter_gaps = 0;
+            int missing_estimate = 0;
+            std::string generation;
+            std::string satellite_name;
+            std::map<std::string, int> per_instrument_gaps;
+            std::map<std::string, int> per_instrument_missing;
+
+            friend void to_json(nlohmann::json &j, const GGAKFrameStats &s)
+            {
+                j = nlohmann::json{
+                    {"total_frames", s.total_frames},
+                    {"data_frames", s.data_frames},
+                    {"fill_frames", s.fill_frames},
+                    {"checksum_pass", s.checksum_pass},
+                    {"checksum_fail", s.checksum_fail},
+                    {"counter_gaps", s.counter_gaps},
+                    {"missing_estimate", s.missing_estimate},
+                    {"generation", s.generation},
+                    {"satellite_name", s.satellite_name}};
+                if (!s.per_instrument_gaps.empty())
+                    j["per_instrument_gaps"] = s.per_instrument_gaps;
+                if (!s.per_instrument_missing.empty())
+                    j["per_instrument_missing"] = s.per_instrument_missing;
+            }
+
+            friend void from_json(const nlohmann::json &j, GGAKFrameStats &s)
+            {
+                j.at("total_frames").get_to(s.total_frames);
+                j.at("data_frames").get_to(s.data_frames);
+                j.at("fill_frames").get_to(s.fill_frames);
+                j.at("checksum_pass").get_to(s.checksum_pass);
+                j.at("checksum_fail").get_to(s.checksum_fail);
+                j.at("counter_gaps").get_to(s.counter_gaps);
+                j.at("missing_estimate").get_to(s.missing_estimate);
+                j.at("generation").get_to(s.generation);
+                j.at("satellite_name").get_to(s.satellite_name);
+                if (j.contains("per_instrument_gaps"))
+                    j.at("per_instrument_gaps").get_to(s.per_instrument_gaps);
+                if (j.contains("per_instrument_missing"))
+                    j.at("per_instrument_missing").get_to(s.per_instrument_missing);
+            }
+        };
+
+        class GGAKProduct : public satdump::products::Product
+        {
+        public:
+            std::vector<GGAKChannel> mag_channels;
+            std::vector<GGAKChannel> particle_channels;
+            std::vector<GGAKChannel> subpacket_channels;
+            GGAKFrameStats stats;
+
+            GGAKProduct() { type = "ggak"; }
+
+            void save(std::string directory);
+            void load(std::string file);
+
+            int totalChannels() const
+            {
+                return (int)(mag_channels.size() + particle_channels.size() + subpacket_channels.size());
+            }
+
+            int totalSamples() const
+            {
+                int n = 0;
+                for (auto &c : mag_channels)
+                    n += (int)c.values.size();
+                for (auto &c : particle_channels)
+                    n += (int)c.values.size();
+                for (auto &c : subpacket_channels)
+                    n += (int)c.values.size();
+                return n;
+            }
+        };
+    } // namespace ggak
+} // namespace elektro_arktika

--- a/plugins/elektro_arktika_support/elektro_arktika/instruments/ggak/ggak_product.h
+++ b/plugins/elektro_arktika_support/elektro_arktika/instruments/ggak/ggak_product.h
@@ -1,5 +1,14 @@
 #pragma once
 
+/**
+ * @file ggak_product.h
+ * @brief GGAK product data model for the SatDump product system.
+ *
+ * Defines the channel data structure (GGAKChannel), frame statistics
+ * (GGAKFrameStats), and the GGAKProduct class that extends the core
+ * Product with magnetometer, particle, and spectrometer time series.
+ */
+
 #include "products/product.h"
 #include "nlohmann/json.hpp"
 #include <cmath>
@@ -23,18 +32,24 @@ namespace elektro_arktika
             double cached_max = 0;
             int cached_valid_count = 0;
 
+            bool isConsistent() const
+            {
+                return timestamps.size() == values.size();
+            }
+
             void updateMinMax()
             {
                 cached_min = std::numeric_limits<double>::max();
                 cached_max = -std::numeric_limits<double>::max();
                 cached_valid_count = 0;
-                for (double v : values)
+                size_t n = std::min(timestamps.size(), values.size());
+                for (size_t i = 0; i < n; i++)
                 {
-                    if (std::isnan(v))
+                    if (std::isnan(values[i]))
                         continue;
                     cached_valid_count++;
-                    if (v < cached_min) cached_min = v;
-                    if (v > cached_max) cached_max = v;
+                    if (values[i] < cached_min) cached_min = values[i];
+                    if (values[i] > cached_max) cached_max = values[i];
                 }
                 if (cached_valid_count == 0)
                     cached_min = cached_max = 0;
@@ -71,6 +86,7 @@ namespace elektro_arktika
             int missing_estimate = 0;
             std::string generation;
             std::string satellite_name;
+            uint8_t observed_source_id = 0;
             std::map<std::string, int> per_instrument_gaps;
             std::map<std::string, int> per_instrument_missing;
 
@@ -85,7 +101,8 @@ namespace elektro_arktika
                     {"counter_gaps", s.counter_gaps},
                     {"missing_estimate", s.missing_estimate},
                     {"generation", s.generation},
-                    {"satellite_name", s.satellite_name}};
+                    {"satellite_name", s.satellite_name},
+                    {"observed_source_id", s.observed_source_id}};
                 if (!s.per_instrument_gaps.empty())
                     j["per_instrument_gaps"] = s.per_instrument_gaps;
                 if (!s.per_instrument_missing.empty())
@@ -103,6 +120,8 @@ namespace elektro_arktika
                 j.at("missing_estimate").get_to(s.missing_estimate);
                 j.at("generation").get_to(s.generation);
                 j.at("satellite_name").get_to(s.satellite_name);
+                if (j.contains("observed_source_id"))
+                    j.at("observed_source_id").get_to(s.observed_source_id);
                 if (j.contains("per_instrument_gaps"))
                     j.at("per_instrument_gaps").get_to(s.per_instrument_gaps);
                 if (j.contains("per_instrument_missing"))
@@ -140,5 +159,8 @@ namespace elektro_arktika
                 return n;
             }
         };
+
+        GGAKChannel with_gap_markers(const GGAKChannel &src);
+        std::vector<GGAKChannel> with_gap_markers(const std::vector<GGAKChannel> &src);
     } // namespace ggak
 } // namespace elektro_arktika

--- a/plugins/elektro_arktika_support/elektro_arktika/instruments/ggak/ggak_product_handler.cpp
+++ b/plugins/elektro_arktika_support/elektro_arktika/instruments/ggak/ggak_product_handler.cpp
@@ -1,10 +1,14 @@
 #include "ggak_product_handler.h"
+#include "ggak_types.h"
 #include "core/style.h"
 #include "imgui/implot/implot.h"
 #include "logger.h"
+#include "nlohmann/json_utils.h"
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <limits>
+#include <unordered_map>
 
 namespace elektro_arktika
 {
@@ -12,49 +16,7 @@ namespace elektro_arktika
     {
         namespace
         {
-            void insert_gap_markers(GGAKChannel &ch)
-            {
-                if (ch.timestamps.size() < 2)
-                    return;
-
-                std::vector<double> deltas;
-                deltas.reserve(ch.timestamps.size());
-                for (size_t i = 1; i < ch.timestamps.size(); i++)
-                {
-                    double dt = ch.timestamps[i] - ch.timestamps[i - 1];
-                    if (dt > 0.01)
-                        deltas.push_back(dt);
-                }
-                if (deltas.empty())
-                    return;
-
-                std::sort(deltas.begin(), deltas.end());
-                double cadence = deltas[deltas.size() / 2];
-                double gap_threshold = 1.5 * cadence;
-
-                std::vector<double> new_ts, new_vals;
-                new_ts.reserve(ch.timestamps.size() + ch.timestamps.size() / 8);
-                new_vals.reserve(new_ts.capacity());
-
-                new_ts.push_back(ch.timestamps[0]);
-                new_vals.push_back(ch.values[0]);
-
-                for (size_t i = 1; i < ch.timestamps.size(); i++)
-                {
-                    double dt = ch.timestamps[i] - ch.timestamps[i - 1];
-                    if (dt > gap_threshold)
-                    {
-                        double nan = std::numeric_limits<double>::quiet_NaN();
-                        new_ts.push_back(nan);
-                        new_vals.push_back(nan);
-                    }
-                    new_ts.push_back(ch.timestamps[i]);
-                    new_vals.push_back(ch.values[i]);
-                }
-
-                ch.timestamps = std::move(new_ts);
-                ch.values = std::move(new_vals);
-            }
+            constexpr float SCROLLBAR_MARGIN = 16.0f;
         } // anonymous namespace
 
         GGAKProductHandler::GGAKProductHandler(std::shared_ptr<satdump::products::Product> p, bool dataset_mode)
@@ -69,29 +31,24 @@ namespace elektro_arktika
             }
             particle_visible.resize(ggak_product->particle_channels.size(), 1);
 
-            for (int i = 0; i < (int)ggak_product->subpacket_channels.size(); i++)
+            plot_mag_channels = with_gap_markers(ggak_product->mag_channels);
+            plot_particle_channels = with_gap_markers(ggak_product->particle_channels);
+            plot_subpacket_channels = with_gap_markers(ggak_product->subpacket_channels);
+
+            std::unordered_map<std::string, int> group_to_index;
+            for (int i = 0; i < static_cast<int>(ggak_product->subpacket_channels.size()); i++)
             {
                 auto &ch = ggak_product->subpacket_channels[i];
                 std::string grp = ch.group.empty() ? ch.name : ch.group;
-                auto it = std::find_if(subpacket_group_info.begin(), subpacket_group_info.end(),
-                                       [&](const SubpacketGroupInfo &g) { return g.name == grp; });
-                if (it != subpacket_group_info.end())
-                    it->channel_indices.push_back(i);
+                auto it = group_to_index.find(grp);
+                if (it != group_to_index.end())
+                    subpacket_group_info[it->second].channel_indices.push_back(i);
                 else
+                {
+                    group_to_index[grp] = static_cast<int>(subpacket_group_info.size());
                     subpacket_group_info.push_back({grp, {i}});
+                }
             }
-
-            for (int i = 0; i < (int)ggak_product->particle_channels.size(); i++)
-                particle_labels.push_back(ggak_product->particle_channels[i].name + "##ptcl_" + std::to_string(i));
-            for (int i = 0; i < (int)subpacket_group_info.size(); i++)
-                subpacket_rb_labels.push_back(subpacket_group_info[i].name + "##spkt_" + std::to_string(i));
-
-            for (auto &ch : ggak_product->mag_channels)
-                insert_gap_markers(ch);
-            for (auto &ch : ggak_product->particle_channels)
-                insert_gap_markers(ch);
-            for (auto &ch : ggak_product->subpacket_channels)
-                insert_gap_markers(ch);
 
             tryApplyDefaultPreset();
         }
@@ -100,6 +57,9 @@ namespace elektro_arktika
 
         void GGAKProductHandler::drawMenu()
         {
+            if (!ggak_product)
+                return;
+
             if (ImGui::CollapsingHeader("View", ImGuiTreeNodeFlags_DefaultOpen))
             {
                 if (ImGui::RadioButton("Magnetometer", current_view == VIEW_MAGNETOMETER))
@@ -134,11 +94,13 @@ namespace elektro_arktika
                 {
                     ImGui::Checkbox("Overlay##ptcl_overlay", &particle_overlay);
                     ImGui::Separator();
-                    for (int i = 0; i < (int)ggak_product->particle_channels.size(); i++)
+                    for (int i = 0; i < static_cast<int>(ggak_product->particle_channels.size()); i++)
                     {
                         bool vis = particle_visible[i] != 0;
-                        if (ImGui::Checkbox(particle_labels[i].c_str(), &vis))
+                        ImGui::PushID(i);
+                        if (ImGui::Checkbox(ggak_product->particle_channels[i].name.c_str(), &vis))
                             particle_visible[i] = vis ? 1 : 0;
+                        ImGui::PopID();
                     }
                 }
             }
@@ -146,18 +108,26 @@ namespace elektro_arktika
             {
                 if (ImGui::CollapsingHeader("Spectrometer##spectrometer_ch", ImGuiTreeNodeFlags_DefaultOpen))
                 {
-                    for (int i = 0; i < (int)subpacket_group_info.size(); i++)
+                    for (int i = 0; i < static_cast<int>(subpacket_group_info.size()); i++)
                     {
-                        if (ImGui::RadioButton(subpacket_rb_labels[i].c_str(), selected_subpacket_group == i))
+                        ImGui::PushID(i);
+                        if (ImGui::RadioButton(subpacket_group_info[i].name.c_str(), selected_subpacket_group == i))
                             selected_subpacket_group = i;
+                        ImGui::PopID();
                     }
                 }
             }
 
+            renderPresetMenu();
         }
 
         void GGAKProductHandler::drawContents(ImVec2 win_size)
         {
+            if (!ggak_product)
+                return;
+
+            plot_id_counter = 0;
+
             switch (current_view)
             {
             case VIEW_MAGNETOMETER:
@@ -181,7 +151,7 @@ namespace elektro_arktika
                 value = 0.0;
             else if (value > 2e9)
                 value = 2e9;
-            int total_s = (int)value;
+            int total_s = static_cast<int>(value);
             int d = total_s / 86400;
             int h = (total_s % 86400) / 3600;
             int m = (total_s % 3600) / 60;
@@ -193,14 +163,14 @@ namespace elektro_arktika
             return 0;
         }
 
-        void GGAKProductHandler::drawChannelPlot(const GGAKChannel &ch, ImVec2 size, const char *y_label)
+        void GGAKProductHandler::drawChannelPlot(const GGAKChannel &ch, ImVec2 size, int plot_idx, const char *y_label)
         {
             if (ch.values.empty())
                 return;
 
             char title_buf[128];
-            snprintf(title_buf, sizeof(title_buf), "%s (%s)##plot_%p",
-                     ch.name.c_str(), ch.unit.c_str(), (const void *)&ch);
+            snprintf(title_buf, sizeof(title_buf), "%s (%s)##plot_%d",
+                     ch.name.c_str(), ch.unit.c_str(), plot_idx);
             if (ImPlot::BeginPlot(title_buf, size))
             {
                 ImPlot::SetupAxes("Elapsed", y_label ? y_label : ch.unit.c_str(),
@@ -208,28 +178,30 @@ namespace elektro_arktika
                 ImPlot::SetupAxisFormat(ImAxis_X1, ggak_time_formatter_cb);
                 ImPlot::PlotLine(ch.name.c_str(),
                                  ch.timestamps.data(), ch.values.data(),
-                                 (int)ch.values.size());
+                                 static_cast<int>(ch.values.size()));
                 ImPlot::EndPlot();
             }
         }
 
         void GGAKProductHandler::drawMagnetometerPlots(ImVec2 win_size)
         {
-            if (ggak_product->mag_channels.empty())
+            if (plot_mag_channels.empty())
             {
                 ImGui::TextColored(style::theme.orange, "No magnetometer data available.");
                 return;
             }
 
-            bool *show_flags[] = {&mag_show_btotal, &mag_show_bx, &mag_show_by, &mag_show_bz};
-            int mag_field_count = std::min(4, (int)ggak_product->mag_channels.size());
+            constexpr int MAG_FIELD_COUNT = 4;
+            std::array<bool*, MAG_FIELD_COUNT> show_flags = {
+                &mag_show_btotal, &mag_show_bx, &mag_show_by, &mag_show_bz};
+            int mag_field_count = std::min(MAG_FIELD_COUNT, static_cast<int>(plot_mag_channels.size()));
 
             int visible_count = 0;
             for (int i = 0; i < mag_field_count; i++)
                 if (*show_flags[i])
                     visible_count++;
 
-            bool has_voltage = mag_show_voltage && (int)ggak_product->mag_channels.size() > 4;
+            bool has_voltage = mag_show_voltage && static_cast<int>(plot_mag_channels.size()) > 4;
 
             int aux_count = has_voltage ? 1 : 0;
 
@@ -248,18 +220,18 @@ namespace elektro_arktika
                     {
                         if (!*show_flags[i])
                             continue;
-                        auto &ch = ggak_product->mag_channels[i];
+                        auto &ch = plot_mag_channels[i];
                         if (ch.values.empty())
                             continue;
                         ImPlot::PlotLine(ch.name.c_str(),
                                          ch.timestamps.data(), ch.values.data(),
-                                         (int)ch.values.size());
+                                         static_cast<int>(ch.values.size()));
                     }
                     ImPlot::EndPlot();
                 }
 
                 if (has_voltage)
-                    drawChannelPlot(ggak_product->mag_channels[4], ImVec2(win_size.x, per_aux_h), "V");
+                    drawChannelPlot(plot_mag_channels[4], ImVec2(win_size.x, per_aux_h), plot_id_counter++, "V");
             }
             else
             {
@@ -273,24 +245,24 @@ namespace elektro_arktika
                 {
                     if (!*show_flags[i])
                         continue;
-                    drawChannelPlot(ggak_product->mag_channels[i], ImVec2(win_size.x, plot_h), "nT");
+                    drawChannelPlot(plot_mag_channels[i], ImVec2(win_size.x, plot_h), plot_id_counter++, "nT");
                 }
 
                 if (has_voltage)
-                    drawChannelPlot(ggak_product->mag_channels[4], ImVec2(win_size.x, plot_h), "V");
+                    drawChannelPlot(plot_mag_channels[4], ImVec2(win_size.x, plot_h), plot_id_counter++, "V");
             }
         }
 
         void GGAKProductHandler::drawParticlePlots(ImVec2 win_size)
         {
-            if (ggak_product->particle_channels.empty())
+            if (plot_particle_channels.empty())
             {
                 ImGui::TextColored(style::theme.orange, "No particle data available.");
                 return;
             }
 
             int visible = 0;
-            for (int i = 0; i < (int)particle_visible.size(); i++)
+            for (int i = 0; i < static_cast<int>(particle_visible.size()); i++)
                 if (particle_visible[i])
                     visible++;
 
@@ -308,16 +280,16 @@ namespace elektro_arktika
                                       ImPlotAxisFlags_AutoFit, ImPlotAxisFlags_AutoFit);
                     ImPlot::SetupAxisFormat(ImAxis_X1, ggak_time_formatter_cb);
 
-                    for (int i = 0; i < (int)ggak_product->particle_channels.size(); i++)
+                    for (int i = 0; i < static_cast<int>(plot_particle_channels.size()); i++)
                     {
                         if (!particle_visible[i])
                             continue;
-                        auto &ch = ggak_product->particle_channels[i];
+                        auto &ch = plot_particle_channels[i];
                         if (ch.values.empty())
                             continue;
                         ImPlot::PlotLine(ch.name.c_str(),
                                          ch.timestamps.data(), ch.values.data(),
-                                         (int)ch.values.size());
+                                         static_cast<int>(ch.values.size()));
                     }
                     ImPlot::EndPlot();
                 }
@@ -331,12 +303,12 @@ namespace elektro_arktika
                 if (total_h > win_size.y)
                     ImGui::BeginChild("##ptcl_scroll", win_size, false, ImGuiWindowFlags_NoBackground);
 
-                for (int i = 0; i < (int)ggak_product->particle_channels.size(); i++)
+                for (int i = 0; i < static_cast<int>(plot_particle_channels.size()); i++)
                 {
                     if (!particle_visible[i])
                         continue;
-                    drawChannelPlot(ggak_product->particle_channels[i],
-                                    ImVec2(win_size.x - 16, plot_h), "Counts");
+                    drawChannelPlot(plot_particle_channels[i],
+                                    ImVec2(win_size.x - SCROLLBAR_MARGIN, plot_h), plot_id_counter++, "Counts");
                 }
 
                 if (total_h > win_size.y)
@@ -352,14 +324,14 @@ namespace elektro_arktika
                 return;
             }
 
-            if (selected_subpacket_group < 0 || selected_subpacket_group >= (int)subpacket_group_info.size())
+            if (selected_subpacket_group < 0 || selected_subpacket_group >= static_cast<int>(subpacket_group_info.size()))
             {
                 ImGui::Text("Selected group has no data.");
                 return;
             }
 
             auto &grp = subpacket_group_info[selected_subpacket_group];
-            int n_channels = (int)grp.channel_indices.size();
+            int n_channels = static_cast<int>(grp.channel_indices.size());
             if (n_channels == 0)
             {
                 ImGui::Text("No data in this group.");
@@ -375,20 +347,20 @@ namespace elektro_arktika
 
             for (int idx : grp.channel_indices)
             {
-                auto &ch = ggak_product->subpacket_channels[idx];
+                auto &ch = plot_subpacket_channels[idx];
                 if (ch.values.empty())
                     continue;
                 char sp_title[128];
                 snprintf(sp_title, sizeof(sp_title), "%s (%s)##subpkt_%d",
                          ch.name.c_str(), ch.unit.c_str(), idx);
-                if (ImPlot::BeginPlot(sp_title, ImVec2(win_size.x - 16, plot_h)))
+                if (ImPlot::BeginPlot(sp_title, ImVec2(win_size.x - SCROLLBAR_MARGIN, plot_h)))
                 {
                     ImPlot::SetupAxes("Elapsed", ch.unit.c_str(),
                                       ImPlotAxisFlags_AutoFit, ImPlotAxisFlags_AutoFit);
                     ImPlot::SetupAxisFormat(ImAxis_X1, ggak_time_formatter_cb);
                     ImPlot::PlotLine(ch.name.c_str(),
                                      ch.timestamps.data(), ch.values.data(),
-                                     (int)ch.values.size());
+                                     static_cast<int>(ch.values.size()));
                     ImPlot::EndPlot();
                 }
             }
@@ -420,7 +392,7 @@ namespace elektro_arktika
             {
                 auto &bt = ggak_product->mag_channels[0];
                 double last_bt = std::numeric_limits<double>::quiet_NaN();
-                for (int i = (int)bt.values.size() - 1; i >= 0; i--)
+                for (int i = static_cast<int>(bt.values.size()) - 1; i >= 0; i--)
                 {
                     if (!std::isnan(bt.values[i]))
                     {
@@ -430,18 +402,20 @@ namespace elektro_arktika
                 }
                 if (!std::isnan(last_bt))
                 {
-                    double dev = std::abs(last_bt - 103.0);
-                    int level = dev < 5.0 ? 1 : dev < 20.0 ? 2 : dev < 50.0 ? 3 : dev < 100.0 ? 4 : 5;
-                    const char *labels[] = {"Normal", "Slight", "Moderate", "Strong", "Extreme"};
+                    double dev = std::abs(last_bt - MAG_BASELINE_NT);
+                    int level = geomagnetic_activity_level(last_bt);
+                    const char *label = geomagnetic_activity_label(level);
                     ImVec4 colors[] = {
                         (ImVec4)style::theme.green, (ImVec4)style::theme.light_green,
                         (ImVec4)style::theme.yellow, (ImVec4)style::theme.orange,
                         (ImVec4)style::theme.red};
+                    int color_idx = std::max(0, std::min(level - 1, 4));
                     ImGui::Spacing();
                     ImGui::Text("Geomagnetic Activity:");
                     ImGui::SameLine();
-                    ImGui::TextColored(colors[level - 1], "Level %d - %s", level, labels[level - 1]);
-                    ImGui::Text("|B| = %.1f nT (baseline 103 nT, dev %.1f nT)", last_bt, dev);
+                    ImGui::TextColored(colors[color_idx], "Level %d - %s", level, label);
+                    ImGui::Text("|B| = %.1f nT (baseline %.0f nT, dev %.1f nT)",
+                                last_bt, MAG_BASELINE_NT, dev);
                 }
             }
 
@@ -449,7 +423,6 @@ namespace elektro_arktika
             ImGui::Separator();
             ImGui::Spacing();
 
-            // Channel overview table
             ImGui::TextColored(style::theme.cyan, "Channel Overview");
             ImGui::Spacing();
 
@@ -471,7 +444,10 @@ namespace elektro_arktika
                     {
                         ImGui::TableNextRow();
                         ImGui::TableSetColumnIndex(0);
-                        ImGui::TextUnformatted(group);
+                        if (group)
+                            ImGui::TextUnformatted(group);
+                        else
+                            ImGui::TextUnformatted(ch.group.empty() ? ch.name.c_str() : ch.group.c_str());
                         ImGui::TableSetColumnIndex(1);
                         ImGui::TextUnformatted(ch.name.c_str());
                         ImGui::TableSetColumnIndex(2);
@@ -488,28 +464,74 @@ namespace elektro_arktika
 
                 draw_channel_rows("FM-VE", ggak_product->mag_channels);
                 draw_channel_rows("GALS-VE + SKIF-VE MIP", ggak_product->particle_channels);
-
-                for (auto &ch : ggak_product->subpacket_channels)
-                {
-                    ImGui::TableNextRow();
-                    ImGui::TableSetColumnIndex(0);
-                    ImGui::TextUnformatted(ch.group.empty() ? ch.name.c_str() : ch.group.c_str());
-                    ImGui::TableSetColumnIndex(1);
-                    ImGui::TextUnformatted(ch.name.c_str());
-                    ImGui::TableSetColumnIndex(2);
-                    ImGui::TextUnformatted(ch.unit.c_str());
-                    ImGui::TableSetColumnIndex(3);
-                    ImGui::Text("%d", ch.cached_valid_count);
-                    ImGui::TableSetColumnIndex(4);
-                    if (ch.cached_valid_count > 0)
-                        ImGui::Text("%.2f .. %.2f", ch.cached_min, ch.cached_max);
-                    else
-                        ImGui::TextDisabled("--");
-                }
+                draw_channel_rows(nullptr, ggak_product->subpacket_channels);
 
                 ImGui::EndTable();
             }
 
+        }
+
+        void GGAKProductHandler::setConfig(nlohmann::json p)
+        {
+            if (p.contains("view"))
+            {
+                std::string v = p["view"].get<std::string>();
+                if (v == "magnetometer")
+                    current_view = VIEW_MAGNETOMETER;
+                else if (v == "particles")
+                    current_view = VIEW_PARTICLES;
+                else if (v == "spectrometer")
+                    current_view = VIEW_SUBPACKETS;
+                else if (v == "summary")
+                    current_view = VIEW_SUMMARY;
+            }
+            if (p.contains("mag_overlay"))
+                mag_overlay = p["mag_overlay"].get<bool>();
+            if (p.contains("particle_overlay"))
+                particle_overlay = p["particle_overlay"].get<bool>();
+            if (p.contains("selected_subpacket_group"))
+                selected_subpacket_group = p["selected_subpacket_group"].get<int>();
+            if (p.contains("mag_show_btotal"))
+                mag_show_btotal = p["mag_show_btotal"].get<bool>();
+            if (p.contains("mag_show_bx"))
+                mag_show_bx = p["mag_show_bx"].get<bool>();
+            if (p.contains("mag_show_by"))
+                mag_show_by = p["mag_show_by"].get<bool>();
+            if (p.contains("mag_show_bz"))
+                mag_show_bz = p["mag_show_bz"].get<bool>();
+            if (p.contains("mag_show_voltage"))
+                mag_show_voltage = p["mag_show_voltage"].get<bool>();
+            if (p.contains("particle_visible") && p["particle_visible"].is_array())
+            {
+                auto arr = p["particle_visible"];
+                for (size_t i = 0; i < arr.size() && i < particle_visible.size(); i++)
+                    particle_visible[i] = arr[i].get<int>();
+            }
+        }
+
+        nlohmann::json GGAKProductHandler::getConfig()
+        {
+            nlohmann::json p;
+
+            switch (current_view)
+            {
+            case VIEW_MAGNETOMETER: p["view"] = "magnetometer"; break;
+            case VIEW_PARTICLES:    p["view"] = "particles"; break;
+            case VIEW_SUBPACKETS:   p["view"] = "spectrometer"; break;
+            case VIEW_SUMMARY:      p["view"] = "summary"; break;
+            }
+
+            p["mag_overlay"] = mag_overlay;
+            p["mag_show_btotal"] = mag_show_btotal;
+            p["mag_show_bx"] = mag_show_bx;
+            p["mag_show_by"] = mag_show_by;
+            p["mag_show_bz"] = mag_show_bz;
+            p["mag_show_voltage"] = mag_show_voltage;
+            p["particle_overlay"] = particle_overlay;
+            p["particle_visible"] = particle_visible;
+            p["selected_subpacket_group"] = selected_subpacket_group;
+
+            return p;
         }
     } // namespace ggak
 } // namespace elektro_arktika

--- a/plugins/elektro_arktika_support/elektro_arktika/instruments/ggak/ggak_product_handler.cpp
+++ b/plugins/elektro_arktika_support/elektro_arktika/instruments/ggak/ggak_product_handler.cpp
@@ -1,0 +1,515 @@
+#include "ggak_product_handler.h"
+#include "core/style.h"
+#include "imgui/implot/implot.h"
+#include "logger.h"
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+namespace elektro_arktika
+{
+    namespace ggak
+    {
+        namespace
+        {
+            void insert_gap_markers(GGAKChannel &ch)
+            {
+                if (ch.timestamps.size() < 2)
+                    return;
+
+                std::vector<double> deltas;
+                deltas.reserve(ch.timestamps.size());
+                for (size_t i = 1; i < ch.timestamps.size(); i++)
+                {
+                    double dt = ch.timestamps[i] - ch.timestamps[i - 1];
+                    if (dt > 0.01)
+                        deltas.push_back(dt);
+                }
+                if (deltas.empty())
+                    return;
+
+                std::sort(deltas.begin(), deltas.end());
+                double cadence = deltas[deltas.size() / 2];
+                double gap_threshold = 1.5 * cadence;
+
+                std::vector<double> new_ts, new_vals;
+                new_ts.reserve(ch.timestamps.size() + ch.timestamps.size() / 8);
+                new_vals.reserve(new_ts.capacity());
+
+                new_ts.push_back(ch.timestamps[0]);
+                new_vals.push_back(ch.values[0]);
+
+                for (size_t i = 1; i < ch.timestamps.size(); i++)
+                {
+                    double dt = ch.timestamps[i] - ch.timestamps[i - 1];
+                    if (dt > gap_threshold)
+                    {
+                        double nan = std::numeric_limits<double>::quiet_NaN();
+                        new_ts.push_back(nan);
+                        new_vals.push_back(nan);
+                    }
+                    new_ts.push_back(ch.timestamps[i]);
+                    new_vals.push_back(ch.values[i]);
+                }
+
+                ch.timestamps = std::move(new_ts);
+                ch.values = std::move(new_vals);
+            }
+        } // anonymous namespace
+
+        GGAKProductHandler::GGAKProductHandler(std::shared_ptr<satdump::products::Product> p, bool dataset_mode)
+            : ProductHandler(p, dataset_mode)
+        {
+            handler_tree_icon = u8"\uf076";
+            ggak_product = dynamic_cast<GGAKProduct *>(ProductHandler::product.get());
+            if (!ggak_product)
+            {
+                logger->error("GGAKProductHandler: product is not a GGAKProduct");
+                return;
+            }
+            particle_visible.resize(ggak_product->particle_channels.size(), 1);
+
+            for (int i = 0; i < (int)ggak_product->subpacket_channels.size(); i++)
+            {
+                auto &ch = ggak_product->subpacket_channels[i];
+                std::string grp = ch.group.empty() ? ch.name : ch.group;
+                auto it = std::find_if(subpacket_group_info.begin(), subpacket_group_info.end(),
+                                       [&](const SubpacketGroupInfo &g) { return g.name == grp; });
+                if (it != subpacket_group_info.end())
+                    it->channel_indices.push_back(i);
+                else
+                    subpacket_group_info.push_back({grp, {i}});
+            }
+
+            for (int i = 0; i < (int)ggak_product->particle_channels.size(); i++)
+                particle_labels.push_back(ggak_product->particle_channels[i].name + "##ptcl_" + std::to_string(i));
+            for (int i = 0; i < (int)subpacket_group_info.size(); i++)
+                subpacket_rb_labels.push_back(subpacket_group_info[i].name + "##spkt_" + std::to_string(i));
+
+            for (auto &ch : ggak_product->mag_channels)
+                insert_gap_markers(ch);
+            for (auto &ch : ggak_product->particle_channels)
+                insert_gap_markers(ch);
+            for (auto &ch : ggak_product->subpacket_channels)
+                insert_gap_markers(ch);
+
+            tryApplyDefaultPreset();
+        }
+
+        GGAKProductHandler::~GGAKProductHandler() {}
+
+        void GGAKProductHandler::drawMenu()
+        {
+            if (ImGui::CollapsingHeader("View", ImGuiTreeNodeFlags_DefaultOpen))
+            {
+                if (ImGui::RadioButton("Magnetometer", current_view == VIEW_MAGNETOMETER))
+                    current_view = VIEW_MAGNETOMETER;
+                if (ImGui::RadioButton("Particles", current_view == VIEW_PARTICLES))
+                    current_view = VIEW_PARTICLES;
+                if (ImGui::RadioButton("Spectrometer", current_view == VIEW_SUBPACKETS))
+                    current_view = VIEW_SUBPACKETS;
+                if (ImGui::RadioButton("Summary", current_view == VIEW_SUMMARY))
+                    current_view = VIEW_SUMMARY;
+            }
+
+            ImGui::Spacing();
+
+            if (current_view == VIEW_MAGNETOMETER)
+            {
+                if (ImGui::CollapsingHeader("FM-VE Channels", ImGuiTreeNodeFlags_DefaultOpen))
+                {
+                    ImGui::Checkbox("Overlay all B##mag_overlay", &mag_overlay);
+                    ImGui::Separator();
+                    ImGui::Checkbox("|B| total##mag_bt", &mag_show_btotal);
+                    ImGui::Checkbox("Bx##mag_bx", &mag_show_bx);
+                    ImGui::Checkbox("By##mag_by", &mag_show_by);
+                    ImGui::Checkbox("Bz##mag_bz", &mag_show_bz);
+                    ImGui::Separator();
+                    ImGui::Checkbox("Voltage##mag_voltage", &mag_show_voltage);
+                }
+            }
+            else if (current_view == VIEW_PARTICLES)
+            {
+                if (ImGui::CollapsingHeader("GALS-VE Channels", ImGuiTreeNodeFlags_DefaultOpen))
+                {
+                    ImGui::Checkbox("Overlay##ptcl_overlay", &particle_overlay);
+                    ImGui::Separator();
+                    for (int i = 0; i < (int)ggak_product->particle_channels.size(); i++)
+                    {
+                        bool vis = particle_visible[i] != 0;
+                        if (ImGui::Checkbox(particle_labels[i].c_str(), &vis))
+                            particle_visible[i] = vis ? 1 : 0;
+                    }
+                }
+            }
+            else if (current_view == VIEW_SUBPACKETS)
+            {
+                if (ImGui::CollapsingHeader("Spectrometer##spectrometer_ch", ImGuiTreeNodeFlags_DefaultOpen))
+                {
+                    for (int i = 0; i < (int)subpacket_group_info.size(); i++)
+                    {
+                        if (ImGui::RadioButton(subpacket_rb_labels[i].c_str(), selected_subpacket_group == i))
+                            selected_subpacket_group = i;
+                    }
+                }
+            }
+
+        }
+
+        void GGAKProductHandler::drawContents(ImVec2 win_size)
+        {
+            switch (current_view)
+            {
+            case VIEW_MAGNETOMETER:
+                drawMagnetometerPlots(win_size);
+                break;
+            case VIEW_PARTICLES:
+                drawParticlePlots(win_size);
+                break;
+            case VIEW_SUBPACKETS:
+                drawSubpacketPlots(win_size);
+                break;
+            case VIEW_SUMMARY:
+                drawSummary(win_size);
+                break;
+            }
+        }
+
+        static int ggak_time_formatter_cb(double value, char *buff, int size, void *)
+        {
+            if (value < 0.0)
+                value = 0.0;
+            else if (value > 2e9)
+                value = 2e9;
+            int total_s = (int)value;
+            int d = total_s / 86400;
+            int h = (total_s % 86400) / 3600;
+            int m = (total_s % 3600) / 60;
+            int s = total_s % 60;
+            if (d > 0)
+                snprintf(buff, size, "D%d %02d:%02d", d, h, m);
+            else
+                snprintf(buff, size, "%02d:%02d:%02d", h, m, s);
+            return 0;
+        }
+
+        void GGAKProductHandler::drawChannelPlot(const GGAKChannel &ch, ImVec2 size, const char *y_label)
+        {
+            if (ch.values.empty())
+                return;
+
+            char title_buf[128];
+            snprintf(title_buf, sizeof(title_buf), "%s (%s)##plot_%p",
+                     ch.name.c_str(), ch.unit.c_str(), (const void *)&ch);
+            if (ImPlot::BeginPlot(title_buf, size))
+            {
+                ImPlot::SetupAxes("Elapsed", y_label ? y_label : ch.unit.c_str(),
+                                  ImPlotAxisFlags_AutoFit, ImPlotAxisFlags_AutoFit);
+                ImPlot::SetupAxisFormat(ImAxis_X1, ggak_time_formatter_cb);
+                ImPlot::PlotLine(ch.name.c_str(),
+                                 ch.timestamps.data(), ch.values.data(),
+                                 (int)ch.values.size());
+                ImPlot::EndPlot();
+            }
+        }
+
+        void GGAKProductHandler::drawMagnetometerPlots(ImVec2 win_size)
+        {
+            if (ggak_product->mag_channels.empty())
+            {
+                ImGui::TextColored(style::theme.orange, "No magnetometer data available.");
+                return;
+            }
+
+            bool *show_flags[] = {&mag_show_btotal, &mag_show_bx, &mag_show_by, &mag_show_bz};
+            int mag_field_count = std::min(4, (int)ggak_product->mag_channels.size());
+
+            int visible_count = 0;
+            for (int i = 0; i < mag_field_count; i++)
+                if (*show_flags[i])
+                    visible_count++;
+
+            bool has_voltage = mag_show_voltage && (int)ggak_product->mag_channels.size() > 4;
+
+            int aux_count = has_voltage ? 1 : 0;
+
+            if (mag_overlay)
+            {
+                float aux_h = aux_count > 0 ? win_size.y * 0.20f * aux_count : 0;
+                float main_h = win_size.y - aux_h;
+                float per_aux_h = aux_count > 0 ? aux_h / aux_count : 0;
+
+                if (ImPlot::BeginPlot("##FM-VE Magnetic Field", ImVec2(win_size.x, main_h)))
+                {
+                    ImPlot::SetupAxes("Elapsed", "nT", ImPlotAxisFlags_AutoFit, ImPlotAxisFlags_AutoFit);
+                    ImPlot::SetupAxisFormat(ImAxis_X1, ggak_time_formatter_cb);
+
+                    for (int i = 0; i < mag_field_count; i++)
+                    {
+                        if (!*show_flags[i])
+                            continue;
+                        auto &ch = ggak_product->mag_channels[i];
+                        if (ch.values.empty())
+                            continue;
+                        ImPlot::PlotLine(ch.name.c_str(),
+                                         ch.timestamps.data(), ch.values.data(),
+                                         (int)ch.values.size());
+                    }
+                    ImPlot::EndPlot();
+                }
+
+                if (has_voltage)
+                    drawChannelPlot(ggak_product->mag_channels[4], ImVec2(win_size.x, per_aux_h), "V");
+            }
+            else
+            {
+                int n_plots = visible_count + aux_count;
+                if (n_plots == 0)
+                    n_plots = 1;
+
+                float plot_h = win_size.y / n_plots;
+
+                for (int i = 0; i < mag_field_count; i++)
+                {
+                    if (!*show_flags[i])
+                        continue;
+                    drawChannelPlot(ggak_product->mag_channels[i], ImVec2(win_size.x, plot_h), "nT");
+                }
+
+                if (has_voltage)
+                    drawChannelPlot(ggak_product->mag_channels[4], ImVec2(win_size.x, plot_h), "V");
+            }
+        }
+
+        void GGAKProductHandler::drawParticlePlots(ImVec2 win_size)
+        {
+            if (ggak_product->particle_channels.empty())
+            {
+                ImGui::TextColored(style::theme.orange, "No particle data available.");
+                return;
+            }
+
+            int visible = 0;
+            for (int i = 0; i < (int)particle_visible.size(); i++)
+                if (particle_visible[i])
+                    visible++;
+
+            if (visible == 0)
+            {
+                ImGui::Text("Select at least one channel.");
+                return;
+            }
+
+            if (particle_overlay)
+            {
+                if (ImPlot::BeginPlot("##GALS-VE Particle Counts", ImVec2(win_size.x, win_size.y)))
+                {
+                    ImPlot::SetupAxes("Elapsed", "Counts",
+                                      ImPlotAxisFlags_AutoFit, ImPlotAxisFlags_AutoFit);
+                    ImPlot::SetupAxisFormat(ImAxis_X1, ggak_time_formatter_cb);
+
+                    for (int i = 0; i < (int)ggak_product->particle_channels.size(); i++)
+                    {
+                        if (!particle_visible[i])
+                            continue;
+                        auto &ch = ggak_product->particle_channels[i];
+                        if (ch.values.empty())
+                            continue;
+                        ImPlot::PlotLine(ch.name.c_str(),
+                                         ch.timestamps.data(), ch.values.data(),
+                                         (int)ch.values.size());
+                    }
+                    ImPlot::EndPlot();
+                }
+            }
+            else
+            {
+                float min_plot_h = ImGui::GetTextLineHeight() * 12;
+                float plot_h = std::max(min_plot_h, win_size.y / visible);
+                float total_h = plot_h * visible;
+
+                if (total_h > win_size.y)
+                    ImGui::BeginChild("##ptcl_scroll", win_size, false, ImGuiWindowFlags_NoBackground);
+
+                for (int i = 0; i < (int)ggak_product->particle_channels.size(); i++)
+                {
+                    if (!particle_visible[i])
+                        continue;
+                    drawChannelPlot(ggak_product->particle_channels[i],
+                                    ImVec2(win_size.x - 16, plot_h), "Counts");
+                }
+
+                if (total_h > win_size.y)
+                    ImGui::EndChild();
+            }
+        }
+
+        void GGAKProductHandler::drawSubpacketPlots(ImVec2 win_size)
+        {
+            if (subpacket_group_info.empty())
+            {
+                ImGui::TextColored(style::theme.orange, "No spectrometer data available.");
+                return;
+            }
+
+            if (selected_subpacket_group < 0 || selected_subpacket_group >= (int)subpacket_group_info.size())
+            {
+                ImGui::Text("Selected group has no data.");
+                return;
+            }
+
+            auto &grp = subpacket_group_info[selected_subpacket_group];
+            int n_channels = (int)grp.channel_indices.size();
+            if (n_channels == 0)
+            {
+                ImGui::Text("No data in this group.");
+                return;
+            }
+
+            float min_plot_h = ImGui::GetTextLineHeight() * 12;
+            float plot_h = std::max(min_plot_h, win_size.y / n_channels);
+            float total_h = plot_h * n_channels;
+
+            if (total_h > win_size.y)
+                ImGui::BeginChild("##spkt_scroll", win_size, false, ImGuiWindowFlags_NoBackground);
+
+            for (int idx : grp.channel_indices)
+            {
+                auto &ch = ggak_product->subpacket_channels[idx];
+                if (ch.values.empty())
+                    continue;
+                char sp_title[128];
+                snprintf(sp_title, sizeof(sp_title), "%s (%s)##subpkt_%d",
+                         ch.name.c_str(), ch.unit.c_str(), idx);
+                if (ImPlot::BeginPlot(sp_title, ImVec2(win_size.x - 16, plot_h)))
+                {
+                    ImPlot::SetupAxes("Elapsed", ch.unit.c_str(),
+                                      ImPlotAxisFlags_AutoFit, ImPlotAxisFlags_AutoFit);
+                    ImPlot::SetupAxisFormat(ImAxis_X1, ggak_time_formatter_cb);
+                    ImPlot::PlotLine(ch.name.c_str(),
+                                     ch.timestamps.data(), ch.values.data(),
+                                     (int)ch.values.size());
+                    ImPlot::EndPlot();
+                }
+            }
+
+            if (total_h > win_size.y)
+                ImGui::EndChild();
+        }
+
+        void GGAKProductHandler::drawSummary(ImVec2 win_size)
+        {
+            auto &s = ggak_product->stats;
+
+            ImGui::TextColored(style::theme.cyan, "GGAK Space Environment Monitor");
+            ImGui::Text("Generation: %s", s.generation.c_str());
+            ImGui::Spacing();
+
+            float checksum_ratio = (s.checksum_pass + s.checksum_fail) > 0
+                                       ? (float)s.checksum_pass / (s.checksum_pass + s.checksum_fail)
+                                       : 0;
+            ImGui::Text("Checksum: ");
+            ImGui::SameLine();
+            ImVec4 csum_col = checksum_ratio > 0.99f   ? (ImVec4)style::theme.green
+                              : checksum_ratio > 0.9f  ? (ImVec4)style::theme.yellow
+                                                       : (ImVec4)style::theme.red;
+            ImGui::TextColored(csum_col, "%d pass / %d fail (%.1f%%)",
+                               s.checksum_pass, s.checksum_fail, checksum_ratio * 100.0f);
+
+            if (!ggak_product->mag_channels.empty() && !ggak_product->mag_channels[0].values.empty())
+            {
+                auto &bt = ggak_product->mag_channels[0];
+                double last_bt = std::numeric_limits<double>::quiet_NaN();
+                for (int i = (int)bt.values.size() - 1; i >= 0; i--)
+                {
+                    if (!std::isnan(bt.values[i]))
+                    {
+                        last_bt = bt.values[i];
+                        break;
+                    }
+                }
+                if (!std::isnan(last_bt))
+                {
+                    double dev = std::abs(last_bt - 103.0);
+                    int level = dev < 5.0 ? 1 : dev < 20.0 ? 2 : dev < 50.0 ? 3 : dev < 100.0 ? 4 : 5;
+                    const char *labels[] = {"Normal", "Slight", "Moderate", "Strong", "Extreme"};
+                    ImVec4 colors[] = {
+                        (ImVec4)style::theme.green, (ImVec4)style::theme.light_green,
+                        (ImVec4)style::theme.yellow, (ImVec4)style::theme.orange,
+                        (ImVec4)style::theme.red};
+                    ImGui::Spacing();
+                    ImGui::Text("Geomagnetic Activity:");
+                    ImGui::SameLine();
+                    ImGui::TextColored(colors[level - 1], "Level %d - %s", level, labels[level - 1]);
+                    ImGui::Text("|B| = %.1f nT (baseline 103 nT, dev %.1f nT)", last_bt, dev);
+                }
+            }
+
+            ImGui::Spacing();
+            ImGui::Separator();
+            ImGui::Spacing();
+
+            // Channel overview table
+            ImGui::TextColored(style::theme.cyan, "Channel Overview");
+            ImGui::Spacing();
+
+            if (ImGui::BeginTable("##ggak_channels", 5,
+                                  ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg |
+                                      ImGuiTableFlags_Resizable | ImGuiTableFlags_ScrollY,
+                                  ImVec2(0, win_size.y * 0.5f)))
+            {
+                ImGui::TableSetupColumn("Group");
+                ImGui::TableSetupColumn("Channel");
+                ImGui::TableSetupColumn("Unit");
+                ImGui::TableSetupColumn("Samples");
+                ImGui::TableSetupColumn("Range");
+                ImGui::TableHeadersRow();
+                ImGui::TableSetupScrollFreeze(0, 1);
+
+                auto draw_channel_rows = [](const char *group, const std::vector<GGAKChannel> &channels) {
+                    for (auto &ch : channels)
+                    {
+                        ImGui::TableNextRow();
+                        ImGui::TableSetColumnIndex(0);
+                        ImGui::TextUnformatted(group);
+                        ImGui::TableSetColumnIndex(1);
+                        ImGui::TextUnformatted(ch.name.c_str());
+                        ImGui::TableSetColumnIndex(2);
+                        ImGui::TextUnformatted(ch.unit.c_str());
+                        ImGui::TableSetColumnIndex(3);
+                        ImGui::Text("%d", ch.cached_valid_count);
+                        ImGui::TableSetColumnIndex(4);
+                        if (ch.cached_valid_count > 0)
+                            ImGui::Text("%.2f .. %.2f", ch.cached_min, ch.cached_max);
+                        else
+                            ImGui::TextDisabled("--");
+                    }
+                };
+
+                draw_channel_rows("FM-VE", ggak_product->mag_channels);
+                draw_channel_rows("GALS-VE + SKIF-VE MIP", ggak_product->particle_channels);
+
+                for (auto &ch : ggak_product->subpacket_channels)
+                {
+                    ImGui::TableNextRow();
+                    ImGui::TableSetColumnIndex(0);
+                    ImGui::TextUnformatted(ch.group.empty() ? ch.name.c_str() : ch.group.c_str());
+                    ImGui::TableSetColumnIndex(1);
+                    ImGui::TextUnformatted(ch.name.c_str());
+                    ImGui::TableSetColumnIndex(2);
+                    ImGui::TextUnformatted(ch.unit.c_str());
+                    ImGui::TableSetColumnIndex(3);
+                    ImGui::Text("%d", ch.cached_valid_count);
+                    ImGui::TableSetColumnIndex(4);
+                    if (ch.cached_valid_count > 0)
+                        ImGui::Text("%.2f .. %.2f", ch.cached_min, ch.cached_max);
+                    else
+                        ImGui::TextDisabled("--");
+                }
+
+                ImGui::EndTable();
+            }
+
+        }
+    } // namespace ggak
+} // namespace elektro_arktika

--- a/plugins/elektro_arktika_support/elektro_arktika/instruments/ggak/ggak_product_handler.h
+++ b/plugins/elektro_arktika_support/elektro_arktika/instruments/ggak/ggak_product_handler.h
@@ -1,5 +1,10 @@
 #pragma once
 
+/**
+ * @file ggak_product_handler.h
+ * @brief UI handler for GGAK space environment products in the SatDump explorer.
+ */
+
 #include "ggak_product.h"
 #include "handlers/product/product_handler.h"
 
@@ -13,7 +18,21 @@ namespace elektro_arktika
             GGAKProductHandler(std::shared_ptr<satdump::products::Product> p, bool dataset_mode = false);
             ~GGAKProductHandler();
 
+            void do_process() override {}
+            void drawMenu() override;
+            void drawContents(ImVec2 win_size) override;
+
+            void setConfig(nlohmann::json p) override;
+            nlohmann::json getConfig() override;
+
+            std::string getID() override { return "ggak_product_handler"; }
+
+        private:
             GGAKProduct *ggak_product;
+
+            std::vector<GGAKChannel> plot_mag_channels;
+            std::vector<GGAKChannel> plot_particle_channels;
+            std::vector<GGAKChannel> plot_subpacket_channels;
 
             enum ViewMode
             {
@@ -44,22 +63,14 @@ namespace elektro_arktika
             };
             std::vector<SubpacketGroupInfo> subpacket_group_info;
 
-            void do_process() override {}
-            void drawMenu() override;
-            void drawContents(ImVec2 win_size) override;
+            int plot_id_counter = 0;
 
-            std::string getID() override { return "ggak_product_handler"; }
-
-        private:
             void drawMagnetometerPlots(ImVec2 win_size);
             void drawParticlePlots(ImVec2 win_size);
             void drawSubpacketPlots(ImVec2 win_size);
             void drawSummary(ImVec2 win_size);
 
-            void drawChannelPlot(const GGAKChannel &ch, ImVec2 size, const char *y_label = nullptr);
-
-            std::vector<std::string> particle_labels;
-            std::vector<std::string> subpacket_rb_labels;
+            void drawChannelPlot(const GGAKChannel &ch, ImVec2 size, int plot_idx, const char *y_label = nullptr);
         };
     } // namespace ggak
 } // namespace elektro_arktika

--- a/plugins/elektro_arktika_support/elektro_arktika/instruments/ggak/ggak_product_handler.h
+++ b/plugins/elektro_arktika_support/elektro_arktika/instruments/ggak/ggak_product_handler.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "ggak_product.h"
+#include "handlers/product/product_handler.h"
+
+namespace elektro_arktika
+{
+    namespace ggak
+    {
+        class GGAKProductHandler : public satdump::handlers::ProductHandler
+        {
+        public:
+            GGAKProductHandler(std::shared_ptr<satdump::products::Product> p, bool dataset_mode = false);
+            ~GGAKProductHandler();
+
+            GGAKProduct *ggak_product;
+
+            enum ViewMode
+            {
+                VIEW_MAGNETOMETER,
+                VIEW_PARTICLES,
+                VIEW_SUBPACKETS,
+                VIEW_SUMMARY,
+            };
+
+            ViewMode current_view = VIEW_MAGNETOMETER;
+
+            bool mag_overlay = true;
+            bool mag_show_btotal = true;
+            bool mag_show_bx = true;
+            bool mag_show_by = true;
+            bool mag_show_bz = true;
+            bool mag_show_voltage = false;
+
+            bool particle_overlay = true;
+            std::vector<int> particle_visible;
+
+            int selected_subpacket_group = 0;
+
+            struct SubpacketGroupInfo
+            {
+                std::string name;
+                std::vector<int> channel_indices;
+            };
+            std::vector<SubpacketGroupInfo> subpacket_group_info;
+
+            void do_process() override {}
+            void drawMenu() override;
+            void drawContents(ImVec2 win_size) override;
+
+            std::string getID() override { return "ggak_product_handler"; }
+
+        private:
+            void drawMagnetometerPlots(ImVec2 win_size);
+            void drawParticlePlots(ImVec2 win_size);
+            void drawSubpacketPlots(ImVec2 win_size);
+            void drawSummary(ImVec2 win_size);
+
+            void drawChannelPlot(const GGAKChannel &ch, ImVec2 size, const char *y_label = nullptr);
+
+            std::vector<std::string> particle_labels;
+            std::vector<std::string> subpacket_rb_labels;
+        };
+    } // namespace ggak
+} // namespace elektro_arktika

--- a/plugins/elektro_arktika_support/elektro_arktika/instruments/ggak/ggak_reader.cpp
+++ b/plugins/elektro_arktika_support/elektro_arktika/instruments/ggak/ggak_reader.cpp
@@ -1,0 +1,303 @@
+#include "ggak_reader.h"
+#include "logger.h"
+
+#include <algorithm>
+
+namespace elektro_arktika
+{
+    namespace ggak
+    {
+        void GGAKReader::pushFrame(const uint8_t *cadu)
+        {
+            total_frames++;
+
+            bool csum_ok = validate_checksum(cadu);
+            if (csum_ok)
+                checksum_pass++;
+            else
+                checksum_fail++;
+
+            GGAKFrameHeader hdr = parse_header(cadu);
+            frame_counts[hdr.frame_type]++;
+
+            if (is_fill_frame(hdr.frame_type))
+            {
+                fill_frames++;
+                return;
+            }
+
+            if (!profile_detected)
+            {
+                observed_source_id = hdr.source_id;
+                if (hdr.source_id == 0x30)
+                    sat_profile = PROFILE_BND_E;
+                else if (hdr.source_id == 0x31 || hdr.source_id == 0x33)
+                    sat_profile = PROFILE_BND_VE;
+                else
+                {
+                    logger->warn("Unknown GGAK source_id 0x%02X, assuming BND-VE", hdr.source_id);
+                    sat_profile = PROFILE_BND_VE;
+                }
+                profile_detected = true;
+                logger->info("Detected: %s (source_id=0x%02X)", sat_profile.name, hdr.source_id);
+            }
+
+            if (prev_coarse_time >= 0 && (prev_coarse_time - static_cast<int>(hdr.coarse_time)) > 50000)
+                coarse_time_offset += 65536;
+            prev_coarse_time = hdr.coarse_time;
+
+            master_counters.push_back(hdr.master_counter);
+            channel_counters[hdr.frame_type].push_back(hdr.channel_counter);
+
+            uint32_t ct = hdr.coarse_time + coarse_time_offset;
+            uint8_t ft = hdr.fine_time;
+            uint8_t data_fill = sat_profile.data_fill_byte;
+            const uint8_t *payload = cadu + PAYLOAD_OFFSET;
+
+            switch (hdr.frame_type)
+            {
+            case 0x70:
+                decode_magnetometer_frame(payload, PAYLOAD_SIZE, ct, ft, data_fill, csum_ok, mag_readings);
+                break;
+            case 0x40:
+                decode_particle_frame(payload, PAYLOAD_SIZE, ct, ft, data_fill, csum_ok, particle_readings);
+                break;
+            case 0x20:
+                decode_subpacket_69(payload, PAYLOAD_SIZE, 0x90, ct, ft, data_fill, csum_ok, subpackets_20);
+                break;
+            case 0x30:
+                decode_subpacket_69(payload, PAYLOAD_SIZE, 0x98, ct, ft, data_fill, csum_ok, subpackets_30);
+                break;
+            case 0x50:
+                decode_spectral(payload, PAYLOAD_SIZE, SPECTRAL_CAL_MARKER, ct, ft, data_fill, csum_ok, subpackets_5c, spectral_buffer);
+                break;
+            case 0x5C:
+                decode_spectral(payload, PAYLOAD_SIZE, SPECTRAL_MARKER, ct, ft, data_fill, csum_ok, subpackets_5c, spectral_buffer);
+                break;
+            case 0x00:
+                decode_housekeeping_12(payload, PAYLOAD_SIZE, 0x80, ct, ft, data_fill, csum_ok, subpackets_00);
+                break;
+            case 0x10:
+                decode_housekeeping_12(payload, PAYLOAD_SIZE, 0x88, ct, ft, data_fill, csum_ok, subpackets_10);
+                break;
+            default:
+                break;
+            }
+        }
+
+        void GGAKReader::sortAll()
+        {
+            auto by_time = [](const auto &a, const auto &b) {
+                return a.elapsed_seconds() < b.elapsed_seconds();
+            };
+            std::sort(mag_readings.begin(), mag_readings.end(), by_time);
+            std::sort(particle_readings.begin(), particle_readings.end(), by_time);
+            std::sort(subpackets_20.begin(), subpackets_20.end(), by_time);
+            std::sort(subpackets_30.begin(), subpackets_30.end(), by_time);
+            std::sort(subpackets_5c.begin(), subpackets_5c.end(), by_time);
+            std::sort(subpackets_00.begin(), subpackets_00.end(), by_time);
+            std::sort(subpackets_10.begin(), subpackets_10.end(), by_time);
+        }
+
+        void GGAKReader::decode_magnetometer_frame(const uint8_t *payload, size_t len,
+                                                   uint32_t ct, uint8_t ft, uint8_t data_fill,
+                                                   bool csum_ok, std::vector<MagReading> &out)
+        {
+            for (int i = 0; i < MAG_READINGS_PER_FRAME; i++)
+            {
+                size_t off = i * MAG_READING_LEN;
+                if (off + MAG_READING_LEN > len)
+                    break;
+                const uint8_t *r = payload + off;
+
+                if (is_fill_data(r, MAG_READING_LEN, data_fill))
+                    continue;
+
+                MagReading rd{};
+                rd.mag_total_raw = read_be16(r + 0);
+                rd.mag_x_raw = read_be16(r + 2);
+                rd.mag_y_raw = read_be16(r + 4);
+                rd.mag_z_raw = read_be16(r + 6);
+                rd.voltage_raw = read_be16(r + 8);
+                rd.met_counter = read_be16(r + 10);
+                rd.status_flag = r[12];
+                rd.mode = r[13];
+                rd.mode2 = r[14];
+                rd.coarse_time = ct;
+                rd.fine_time = ft;
+                rd.checksum_ok = csum_ok;
+                out.push_back(rd);
+            }
+        }
+
+        void GGAKReader::decode_particle_frame(const uint8_t *payload, size_t len,
+                                               uint32_t ct, uint8_t ft, uint8_t data_fill,
+                                               bool csum_ok, std::vector<ParticleReading> &out)
+        {
+            for (int i = 0; i < PARTICLE_READINGS_PER_FRAME; i++)
+            {
+                size_t off = i * PARTICLE_READING_LEN;
+                if (off + PARTICLE_READING_LEN > len)
+                    break;
+                const uint8_t *r = payload + off;
+
+                if (r[0] != PARTICLE_MARKER_A0 && r[0] != PARTICLE_MARKER_A1)
+                    continue;
+                if (is_fill_data(r, PARTICLE_READING_LEN, data_fill))
+                    continue;
+
+                ParticleReading rd{};
+                rd.sub_type = r[1];
+                rd.counter = r[2];
+                for (int ch = 0; ch < PARTICLE_CHANNELS; ch++)
+                    rd.channels[ch] = read_be16(r + 3 + ch * 2);
+                rd.coarse_time = ct;
+                rd.fine_time = ft;
+                rd.checksum_ok = csum_ok;
+                out.push_back(rd);
+            }
+        }
+
+        void GGAKReader::decode_subpacket_69(const uint8_t *payload, size_t len,
+                                             uint8_t marker_hi,
+                                             uint32_t ct, uint8_t ft, uint8_t data_fill,
+                                             bool csum_ok, std::vector<SubPacket> &out)
+        {
+            for (int p = 0; p < 3; p++)
+            {
+                if (SKIF_ESA_OFFSETS[p] + SKIF_ESA_PKT_SIZE > len)
+                    break;
+                const uint8_t *r = payload + SKIF_ESA_OFFSETS[p];
+
+                if (r[0] != marker_hi)
+                    continue;
+                if (is_fill_data(r, SKIF_ESA_PKT_SIZE, data_fill))
+                    continue;
+
+                SubPacket pkt{};
+                pkt.seq = r[2];
+                pkt.coarse_time = ct;
+                pkt.fine_time = ft;
+                pkt.checksum_ok = csum_ok;
+
+                const uint8_t *data = r + 3;
+                for (int ch = 0; ch + 1 < SKIF_ESA_DATA_LEN; ch += 2)
+                    pkt.channels.push_back(static_cast<int32_t>(read_be16(data + ch)));
+
+                out.push_back(std::move(pkt));
+            }
+        }
+
+        void GGAKReader::decode_housekeeping_12(const uint8_t *payload, size_t len,
+                                                uint8_t marker_byte,
+                                                uint32_t ct, uint8_t ft, uint8_t data_fill,
+                                                bool csum_ok, std::vector<SubPacket> &out)
+        {
+            size_t off = 0;
+
+            while (off + HK_BLK_SIZE <= len)
+            {
+                const uint8_t *r = payload + off;
+
+                if (r[0] != marker_byte)
+                {
+                    off++;
+                    continue;
+                }
+                if (is_fill_data(r, HK_BLK_SIZE, data_fill))
+                {
+                    off += HK_BLK_SIZE;
+                    continue;
+                }
+
+                SubPacket pkt{};
+                pkt.seq = r[1];
+                pkt.coarse_time = ct;
+                pkt.fine_time = ft;
+                pkt.checksum_ok = csum_ok;
+
+                for (int ch = 0; ch < HK_CHANNELS; ch++)
+                    pkt.channels.push_back(static_cast<int32_t>(read_be16(r + 2 + ch * 2)));
+
+                out.push_back(std::move(pkt));
+                off += HK_BLK_SIZE;
+            }
+        }
+
+        void GGAKReader::decode_spectral(const uint8_t *payload, size_t len,
+                                         uint8_t marker,
+                                         uint32_t ct, uint8_t ft, uint8_t data_fill,
+                                         bool csum_ok, std::vector<SubPacket> &out,
+                                         std::vector<uint8_t> &buffer)
+        {
+            std::vector<uint8_t> data_to_process;
+            data_to_process.reserve(buffer.size() + len);
+            data_to_process.insert(data_to_process.end(), buffer.begin(), buffer.end());
+            data_to_process.insert(data_to_process.end(), payload, payload + len);
+            buffer.clear();
+
+            size_t off = 0;
+            size_t total_len = data_to_process.size();
+
+            while (off < total_len)
+            {
+                if (data_to_process[off] != marker)
+                {
+                    off++;
+                    continue;
+                }
+
+                if (off + SPECTRAL_MIN_PACKET_BYTES > total_len)
+                {
+                    buffer.insert(buffer.end(), data_to_process.begin() + off, data_to_process.end());
+                    break;
+                }
+
+                size_t next = off + SPECTRAL_MIN_PACKET_BYTES;
+                while (next < total_len && data_to_process[next] != marker)
+                    next++;
+
+                size_t end = next;
+
+                if (next == total_len)
+                {
+                    size_t pkt_len = end - off;
+                    size_t check_len = pkt_len;
+                    while (check_len > 3 && data_to_process[off + check_len - 1] == data_fill)
+                        check_len--;
+
+                    if (check_len == pkt_len)
+                    {
+                        buffer.insert(buffer.end(), data_to_process.begin() + off, data_to_process.end());
+                        break;
+                    }
+                }
+
+                size_t pkt_len = end - off;
+                while (pkt_len > 3 && data_to_process[off + pkt_len - 1] == data_fill)
+                    pkt_len--;
+
+                size_t data_len = pkt_len - 3;
+                if (pkt_len >= static_cast<size_t>(SPECTRAL_MIN_PACKET_BYTES) && (data_len % 2) == 0)
+                {
+                    SubPacket pkt{};
+                    pkt.seq = data_to_process[off + 2];
+                    pkt.coarse_time = ct;
+                    pkt.fine_time = ft;
+                    pkt.checksum_ok = csum_ok;
+
+                    const uint8_t *data = data_to_process.data() + off + 3;
+                    for (size_t ch = 0; ch + 1 < data_len; ch += 2)
+                        pkt.channels.push_back(static_cast<int32_t>(read_be16s(data + ch)));
+
+                    out.push_back(std::move(pkt));
+                    off = end;
+                }
+                else
+                {
+                    off++;
+                }
+            }
+        }
+    } // namespace ggak
+} // namespace elektro_arktika

--- a/plugins/elektro_arktika_support/elektro_arktika/instruments/ggak/ggak_reader.h
+++ b/plugins/elektro_arktika_support/elektro_arktika/instruments/ggak/ggak_reader.h
@@ -1,0 +1,81 @@
+#pragma once
+
+/**
+ * @file ggak_reader.h
+ * @brief GGAK frame reader/decoder.
+ *
+ * Accumulates decoded readings from GGAK-VE / GGAK-E 224-byte CADUs.
+ * Follows the SatDump reader pattern (cf. MSUVISReader, MSUIRReader).
+ */
+
+#include "ggak_types.h"
+
+#include <map>
+#include <vector>
+
+namespace elektro_arktika
+{
+    namespace ggak
+    {
+        class GGAKReader
+        {
+        public:
+            void pushFrame(const uint8_t *cadu);
+
+            // Decoded readings
+            std::vector<MagReading> mag_readings;
+            std::vector<ParticleReading> particle_readings;
+            std::vector<SubPacket> subpackets_20; // SKIF-VE/V ESA
+            std::vector<SubPacket> subpackets_30; // SKIF-VE/G ESA
+            std::vector<SubPacket> subpackets_5c; // SKL-E spectral
+            std::vector<SubPacket> subpackets_00; // Housekeeping-A
+            std::vector<SubPacket> subpackets_10; // SKIF-VE SER summary
+
+            // Frame accounting
+            int total_frames = 0;
+            int fill_frames = 0;
+            int checksum_pass = 0;
+            int checksum_fail = 0;
+            std::map<uint8_t, int> frame_counts;
+            std::vector<uint16_t> master_counters;
+            std::map<uint8_t, std::vector<uint16_t>> channel_counters;
+
+            // Detected satellite profile
+            SatelliteProfile sat_profile = PROFILE_BND_VE;
+            bool profile_detected = false;
+            uint8_t observed_source_id = 0;
+
+            // Sort all accumulated readings by elapsed time
+            void sortAll();
+
+        private:
+            int prev_coarse_time = -1;
+            uint32_t coarse_time_offset = 0;
+            std::vector<uint8_t> spectral_buffer;
+
+            static void decode_magnetometer_frame(const uint8_t *payload, size_t len,
+                                                  uint32_t ct, uint8_t ft, uint8_t data_fill,
+                                                  bool csum_ok, std::vector<MagReading> &out);
+
+            static void decode_particle_frame(const uint8_t *payload, size_t len,
+                                              uint32_t ct, uint8_t ft, uint8_t data_fill,
+                                              bool csum_ok, std::vector<ParticleReading> &out);
+
+            static void decode_subpacket_69(const uint8_t *payload, size_t len,
+                                            uint8_t marker_hi,
+                                            uint32_t ct, uint8_t ft, uint8_t data_fill,
+                                            bool csum_ok, std::vector<SubPacket> &out);
+
+            static void decode_housekeeping_12(const uint8_t *payload, size_t len,
+                                               uint8_t marker_byte,
+                                               uint32_t ct, uint8_t ft, uint8_t data_fill,
+                                               bool csum_ok, std::vector<SubPacket> &out);
+
+            static void decode_spectral(const uint8_t *payload, size_t len,
+                                        uint8_t marker,
+                                        uint32_t ct, uint8_t ft, uint8_t data_fill,
+                                        bool csum_ok, std::vector<SubPacket> &out,
+                                        std::vector<uint8_t> &buffer);
+        };
+    } // namespace ggak
+} // namespace elektro_arktika

--- a/plugins/elektro_arktika_support/elektro_arktika/instruments/ggak/ggak_types.h
+++ b/plugins/elektro_arktika_support/elektro_arktika/instruments/ggak/ggak_types.h
@@ -1,14 +1,27 @@
 #pragma once
 
-// GGAK-VE / GGAK-E space environment telemetry types.
-// 224-byte CADUs: 4B ASM + 9B proprietary header + 209B payload + 2B checksum.
-// NOT standard CCSDS AOS/TM.
+/**
+ * @file ggak_types.h
+ * @brief GGAK-VE / GGAK-E space environment telemetry protocol types and constants.
+ *
+ * Frame structure: 224-byte CADUs with 4B ASM + 9B proprietary header + 209B payload + 2B checksum.
+ * NOT standard CCSDS AOS/TM. The 9-byte header contains frame_type, master/channel counters,
+ * source_id (0x30 BND-E / 0x31 BND-VE), and a coarse+fine timestamp pair.
+ *
+ * Instruments carried:
+ *   - FM-VE: Fluxgate magnetometer (0x70 frames, 13 readings/frame)
+ *   - GALS-VE: Particle telescope, 7 channels (0x40 frames)
+ *   - SKIF-VE: Electrostatic analyzer + MIP channel (0x20/0x30/0x40 frames)
+ *   - SKL-E: Spectrometer (0x5C/0x50 frames)
+ *   - Housekeeping/ISP-2M (0x00/0x10 frames)
+ */
 
 #include <array>
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
 #include <vector>
+#include "common/big_endian.h"
 
 namespace elektro_arktika
 {
@@ -21,12 +34,10 @@ namespace elektro_arktika
         constexpr size_t CHECKSUM_SIZE = 2;
         constexpr size_t PAYLOAD_OFFSET = ASM_SIZE + HEADER_SIZE; // byte 13
 
-        constexpr uint8_t FILL_BYTE = 0x33;
         constexpr uint8_t FILL_BYTE_N2 = 0xAA;
-        constexpr uint8_t FILL_BYTE_N5 = 0x33;
 
-        constexpr int SYMBOL_RATE = 5000;
         constexpr int FINE_TIME_STEPS = 256;
+        constexpr int COUNTER_GAP_WRAP_THRESHOLD = 60000;
         constexpr double TIME_TICK_SECONDS = 254.84;
         constexpr double FINE_TIME_STEP = TIME_TICK_SECONDS / FINE_TIME_STEPS;
 
@@ -57,10 +68,17 @@ namespace elektro_arktika
             0.05, 0.25, 0.45, 0.80, 1.30, 2.50,
             4.50, 7.50, 10.00, 13.00, 16.00, 20.00,
         };
+        constexpr int SKIF_ESA_PKT_SIZE = 69;
+        constexpr int SKIF_ESA_DATA_LEN = 65;
+        constexpr std::array<size_t, 3> SKIF_ESA_OFFSETS = {0, 69, 138};
+
+        // Housekeeping
+        constexpr int HK_BLK_SIZE = 12;
+        constexpr int HK_CHANNELS = 5;
 
         inline uint16_t read_be16(const uint8_t *p)
         {
-            return (static_cast<uint16_t>(p[0]) << 8) | p[1];
+            return *reinterpret_cast<const be_uint16_t *>(p);
         }
 
         inline int16_t read_be16s(const uint8_t *p)
@@ -81,7 +99,7 @@ namespace elektro_arktika
             return true;
         }
 
-        inline bool validate_checksum(const uint8_t *cadu)
+        [[nodiscard]] inline bool validate_checksum(const uint8_t *cadu)
         {
             uint32_t sum = 0;
             for (size_t i = 0; i < CADU_SIZE - CHECKSUM_SIZE; i++)
@@ -150,9 +168,7 @@ namespace elektro_arktika
             "GGAK-E (Elektro-L N1/N2)", "BND-E", 0x30, FILL_BYTE_N2, 0x50, SPECTRAL_CAL_MARKER};
 
         constexpr SatelliteProfile PROFILE_BND_VE = {
-            "GGAK-VE (Elektro-L N3+)", "BND-VE", 0x31, FILL_BYTE_N5, 0x5C, SPECTRAL_MARKER};
-
-        constexpr uint8_t DEFAULT_SOURCE_ID = 0x31;
+            "GGAK-VE (Elektro-L N3+, Arktika-M)", "BND-VE", 0x31, 0x33, 0x5C, SPECTRAL_MARKER};
 
         // 9-byte proprietary header (bytes 4-12): frame_type, master/channel counter,
         // source_id (0x30/0x31/0x33), coarse_time (uint16 BE), fine_time (0-255)
@@ -181,6 +197,35 @@ namespace elektro_arktika
                 read_be16(cadu + 10),
                 cadu[12],
             };
+        }
+
+        // Geomagnetic activity classification based on deviation from quiet-time
+        // baseline |B| at GEO. Thresholds derived from GOES Hp index ranges:
+        //   Level 1 (Normal): <5 nT deviation
+        //   Level 2 (Slight): 5-20 nT
+        //   Level 3 (Moderate): 20-50 nT (minor storm onset)
+        //   Level 4 (Strong): 50-100 nT
+        //   Level 5 (Extreme): >100 nT (severe storm)
+        inline int geomagnetic_activity_level(double bt_nT)
+        {
+            double dev = std::abs(bt_nT - MAG_BASELINE_NT);
+            if (dev < 5.0) return 1;
+            if (dev < 20.0) return 2;
+            if (dev < 50.0) return 3;
+            if (dev < 100.0) return 4;
+            return 5;
+        }
+
+        inline const char *geomagnetic_activity_label(int level)
+        {
+            switch (level)
+            {
+            case 1: return "Normal";
+            case 2: return "Slight";
+            case 3: return "Moderate";
+            case 4: return "Strong";
+            default: return "Extreme";
+            }
         }
 
         // FM-VE magnetometer reading: 15 bytes per sample, up to 13 per 0x70 frame
@@ -220,24 +265,12 @@ namespace elektro_arktika
 
             int activity_level() const
             {
-                double dev = std::abs(mag_total_nt() - MAG_BASELINE_NT);
-                if (dev < 5.0) return 1;
-                if (dev < 20.0) return 2;
-                if (dev < 50.0) return 3;
-                if (dev < 100.0) return 4;
-                return 5;
+                return geomagnetic_activity_level(mag_total_nt());
             }
 
             const char *activity_label() const
             {
-                switch (activity_level())
-                {
-                case 1: return "Normal";
-                case 2: return "Slight";
-                case 3: return "Moderate";
-                case 4: return "Strong";
-                default: return "Extreme";
-                }
+                return geomagnetic_activity_label(activity_level());
             }
         };
 

--- a/plugins/elektro_arktika_support/elektro_arktika/instruments/ggak/ggak_types.h
+++ b/plugins/elektro_arktika_support/elektro_arktika/instruments/ggak/ggak_types.h
@@ -1,0 +1,283 @@
+#pragma once
+
+// GGAK-VE / GGAK-E space environment telemetry types.
+// 224-byte CADUs: 4B ASM + 9B proprietary header + 209B payload + 2B checksum.
+// NOT standard CCSDS AOS/TM.
+
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+namespace elektro_arktika
+{
+    namespace ggak
+    {
+        constexpr size_t ASM_SIZE = 4;
+        constexpr size_t CADU_SIZE = 224;
+        constexpr size_t HEADER_SIZE = 9;
+        constexpr size_t PAYLOAD_SIZE = 209;
+        constexpr size_t CHECKSUM_SIZE = 2;
+        constexpr size_t PAYLOAD_OFFSET = ASM_SIZE + HEADER_SIZE; // byte 13
+
+        constexpr uint8_t FILL_BYTE = 0x33;
+        constexpr uint8_t FILL_BYTE_N2 = 0xAA;
+        constexpr uint8_t FILL_BYTE_N5 = 0x33;
+
+        constexpr int SYMBOL_RATE = 5000;
+        constexpr int FINE_TIME_STEPS = 256;
+        constexpr double TIME_TICK_SECONDS = 254.84;
+        constexpr double FINE_TIME_STEP = TIME_TICK_SECONDS / FINE_TIME_STEPS;
+
+        // FM-VE magnetometer: ADC offset 2339, scale 2.359 nT/count (IGRF at GEO)
+        constexpr int MAG_READING_LEN = 15;
+        constexpr int MAG_READINGS_PER_FRAME = 13;
+        constexpr int MAG_ADC_OFFSET = 2339;
+        constexpr double MAG_SCALE = 2.359;
+        constexpr double MAG_BASELINE_NT = 103.0;
+        constexpr double VOLTAGE_DIVISOR = 125.0;
+        constexpr int MAG_RAW_SANITY = 10000;
+
+        // Particle detectors (0x40 frames): GALS-VE ch1-7 + SKIF-VE MIP ch8
+        constexpr uint8_t PARTICLE_MARKER_A0 = 0xA0;
+        constexpr uint8_t PARTICLE_MARKER_A1 = 0xA1;
+        constexpr int PARTICLE_READING_LEN = 19;
+        constexpr int PARTICLE_CHANNELS = 8;
+        constexpr int PARTICLE_READINGS_PER_FRAME = 11;
+
+        // SKL-E spectral (0x5C / 0x50 frames)
+        constexpr uint8_t SPECTRAL_MARKER = 0xAC;
+        constexpr uint8_t SPECTRAL_CAL_MARKER = 0xA8;
+        constexpr int SPECTRAL_MIN_PACKET_BYTES = 10;
+
+        // SKIF-VE ESA energy sweep: 12 levels, 1 s/step (0x20 = V, 0x30 = G)
+        constexpr int SKIF_VE_ESA_STEPS = 12;
+        constexpr std::array<double, 12> SKIF_VE_ESA_ENERGIES_KEV = {
+            0.05, 0.25, 0.45, 0.80, 1.30, 2.50,
+            4.50, 7.50, 10.00, 13.00, 16.00, 20.00,
+        };
+
+        inline uint16_t read_be16(const uint8_t *p)
+        {
+            return (static_cast<uint16_t>(p[0]) << 8) | p[1];
+        }
+
+        inline int16_t read_be16s(const uint8_t *p)
+        {
+            return static_cast<int16_t>(read_be16(p));
+        }
+
+        inline bool is_fill_frame(uint8_t frame_type)
+        {
+            return frame_type == 0x77 || frame_type == 0x88;
+        }
+
+        inline bool is_fill_data(const uint8_t *data, size_t len, uint8_t fill_byte)
+        {
+            for (size_t i = 0; i < len; i++)
+                if (data[i] != fill_byte)
+                    return false;
+            return true;
+        }
+
+        inline bool validate_checksum(const uint8_t *cadu)
+        {
+            uint32_t sum = 0;
+            for (size_t i = 0; i < CADU_SIZE - CHECKSUM_SIZE; i++)
+                sum += cadu[i];
+            return (sum & 0xFFFF) == read_be16(cadu + CADU_SIZE - CHECKSUM_SIZE);
+        }
+
+        inline void format_timestamp(double elapsed_s, char *buf, size_t buf_size)
+        {
+            if (elapsed_s < 0.0)
+                elapsed_s = 0.0;
+            int days = static_cast<int>(elapsed_s / 86400.0);
+            double rem = elapsed_s - days * 86400.0;
+            int hours = static_cast<int>(rem / 3600.0);
+            int mins = static_cast<int>(std::fmod(rem, 3600.0) / 60.0);
+            int secs = static_cast<int>(std::fmod(rem, 60.0));
+            std::snprintf(buf, buf_size, "D%03d %02d:%02d:%02d", days, hours, mins, secs);
+        }
+
+        inline const char *frame_type_name(uint8_t ft)
+        {
+            switch (ft)
+            {
+            case 0x00: return "Housekeeping-A";
+            case 0x10: return "SKIF-VE SER summary";
+            case 0x20: return "SKIF-VE/V ESA";
+            case 0x30: return "SKIF-VE/G ESA";
+            case 0x40: return "GALS-VE + SKIF-VE MIP";
+            case 0x50: return "SKL-E calibration";
+            case 0x5C: return "SKL-E spectral";
+            case 0x60: return "Housekeeping-B (N2)";
+            case 0x70: return "FM-VE Magnetometer";
+            case 0x77: return "Fill";
+            case 0x88: return "Fill-alt";
+            default:   return "Unknown";
+            }
+        }
+
+        inline double frame_cadence_seconds(uint8_t ft)
+        {
+            switch (ft)
+            {
+            case 0x5C: return 2 * FINE_TIME_STEP;
+            case 0x20:
+            case 0x30: return 3 * FINE_TIME_STEP;
+            case 0x40: return 11 * FINE_TIME_STEP;
+            case 0x70: return 13 * FINE_TIME_STEP;
+            case 0x00:
+            case 0x10: return 17 * FINE_TIME_STEP;
+            default:   return 0.0;
+            }
+        }
+
+        // Source ID: 0x30 = BND-E (GGAK-E, Elektro-L N1/N2), 0x31 = BND-VE (Elektro-L N3+, Arktika-M N1+)
+        struct SatelliteProfile
+        {
+            const char *name;
+            const char *generation;
+            uint8_t source_id;
+            uint8_t data_fill_byte;
+            uint8_t skl_primary_type;
+            uint8_t skl_marker;
+        };
+
+        constexpr SatelliteProfile PROFILE_BND_E = {
+            "GGAK-E (Elektro-L N1/N2)", "BND-E", 0x30, FILL_BYTE_N2, 0x50, SPECTRAL_CAL_MARKER};
+
+        constexpr SatelliteProfile PROFILE_BND_VE = {
+            "GGAK-VE (Elektro-L N3+)", "BND-VE", 0x31, FILL_BYTE_N5, 0x5C, SPECTRAL_MARKER};
+
+        constexpr uint8_t DEFAULT_SOURCE_ID = 0x31;
+
+        // 9-byte proprietary header (bytes 4-12): frame_type, master/channel counter,
+        // source_id (0x30/0x31/0x33), coarse_time (uint16 BE), fine_time (0-255)
+        struct GGAKFrameHeader
+        {
+            uint8_t frame_type;
+            uint16_t master_counter;
+            uint16_t channel_counter;
+            uint8_t source_id;
+            uint16_t coarse_time;
+            uint8_t fine_time;
+
+            double elapsed_seconds() const
+            {
+                return coarse_time * TIME_TICK_SECONDS + fine_time * FINE_TIME_STEP;
+            }
+        };
+
+        inline GGAKFrameHeader parse_header(const uint8_t *cadu)
+        {
+            return {
+                cadu[4],
+                read_be16(cadu + 5),
+                read_be16(cadu + 7),
+                cadu[9],
+                read_be16(cadu + 10),
+                cadu[12],
+            };
+        }
+
+        // FM-VE magnetometer reading: 15 bytes per sample, up to 13 per 0x70 frame
+        struct MagReading
+        {
+            uint16_t mag_total_raw;
+            uint16_t mag_x_raw;
+            uint16_t mag_y_raw;
+            uint16_t mag_z_raw;
+            uint16_t voltage_raw;
+            uint16_t met_counter; // onboard elapsed-time counter (~1 tick/min), NOT temperature
+            uint8_t status_flag;
+            uint8_t mode;
+            uint8_t mode2;
+            uint32_t coarse_time;
+            uint8_t fine_time;
+            bool checksum_ok = true;
+
+            double mag_total_nt() const { return (static_cast<int>(mag_total_raw) - MAG_ADC_OFFSET) * MAG_SCALE; }
+            double mag_x_nt() const { return (static_cast<int>(mag_x_raw) - MAG_ADC_OFFSET) * MAG_SCALE; }
+            double mag_y_nt() const { return (static_cast<int>(mag_y_raw) - MAG_ADC_OFFSET) * MAG_SCALE; }
+            double mag_z_nt() const { return (static_cast<int>(mag_z_raw) - MAG_ADC_OFFSET) * MAG_SCALE; }
+            double voltage() const { return voltage_raw / VOLTAGE_DIVISOR; }
+
+            double elapsed_seconds() const
+            {
+                return coarse_time * TIME_TICK_SECONDS + fine_time * FINE_TIME_STEP;
+            }
+
+            bool is_valid() const
+            {
+                if (mag_x_raw > MAG_RAW_SANITY || mag_y_raw > MAG_RAW_SANITY ||
+                    mag_z_raw > MAG_RAW_SANITY || mag_total_raw > MAG_RAW_SANITY)
+                    return false;
+                return status_flag != 0xFF;
+            }
+
+            int activity_level() const
+            {
+                double dev = std::abs(mag_total_nt() - MAG_BASELINE_NT);
+                if (dev < 5.0) return 1;
+                if (dev < 20.0) return 2;
+                if (dev < 50.0) return 3;
+                if (dev < 100.0) return 4;
+                return 5;
+            }
+
+            const char *activity_label() const
+            {
+                switch (activity_level())
+                {
+                case 1: return "Normal";
+                case 2: return "Slight";
+                case 3: return "Moderate";
+                case 4: return "Strong";
+                default: return "Extreme";
+                }
+            }
+        };
+
+        // GALS-VE + SKIF-VE MIP: 11 readings per 0x40 frame, 19 bytes each, 8 channels
+        struct ParticleReading
+        {
+            uint8_t sub_type;
+            uint8_t counter;
+            std::array<uint16_t, PARTICLE_CHANNELS> channels;
+            uint32_t coarse_time;
+            uint8_t fine_time;
+            bool checksum_ok = true;
+
+            double elapsed_seconds() const
+            {
+                return coarse_time * TIME_TICK_SECONDS + fine_time * FINE_TIME_STEP;
+            }
+        };
+
+        // Generic sub-packet for ESA, SKL-E spectral, and housekeeping (int32_t channels)
+        struct SubPacket
+        {
+            uint8_t seq;
+            std::vector<int32_t> channels;
+            uint32_t coarse_time;
+            uint8_t fine_time;
+            bool checksum_ok = true;
+
+            double elapsed_seconds() const
+            {
+                return coarse_time * TIME_TICK_SECONDS + fine_time * FINE_TIME_STEP;
+            }
+        };
+
+        struct CounterGapInfo
+        {
+            int total_frames;
+            int gaps;
+            int missing_estimate;
+        };
+
+    } // namespace ggak
+} // namespace elektro_arktika

--- a/plugins/elektro_arktika_support/elektro_arktika/instruments/ggak/module_ggak.cpp
+++ b/plugins/elektro_arktika_support/elektro_arktika/instruments/ggak/module_ggak.cpp
@@ -1,0 +1,109 @@
+#include "module_ggak.h"
+#include "imgui/imgui.h"
+#include "logger.h"
+
+namespace elektro_arktika
+{
+    namespace ggak
+    {
+        GGAKDecoderModule::GGAKDecoderModule(std::string input_file,
+                                             std::string output_file_hint,
+                                             nlohmann::json parameters)
+            : satdump::pipeline::base::FileStreamToFileStreamModule(input_file, output_file_hint, parameters)
+        {
+            fsfsm_enable_output = false;
+        }
+
+        void GGAKDecoderModule::drawUI(bool window)
+        {
+            ImGui::Begin("ELEKTRO / ARKTIKA GGAK Decoder", NULL, window ? 0 : NOWINDOW_FLAGS);
+
+            if (ImGui::BeginTable("##ggaktable", 3, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg))
+            {
+                ImGui::TableNextRow();
+                ImGui::TableSetColumnIndex(0);
+                ImGui::Text("Instrument");
+                ImGui::TableSetColumnIndex(1);
+                ImGui::Text("Frames");
+                ImGui::TableSetColumnIndex(2); 
+                ImGui::Text("Status");
+
+                ImGui::TableNextRow();
+                ImGui::TableSetColumnIndex(0);
+                ImGui::Text("FM-VE Magnetometer");
+                ImGui::TableSetColumnIndex(1);
+                ImGui::TextColored(style::theme.green, "%d", ui_mag_count.load(std::memory_order_relaxed));
+                ImGui::TableSetColumnIndex(2);
+                drawStatus(inst_status[STATUS_MAG]);
+
+                ImGui::TableNextRow();
+                ImGui::TableSetColumnIndex(0);
+                ImGui::Text("GALS-VE + SKIF-VE MIP");
+                ImGui::TableSetColumnIndex(1);
+                ImGui::TextColored(style::theme.green, "%d", ui_particle_count.load(std::memory_order_relaxed));
+                ImGui::TableSetColumnIndex(2);
+                drawStatus(inst_status[STATUS_PARTICLES]);
+
+                ImGui::TableNextRow();
+                ImGui::TableSetColumnIndex(0);
+                ImGui::Text("SKIF-VE ESA");
+                ImGui::TableSetColumnIndex(1);
+                ImGui::TextColored(style::theme.green, "%d",
+                    ui_subpackets_20_count.load(std::memory_order_relaxed) +
+                    ui_subpackets_30_count.load(std::memory_order_relaxed));
+                ImGui::TableSetColumnIndex(2);
+                drawStatus(inst_status[STATUS_SKIF_ESA]);
+
+                ImGui::TableNextRow();
+                ImGui::TableSetColumnIndex(0);
+                ImGui::Text("SKL-E Spectral");
+                ImGui::TableSetColumnIndex(1);
+                ImGui::TextColored(style::theme.green, "%d", ui_subpackets_5c_count.load(std::memory_order_relaxed));
+                ImGui::TableSetColumnIndex(2);
+                drawStatus(inst_status[STATUS_SKL]);
+
+                ImGui::TableNextRow();
+                ImGui::TableSetColumnIndex(0);
+                ImGui::Text("Housekeeping");
+                ImGui::TableSetColumnIndex(1);
+                ImGui::TextColored(style::theme.green, "%d",
+                    ui_subpackets_00_count.load(std::memory_order_relaxed) +
+                    ui_subpackets_10_count.load(std::memory_order_relaxed));
+                ImGui::TableSetColumnIndex(2);
+                drawStatus(inst_status[STATUS_HK]);
+
+                ImGui::TableNextRow();
+                ImGui::TableSetColumnIndex(0);
+                if (profile_detected)
+                    ImGui::Text("%s", sat_profile.generation);
+                else
+                    ImGui::Text("Telemetry Mux");
+                ImGui::TableSetColumnIndex(1);
+                ImGui::TextColored(style::theme.green, "%d",
+                    ui_total_frames.load(std::memory_order_relaxed) -
+                    ui_fill_frames.load(std::memory_order_relaxed));
+                ImGui::TableSetColumnIndex(2);
+                drawStatus(inst_status[STATUS_BND]);
+
+                ImGui::EndTable();
+            }
+
+            drawProgressBar();
+
+            ImGui::End();
+        }
+
+        std::string GGAKDecoderModule::getID()
+        {
+            return "elektro_arktika_ggak";
+        }
+
+        std::shared_ptr<satdump::pipeline::ProcessingModule>
+        GGAKDecoderModule::getInstance(std::string input_file,
+                                       std::string output_file_hint,
+                                       nlohmann::json parameters)
+        {
+            return std::make_shared<GGAKDecoderModule>(input_file, output_file_hint, parameters);
+        }
+    } // namespace ggak
+} // namespace elektro_arktika

--- a/plugins/elektro_arktika_support/elektro_arktika/instruments/ggak/module_ggak.cpp
+++ b/plugins/elektro_arktika_support/elektro_arktika/instruments/ggak/module_ggak.cpp
@@ -1,6 +1,8 @@
 #include "module_ggak.h"
+#include "core/style.h"
 #include "imgui/imgui.h"
 #include "logger.h"
+#include "nlohmann/json.hpp"
 
 namespace elektro_arktika
 {
@@ -25,7 +27,7 @@ namespace elektro_arktika
                 ImGui::Text("Instrument");
                 ImGui::TableSetColumnIndex(1);
                 ImGui::Text("Frames");
-                ImGui::TableSetColumnIndex(2); 
+                ImGui::TableSetColumnIndex(2);
                 ImGui::Text("Status");
 
                 ImGui::TableNextRow();
@@ -74,8 +76,8 @@ namespace elektro_arktika
 
                 ImGui::TableNextRow();
                 ImGui::TableSetColumnIndex(0);
-                if (profile_detected)
-                    ImGui::Text("%s", sat_profile.generation);
+                if (reader.profile_detected)
+                    ImGui::Text("%s", reader.sat_profile.generation);
                 else
                     ImGui::Text("Telemetry Mux");
                 ImGui::TableSetColumnIndex(1);
@@ -96,6 +98,11 @@ namespace elektro_arktika
         std::string GGAKDecoderModule::getID()
         {
             return "elektro_arktika_ggak";
+        }
+
+        nlohmann::json GGAKDecoderModule::getParams()
+        {
+            return {{"interpolate_mag_gaps", false}};
         }
 
         std::shared_ptr<satdump::pipeline::ProcessingModule>

--- a/plugins/elektro_arktika_support/elektro_arktika/instruments/ggak/module_ggak.h
+++ b/plugins/elektro_arktika_support/elektro_arktika/instruments/ggak/module_ggak.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include "ggak_types.h"
+#include "pipeline/modules/base/filestream_to_filestream.h"
+#include "pipeline/modules/instrument_utils.h"
+
+#include <atomic>
+#include <map>
+
+namespace elektro_arktika
+{
+    namespace ggak
+    {
+        class GGAKDecoderModule : public satdump::pipeline::base::FileStreamToFileStreamModule
+        {
+        protected:
+            // Per-instrument accumulated readings
+            std::vector<MagReading> mag_readings;
+            std::vector<ParticleReading> particle_readings;
+            std::vector<SubPacket> subpackets_20; // SKIF-VE/V ESA
+            std::vector<SubPacket> subpackets_30; // SKIF-VE/G ESA
+            std::vector<SubPacket> subpackets_5c; // SKL-E spectral
+            std::vector<SubPacket> subpackets_00; // Housekeeping-A
+            std::vector<SubPacket> subpackets_10; // SKIF-VE SER summary
+
+            // Frame accounting
+            std::map<uint8_t, int> frame_counts;
+            std::vector<uint16_t> master_counters;
+            std::map<uint8_t, std::vector<uint16_t>> channel_counters;
+            int total_frames = 0;
+            int fill_frames = 0;
+            int checksum_pass = 0;
+            int checksum_fail = 0;
+
+            // Detected satellite profile
+            SatelliteProfile sat_profile = PROFILE_BND_VE;
+            bool profile_detected = false;
+
+            // Instrument processing status (for drawUI)
+            enum
+            {
+                STATUS_MAG = 0,
+                STATUS_PARTICLES,
+                STATUS_SKIF_ESA,
+                STATUS_SKL,
+                STATUS_HK,
+                STATUS_BND,
+                STATUS_COUNT
+            };
+            instrument_status_t inst_status[STATUS_COUNT] = {
+                DECODING, DECODING, DECODING, DECODING, DECODING, DECODING};
+
+            std::atomic<int> ui_total_frames{0};
+            std::atomic<int> ui_fill_frames{0};
+            std::atomic<int> ui_mag_count{0};
+            std::atomic<int> ui_particle_count{0};
+            std::atomic<int> ui_subpackets_20_count{0};
+            std::atomic<int> ui_subpackets_30_count{0};
+            std::atomic<int> ui_subpackets_5c_count{0};
+            std::atomic<int> ui_subpackets_00_count{0};
+            std::atomic<int> ui_subpackets_10_count{0};
+
+        public:
+            GGAKDecoderModule(std::string input_file, std::string output_file_hint, nlohmann::json parameters);
+            void process();
+            void drawUI(bool window);
+
+        public:
+            static std::string getID();
+            virtual std::string getIDM() { return getID(); };
+            static nlohmann::json getParams() { return {}; }
+            static std::shared_ptr<ProcessingModule> getInstance(std::string input_file,
+                                                                 std::string output_file_hint,
+                                                                 nlohmann::json parameters);
+        };
+    } // namespace ggak
+} // namespace elektro_arktika

--- a/plugins/elektro_arktika_support/elektro_arktika/instruments/ggak/module_ggak.h
+++ b/plugins/elektro_arktika_support/elektro_arktika/instruments/ggak/module_ggak.h
@@ -1,6 +1,16 @@
 #pragma once
 
-#include "ggak_types.h"
+/**
+ * @file module_ggak.h
+ * @brief GGAK space environment decoder pipeline module.
+ *
+ * Reads 224-byte CADUs from the GGAK-VE / GGAK-E telemetry stream,
+ * decodes magnetometer, particle, and spectrometer data, and produces
+ * a GGAKProduct for the SatDump explorer.
+ */
+
+#include "ggak_reader.h"
+#include "ggak_product.h"
 #include "pipeline/modules/base/filestream_to_filestream.h"
 #include "pipeline/modules/instrument_utils.h"
 
@@ -14,27 +24,12 @@ namespace elektro_arktika
         class GGAKDecoderModule : public satdump::pipeline::base::FileStreamToFileStreamModule
         {
         protected:
-            // Per-instrument accumulated readings
-            std::vector<MagReading> mag_readings;
-            std::vector<ParticleReading> particle_readings;
-            std::vector<SubPacket> subpackets_20; // SKIF-VE/V ESA
-            std::vector<SubPacket> subpackets_30; // SKIF-VE/G ESA
-            std::vector<SubPacket> subpackets_5c; // SKL-E spectral
-            std::vector<SubPacket> subpackets_00; // Housekeeping-A
-            std::vector<SubPacket> subpackets_10; // SKIF-VE SER summary
+            GGAKReader reader;
 
-            // Frame accounting
-            std::map<uint8_t, int> frame_counts;
-            std::vector<uint16_t> master_counters;
-            std::map<uint8_t, std::vector<uint16_t>> channel_counters;
-            int total_frames = 0;
-            int fill_frames = 0;
-            int checksum_pass = 0;
-            int checksum_fail = 0;
-
-            // Detected satellite profile
-            SatelliteProfile sat_profile = PROFILE_BND_VE;
-            bool profile_detected = false;
+            // Shared state for decomposed process() phases
+            CounterGapInfo master_gap_info{0, 0, 0};
+            std::map<std::string, int> per_inst_gaps;
+            std::map<std::string, int> per_inst_missing;
 
             // Instrument processing status (for drawUI)
             enum
@@ -60,6 +55,12 @@ namespace elektro_arktika
             std::atomic<int> ui_subpackets_00_count{0};
             std::atomic<int> ui_subpackets_10_count{0};
 
+        private:
+            void decodeFrames();
+            void refreshUiCounters();
+            void logSummary();
+            void buildProduct(GGAKProduct &product);
+
         public:
             GGAKDecoderModule(std::string input_file, std::string output_file_hint, nlohmann::json parameters);
             void process();
@@ -68,7 +69,7 @@ namespace elektro_arktika
         public:
             static std::string getID();
             virtual std::string getIDM() { return getID(); };
-            static nlohmann::json getParams() { return {}; }
+            static nlohmann::json getParams();
             static std::shared_ptr<ProcessingModule> getInstance(std::string input_file,
                                                                  std::string output_file_hint,
                                                                  nlohmann::json parameters);

--- a/plugins/elektro_arktika_support/elektro_arktika/instruments/ggak/module_ggak_proc.cpp
+++ b/plugins/elektro_arktika_support/elektro_arktika/instruments/ggak/module_ggak_proc.cpp
@@ -1,0 +1,754 @@
+#include "module_ggak.h"
+#include "ggak_product.h"
+#include "logger.h"
+#include "nlohmann/json_utils.h"
+#include "products/dataset.h"
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+
+namespace elektro_arktika
+{
+    namespace ggak
+    {
+        namespace
+        {
+            void decode_magnetometer_frame(const uint8_t *payload, size_t len,
+                                           uint32_t ct, uint8_t ft, uint8_t data_fill,
+                                           bool csum_ok, std::vector<MagReading> &out)
+            {
+                for (int i = 0; i < MAG_READINGS_PER_FRAME; i++)
+                {
+                    size_t off = i * MAG_READING_LEN;
+                    if (off + MAG_READING_LEN > len)
+                        break;
+                    const uint8_t *r = payload + off;
+
+                    if (is_fill_data(r, MAG_READING_LEN, data_fill))
+                        continue;
+
+                    MagReading rd{};
+                    rd.mag_total_raw = read_be16(r + 0);
+                    rd.mag_x_raw = read_be16(r + 2);
+                    rd.mag_y_raw = read_be16(r + 4);
+                    rd.mag_z_raw = read_be16(r + 6);
+                    rd.voltage_raw = read_be16(r + 8);
+                    rd.met_counter = read_be16(r + 10);
+                    rd.status_flag = r[12];
+                    rd.mode = r[13];
+                    rd.mode2 = r[14];
+                    rd.coarse_time = ct;
+                    rd.fine_time = ft;
+                    rd.checksum_ok = csum_ok;
+                    out.push_back(rd);
+                }
+            }
+
+            void decode_particle_frame(const uint8_t *payload, size_t len,
+                                       uint32_t ct, uint8_t ft, uint8_t data_fill,
+                                       bool csum_ok, std::vector<ParticleReading> &out)
+            {
+                for (int i = 0; i < PARTICLE_READINGS_PER_FRAME; i++)
+                {
+                    size_t off = i * PARTICLE_READING_LEN;
+                    if (off + PARTICLE_READING_LEN > len)
+                        break;
+                    const uint8_t *r = payload + off;
+
+                    if (r[0] != PARTICLE_MARKER_A0 && r[0] != PARTICLE_MARKER_A1)
+                        continue;
+                    if (is_fill_data(r, PARTICLE_READING_LEN, data_fill))
+                        continue;
+
+                    ParticleReading rd{};
+                    rd.sub_type = r[1];
+                    rd.counter = r[2];
+                    for (int ch = 0; ch < PARTICLE_CHANNELS; ch++)
+                        rd.channels[ch] = read_be16(r + 3 + ch * 2);
+                    rd.coarse_time = ct;
+                    rd.fine_time = ft;
+                    rd.checksum_ok = csum_ok;
+                    out.push_back(rd);
+                }
+            }
+
+            void decode_subpacket_69(const uint8_t *payload, size_t len,
+                                     uint8_t marker_hi,
+                                     uint32_t ct, uint8_t ft, uint8_t data_fill,
+                                     bool csum_ok, std::vector<SubPacket> &out)
+            {
+                constexpr int PKT_SIZE = 69;
+                const size_t offsets[] = {0, 69, 138};
+
+                for (int p = 0; p < 3; p++)
+                {
+                    if (offsets[p] + PKT_SIZE > len)
+                        break;
+                    const uint8_t *r = payload + offsets[p];
+
+                    if (r[0] != marker_hi)
+                        continue;
+                    if (is_fill_data(r, PKT_SIZE, data_fill))
+                        continue;
+
+                    SubPacket pkt{};
+                    pkt.seq = r[2];
+                    pkt.coarse_time = ct;
+                    pkt.fine_time = ft;
+                    pkt.checksum_ok = csum_ok;
+
+                    const uint8_t *data = r + 3;
+                    int data_len = 65;
+                    for (int ch = 0; ch + 1 < data_len; ch += 2)
+                        pkt.channels.push_back(static_cast<int32_t>(read_be16(data + ch)));
+
+                    out.push_back(std::move(pkt));
+                }
+            }
+
+            void decode_housekeeping_12(const uint8_t *payload, size_t len,
+                                        uint8_t marker_byte,
+                                        uint32_t ct, uint8_t ft, uint8_t data_fill,
+                                        bool csum_ok, std::vector<SubPacket> &out)
+            {
+                constexpr int BLK_SIZE = 12;
+                size_t off = 0;
+
+                while (off + BLK_SIZE <= len)
+                {
+                    const uint8_t *r = payload + off;
+
+                    if (r[0] != marker_byte)
+                    {
+                        off++;
+                        continue;
+                    }
+                    if (is_fill_data(r, BLK_SIZE, data_fill))
+                    {
+                        off += BLK_SIZE;
+                        continue;
+                    }
+
+                    SubPacket pkt{};
+                    pkt.seq = r[1];
+                    pkt.coarse_time = ct;
+                    pkt.fine_time = ft;
+                    pkt.checksum_ok = csum_ok;
+
+                    for (int ch = 0; ch < 5; ch++)
+                        pkt.channels.push_back(static_cast<int32_t>(read_be16(r + 2 + ch * 2)));
+
+                    out.push_back(std::move(pkt));
+                    off += BLK_SIZE;
+                }
+            }
+
+            void decode_spectral(const uint8_t *payload, size_t len,
+                                 uint8_t marker,
+                                 uint32_t ct, uint8_t ft, uint8_t data_fill,
+                                 bool csum_ok, std::vector<SubPacket> &out)
+            {
+                size_t off = 0;
+
+                while (off < len && off + SPECTRAL_MIN_PACKET_BYTES <= len)
+                {
+                    if (payload[off] != marker)
+                    {
+                        off++;
+                        continue;
+                    }
+
+                    // Find next marker (minimum distance = SPECTRAL_MIN_PACKET_BYTES)
+                    size_t next = off + SPECTRAL_MIN_PACKET_BYTES;
+                    while (next < len && payload[next] != marker)
+                        next++;
+                    size_t end = (next < len) ? next : len;
+
+                    // Strip trailing fill bytes
+                    size_t pkt_len = end - off;
+                    while (pkt_len > 3 && payload[off + pkt_len - 1] == data_fill)
+                        pkt_len--;
+
+                    size_t data_len = pkt_len - 3; // skip marker + type + seq
+                    if (pkt_len >= static_cast<size_t>(SPECTRAL_MIN_PACKET_BYTES) && (data_len % 2) == 0)
+                    {
+                        SubPacket pkt{};
+                        pkt.seq = payload[off + 2];
+                        pkt.coarse_time = ct;
+                        pkt.fine_time = ft;
+                        pkt.checksum_ok = csum_ok;
+
+                        const uint8_t *data = payload + off + 3;
+                        for (size_t ch = 0; ch + 1 < data_len; ch += 2)
+                            pkt.channels.push_back(static_cast<int32_t>(read_be16s(data + ch)));
+
+                        out.push_back(std::move(pkt));
+                        off = end;
+                    }
+                    else
+                    {
+                        off++;
+                    }
+                }
+            }
+
+            CounterGapInfo analyze_counter_gaps(const std::vector<uint16_t> &counters)
+            {
+                CounterGapInfo info{static_cast<int>(counters.size()), 0, 0};
+                for (size_t i = 1; i < counters.size(); i++)
+                {
+                    int diff = (counters[i] - counters[i - 1] + 65536) % 65536;
+                    if (diff > 1 && diff < 60000)
+                    {
+                        info.gaps++;
+                        info.missing_estimate += diff - 1;
+                    }
+                }
+                return info;
+            }
+
+            /**
+             * Fill small gaps (up to max_gap_frames missed frames) via linear
+             * interpolation.  Only suitable for slowly-varying quantities
+             * like magnetic field at GEO.
+             */
+            int interpolate_small_gaps(GGAKChannel &ch, double cadence, int max_gap_frames)
+            {
+                if (ch.timestamps.size() < 2 || cadence <= 0)
+                    return 0;
+
+                double max_gap_dt = (max_gap_frames + 1) * cadence * 0.9;
+                int filled = 0;
+
+                std::vector<double> new_ts, new_vals;
+                new_ts.reserve(ch.timestamps.size() * 2);
+                new_vals.reserve(new_ts.capacity());
+
+                new_ts.push_back(ch.timestamps[0]);
+                new_vals.push_back(ch.values[0]);
+
+                for (size_t i = 1; i < ch.timestamps.size(); i++)
+                {
+                    double dt = ch.timestamps[i] - ch.timestamps[i - 1];
+                    if (dt > cadence * 1.5 && dt <= max_gap_dt)
+                    {
+                        int n_fill = static_cast<int>(std::round(dt / cadence)) - 1;
+                        for (int k = 1; k <= n_fill; k++)
+                        {
+                            double frac = static_cast<double>(k) / (n_fill + 1);
+                            double t = ch.timestamps[i - 1] + frac * dt;
+                            double v = ch.values[i - 1] + frac * (ch.values[i] - ch.values[i - 1]);
+                            new_ts.push_back(t);
+                            new_vals.push_back(v);
+                            filled++;
+                        }
+                    }
+                    new_ts.push_back(ch.timestamps[i]);
+                    new_vals.push_back(ch.values[i]);
+                }
+
+                ch.timestamps = std::move(new_ts);
+                ch.values = std::move(new_vals);
+                return filled;
+            }
+
+            void write_magnetometer_csv(const std::vector<MagReading> &readings,
+                                        const std::string &path)
+            {
+                std::ofstream f(path);
+                if (!f.is_open())
+                    return;
+
+                f << "timestamp,elapsed_s,"
+                     "mag_total_raw,mag_x_raw,mag_y_raw,mag_z_raw,"
+                     "B_total_nT,Bx_nT,By_nT,Bz_nT,"
+                     "voltage_raw,voltage_V,met_counter,"
+                     "status,mode,mode2,activity_level,activity_label,"
+                     "checksum_ok\n";
+
+                char ts[32];
+                for (auto &r : readings)
+                {
+                    if (!r.is_valid())
+                        continue;
+                    double es = r.elapsed_seconds();
+                    format_timestamp(es, ts, sizeof(ts));
+
+                    f << ts << "," << std::fixed;
+                    f.precision(1);
+                    f << es << ",";
+                    f << r.mag_total_raw << "," << r.mag_x_raw << ","
+                      << r.mag_y_raw << "," << r.mag_z_raw << ",";
+                    f.precision(2);
+                    f << r.mag_total_nt() << "," << r.mag_x_nt() << ","
+                      << r.mag_y_nt() << "," << r.mag_z_nt() << ",";
+                    f << r.voltage_raw << ",";
+                    f.precision(2);
+                    f << r.voltage() << ",";
+                    f << r.met_counter << ",";
+                    f << (int)r.status_flag << "," << (int)r.mode << "," << (int)r.mode2 << ",";
+                    f << r.activity_level() << "," << r.activity_label() << ","
+                      << (r.checksum_ok ? 1 : 0) << "\n";
+                }
+            }
+
+            void write_particle_csv(const std::vector<ParticleReading> &readings,
+                                    const std::string &path)
+            {
+                std::ofstream f(path);
+                if (!f.is_open())
+                    return;
+
+                f << "timestamp,elapsed_s,sub_type,counter";
+                for (int i = 0; i < PARTICLE_CHANNELS; i++)
+                    f << ",ch_" << (i + 1);
+                f << ",checksum_ok\n";
+
+                char ts[32];
+                for (auto &r : readings)
+                {
+                    double es = r.elapsed_seconds();
+                    format_timestamp(es, ts, sizeof(ts));
+
+                    f << ts << "," << std::fixed;
+                    f.precision(1);
+                    f << es << ",0x";
+
+                    // sub_type as hex
+                    char hex[8];
+                    std::snprintf(hex, sizeof(hex), "%02X", r.sub_type);
+                    f << hex << "," << (int)r.counter;
+
+                    for (int i = 0; i < PARTICLE_CHANNELS; i++)
+                        f << "," << r.channels[i];
+                    f << "," << (r.checksum_ok ? 1 : 0) << "\n";
+                }
+            }
+
+            void write_subpacket_csv(const std::vector<SubPacket> &packets,
+                                     const std::string &path)
+            {
+                if (packets.empty())
+                    return;
+
+                std::ofstream f(path);
+                if (!f.is_open())
+                    return;
+
+                int max_ch = 0;
+                for (auto &p : packets)
+                    if (static_cast<int>(p.channels.size()) > max_ch)
+                        max_ch = static_cast<int>(p.channels.size());
+
+                f << "timestamp,elapsed_s,seq";
+                for (int i = 0; i < max_ch; i++)
+                    f << ",ch_" << (i + 1);
+                f << ",checksum_ok\n";
+
+                char ts[32];
+                for (auto &p : packets)
+                {
+                    double es = p.elapsed_seconds();
+                    format_timestamp(es, ts, sizeof(ts));
+
+                    f << ts << "," << std::fixed;
+                    f.precision(1);
+                    f << es << "," << (int)p.seq;
+
+                    for (size_t i = 0; i < static_cast<size_t>(max_ch); i++)
+                    {
+                        f << ",";
+                        if (i < p.channels.size())
+                            f << p.channels[i];
+                        else
+                            f << "0";
+                    }
+                    f << "," << (p.checksum_ok ? 1 : 0) << "\n";
+                }
+            }
+        } // anonymous namespace
+
+        void GGAKDecoderModule::process()
+        {
+            std::string directory = d_output_file_hint.substr(0, d_output_file_hint.rfind('/')) + "/GGAK";
+
+            if (!std::filesystem::exists(directory))
+                std::filesystem::create_directories(directory);
+
+            logger->info("Processing GGAK space environment data...");
+
+            uint8_t cadu[CADU_SIZE];
+
+            int prev_coarse_time = -1;
+            uint32_t coarse_time_offset = 0;
+
+            while (should_run())
+            {
+                read_data(cadu, CADU_SIZE);
+                total_frames++;
+
+                // Checksum verification
+                bool csum_ok = validate_checksum(cadu);
+                if (csum_ok)
+                    checksum_pass++;
+                else
+                    checksum_fail++;
+
+                GGAKFrameHeader hdr = parse_header(cadu);
+                frame_counts[hdr.frame_type]++;
+
+                if (is_fill_frame(hdr.frame_type))
+                {
+                    fill_frames++;
+                    ui_total_frames.store(total_frames, std::memory_order_relaxed);
+                    ui_fill_frames.store(fill_frames, std::memory_order_relaxed);
+                    continue;
+                }
+
+                // Auto-detect BND generation from first data frame
+                if (!profile_detected)
+                {
+                    if (hdr.source_id == 0x30)
+                        sat_profile = PROFILE_BND_E;
+                    else
+                        sat_profile = PROFILE_BND_VE;
+                    profile_detected = true;
+                    logger->info("Detected: %s (source_id=0x%02X)", sat_profile.name, sat_profile.source_id);
+                }
+
+                // Track 16-bit coarse_time wraparound (~193 day period)
+                if (prev_coarse_time >= 0 && (prev_coarse_time - static_cast<int>(hdr.coarse_time)) > 50000)
+                    coarse_time_offset += 65536;
+                prev_coarse_time = hdr.coarse_time;
+
+                master_counters.push_back(hdr.master_counter);
+                channel_counters[hdr.frame_type].push_back(hdr.channel_counter);
+
+                uint32_t ct = hdr.coarse_time + coarse_time_offset;
+                uint8_t ft = hdr.fine_time;
+                uint8_t data_fill = sat_profile.data_fill_byte;
+
+                // Payload region: bytes 13..221 of the CADU (after ASM + header)
+                const uint8_t *payload = cadu + PAYLOAD_OFFSET;
+
+                switch (hdr.frame_type)
+                {
+                case 0x70:
+                    decode_magnetometer_frame(payload, PAYLOAD_SIZE, ct, ft, data_fill, csum_ok, mag_readings);
+                    break;
+                case 0x40:
+                    decode_particle_frame(payload, PAYLOAD_SIZE, ct, ft, data_fill, csum_ok, particle_readings);
+                    break;
+                case 0x20:
+                    decode_subpacket_69(payload, PAYLOAD_SIZE, 0x90, ct, ft, data_fill, csum_ok, subpackets_20);
+                    break;
+                case 0x30:
+                    decode_subpacket_69(payload, PAYLOAD_SIZE, 0x98, ct, ft, data_fill, csum_ok, subpackets_30);
+                    break;
+                case 0x50:
+                    decode_spectral(payload, PAYLOAD_SIZE, SPECTRAL_CAL_MARKER, ct, ft, data_fill, csum_ok, subpackets_5c);
+                    break;
+                case 0x5C:
+                    decode_spectral(payload, PAYLOAD_SIZE, SPECTRAL_MARKER, ct, ft, data_fill, csum_ok, subpackets_5c);
+                    break;
+                case 0x00:
+                    decode_housekeeping_12(payload, PAYLOAD_SIZE, 0x80, ct, ft, data_fill, csum_ok, subpackets_00);
+                    break;
+                case 0x10:
+                    decode_housekeeping_12(payload, PAYLOAD_SIZE, 0x88, ct, ft, data_fill, csum_ok, subpackets_10);
+                    break;
+                default:
+                    break;
+                }
+
+                ui_total_frames.store(total_frames, std::memory_order_relaxed);
+                ui_fill_frames.store(fill_frames, std::memory_order_relaxed);
+                ui_mag_count.store((int)mag_readings.size(), std::memory_order_relaxed);
+                ui_particle_count.store((int)particle_readings.size(), std::memory_order_relaxed);
+                ui_subpackets_20_count.store((int)subpackets_20.size(), std::memory_order_relaxed);
+                ui_subpackets_30_count.store((int)subpackets_30.size(), std::memory_order_relaxed);
+                ui_subpackets_5c_count.store((int)subpackets_5c.size(), std::memory_order_relaxed);
+                ui_subpackets_00_count.store((int)subpackets_00.size(), std::memory_order_relaxed);
+                ui_subpackets_10_count.store((int)subpackets_10.size(), std::memory_order_relaxed);
+            }
+
+            cleanup();
+
+            auto by_time = [](const auto &a, const auto &b) {
+                return a.elapsed_seconds() < b.elapsed_seconds();
+            };
+            std::sort(mag_readings.begin(), mag_readings.end(), by_time);
+            std::sort(particle_readings.begin(), particle_readings.end(), by_time);
+            std::sort(subpackets_20.begin(), subpackets_20.end(), by_time);
+            std::sort(subpackets_30.begin(), subpackets_30.end(), by_time);
+            std::sort(subpackets_5c.begin(), subpackets_5c.end(), by_time);
+            std::sort(subpackets_00.begin(), subpackets_00.end(), by_time);
+            std::sort(subpackets_10.begin(), subpackets_10.end(), by_time);
+
+            logger->info("----------- GGAK %s", sat_profile.name);
+            logger->info("Total frames        : %d (%d data, %d fill)", total_frames,
+                         total_frames - fill_frames, fill_frames);
+            logger->info("Checksum            : %d pass / %d fail", checksum_pass, checksum_fail);
+            logger->info("FM-VE readings      : %zu", mag_readings.size());
+            logger->info("GALS-VE+MIP readings: %zu", particle_readings.size());
+            logger->info("SKIF-VE/V ESA pkts  : %zu", subpackets_20.size());
+            logger->info("SKIF-VE/G ESA pkts  : %zu", subpackets_30.size());
+            logger->info("SKL-E spectral pkts : %zu", subpackets_5c.size());
+            logger->info("Housekeeping-A pkts : %zu", subpackets_00.size());
+            logger->info("SKIF-VE SER pkts    : %zu", subpackets_10.size());
+
+            CounterGapInfo gap_info = analyze_counter_gaps(master_counters);
+            if (gap_info.gaps > 0)
+                logger->warn("Counter gaps: %d (est. %d frames missing)", gap_info.gaps, gap_info.missing_estimate);
+
+            std::map<std::string, int> per_inst_gaps, per_inst_missing;
+            for (auto &[ft_key, counters] : channel_counters)
+            {
+                CounterGapInfo ci = analyze_counter_gaps(counters);
+                if (ci.gaps > 0)
+                {
+                    std::string name = frame_type_name(ft_key);
+                    per_inst_gaps[name] = ci.gaps;
+                    per_inst_missing[name] = ci.missing_estimate;
+                    logger->warn("  %s channel gaps: %d (est. %d missing)", name.c_str(), ci.gaps, ci.missing_estimate);
+                }
+            }
+
+            for (int i = 0; i < STATUS_COUNT; i++)
+                inst_status[i] = SAVING;
+            inst_status[STATUS_BND] = DONE;
+
+            logger->info("Writing GGAK CSV and metadata...");
+
+            write_magnetometer_csv(mag_readings, directory + "/magnetometer.csv");
+            inst_status[STATUS_MAG] = DONE;
+
+            write_particle_csv(particle_readings, directory + "/particles.csv");
+            inst_status[STATUS_PARTICLES] = DONE;
+
+            write_subpacket_csv(subpackets_20, directory + "/skif_v_esa.csv");
+            write_subpacket_csv(subpackets_30, directory + "/skif_g_esa.csv");
+            inst_status[STATUS_SKIF_ESA] = DONE;
+
+            write_subpacket_csv(subpackets_5c, directory + "/skl_spectral.csv");
+            inst_status[STATUS_SKL] = DONE;
+
+            write_subpacket_csv(subpackets_00, directory + "/housekeeping.csv");
+            write_subpacket_csv(subpackets_10, directory + "/skif_ser.csv");
+            inst_status[STATUS_HK] = DONE;
+
+            GGAKProduct ggak_product;
+            ggak_product.instrument_name = "ggak";
+
+            {
+                constexpr int MAG_CH_COUNT = 5;
+                const char *mag_names[MAG_CH_COUNT] = {"|B|", "Bx", "By", "Bz", "Voltage"};
+                const char *mag_units[MAG_CH_COUNT] = {"nT", "nT", "nT", "nT", "V"};
+
+                ggak_product.mag_channels.resize(MAG_CH_COUNT);
+                for (int i = 0; i < MAG_CH_COUNT; i++)
+                {
+                    ggak_product.mag_channels[i].name = mag_names[i];
+                    ggak_product.mag_channels[i].unit = mag_units[i];
+                }
+
+                for (auto &r : mag_readings)
+                {
+                    if (!r.is_valid())
+                        continue;
+                    double t = r.elapsed_seconds();
+                    for (int i = 0; i < MAG_CH_COUNT; i++)
+                        ggak_product.mag_channels[i].timestamps.push_back(t);
+
+                    ggak_product.mag_channels[0].values.push_back(r.mag_total_nt());
+                    ggak_product.mag_channels[1].values.push_back(r.mag_x_nt());
+                    ggak_product.mag_channels[2].values.push_back(r.mag_y_nt());
+                    ggak_product.mag_channels[3].values.push_back(r.mag_z_nt());
+                    ggak_product.mag_channels[4].values.push_back(r.voltage());
+                }
+            }
+
+            if (d_parameters.value("interpolate_mag_gaps", false))
+            {
+                double mag_cadence = frame_cadence_seconds(0x70);
+                int total_filled = 0;
+                for (auto &ch : ggak_product.mag_channels)
+                    total_filled += interpolate_small_gaps(ch, mag_cadence, 2);
+                if (total_filled > 0)
+                    logger->info("Interpolated %d magnetometer gap samples", total_filled);
+            }
+
+            for (auto &ch : ggak_product.mag_channels)
+                ch.updateMinMax();
+
+            {
+                const char *particle_names[PARTICLE_CHANNELS] = {
+                    "Ep>=600MeV", "Ep>=800MeV", "Ep>=1100MeV",
+                    "Cg-1", "Cg-2", "Cg-3", "Cg-4", "MIP"};
+
+                ggak_product.particle_channels.resize(PARTICLE_CHANNELS);
+                for (int ch = 0; ch < PARTICLE_CHANNELS; ch++)
+                {
+                    ggak_product.particle_channels[ch].name = particle_names[ch];
+                    ggak_product.particle_channels[ch].unit = "Counts";
+                }
+
+                for (auto &r : particle_readings)
+                {
+                    double t = r.elapsed_seconds();
+                    for (int ch = 0; ch < PARTICLE_CHANNELS; ch++)
+                    {
+                        ggak_product.particle_channels[ch].timestamps.push_back(t);
+                        ggak_product.particle_channels[ch].values.push_back(static_cast<double>(r.channels[ch]));
+                    }
+                }
+
+                for (auto &ch : ggak_product.particle_channels)
+                    ch.updateMinMax();
+            }
+
+            auto make_subpkt_avg = [](const char *name, const char *unit, const char *group,
+                                      const std::vector<SubPacket> &data) -> GGAKChannel {
+                GGAKChannel gc;
+                gc.name = name;
+                gc.unit = unit;
+                gc.group = group;
+                for (auto &p : data)
+                {
+                    double avg = 0;
+                    if (!p.channels.empty())
+                    {
+                        for (auto v : p.channels)
+                            avg += v;
+                        avg /= p.channels.size();
+                    }
+                    gc.timestamps.push_back(p.elapsed_seconds());
+                    gc.values.push_back(avg);
+                }
+                gc.updateMinMax();
+                return gc;
+            };
+
+            auto make_subpkt_ch = [](const char *name, const char *unit, const char *group,
+                                     const std::vector<SubPacket> &data, int ch_idx,
+                                     double scale = 1.0) -> GGAKChannel {
+                GGAKChannel gc;
+                gc.name = name;
+                gc.unit = unit;
+                gc.group = group;
+                for (auto &p : data)
+                {
+                    if (ch_idx < (int)p.channels.size())
+                    {
+                        gc.timestamps.push_back(p.elapsed_seconds());
+                        gc.values.push_back(p.channels[ch_idx] * scale);
+                    }
+                }
+                gc.updateMinMax();
+                return gc;
+            };
+
+            ggak_product.subpacket_channels.push_back(
+                make_subpkt_avg("SKIF-VE/V ESA (avg)", "counts", "SKIF-VE/V ESA", subpackets_20));
+            ggak_product.subpacket_channels.push_back(
+                make_subpkt_avg("SKIF-VE/G ESA (avg)", "counts", "SKIF-VE/G ESA", subpackets_30));
+            ggak_product.subpacket_channels.push_back(
+                make_subpkt_avg("SKL-E Spectral (avg)", "counts (signed)", "SKL-E Spectral", subpackets_5c));
+
+            ggak_product.subpacket_channels.push_back(
+                make_subpkt_ch("ISP-2M TSI", "W/m\xC2\xB2", "Housekeeping-A", subpackets_00, 2, 0.0331));
+            ggak_product.subpacket_channels.push_back(
+                make_subpkt_ch("BND-VE Thermal", "counts (14-bit)", "Housekeeping-A", subpackets_00, 1));
+            ggak_product.subpacket_channels.push_back(
+                make_subpkt_ch("HK Mux (ch_1)", "counts", "Housekeeping-A", subpackets_00, 0));
+
+            ggak_product.subpacket_channels.push_back(
+                make_subpkt_ch("SKIF-VE/V SER", "cts/frame", "SKIF-VE SER summary", subpackets_10, 2));
+            ggak_product.subpacket_channels.push_back(
+                make_subpkt_ch("SKIF-VE/G SER", "cts/frame", "SKIF-VE SER summary", subpackets_10, 4));
+
+            int valid_mag = ggak_product.mag_channels.empty()
+                                ? 0
+                                : (int)ggak_product.mag_channels[0].values.size();
+
+            nlohmann::json meta;
+            meta["instrument"] = "GGAK";
+            meta["generation"] = sat_profile.generation;
+            meta["satellite_name"] = sat_profile.name;
+            meta["source_id"] = sat_profile.source_id;
+            meta["total_frames"] = total_frames;
+            meta["data_frames"] = total_frames - fill_frames;
+            meta["fill_frames"] = fill_frames;
+            meta["checksum"] = {{"pass", checksum_pass}, {"fail", checksum_fail}};
+
+            nlohmann::json fc;
+            for (auto &[ft_key, count] : frame_counts)
+            {
+                char key[8];
+                std::snprintf(key, sizeof(key), "0x%02X", ft_key);
+                fc[key] = count;
+            }
+            meta["frame_counts"] = fc;
+
+            meta["counter_analysis"] = {
+                {"total_frames", gap_info.total_frames},
+                {"gaps", gap_info.gaps},
+                {"missing_estimate", gap_info.missing_estimate}};
+
+            meta["timing"] = {
+                {"tick_rate_seconds", TIME_TICK_SECONDS},
+                {"fine_step_seconds", FINE_TIME_STEP},
+                {"capture_frames", total_frames}};
+
+            meta["magnetometer"] = {
+                {"total_readings", (int)mag_readings.size()},
+                {"valid_readings", valid_mag},
+                {"calibration", {{"adc_offset", MAG_ADC_OFFSET}, {"scale_nT_per_count", MAG_SCALE}, {"formula", "nT = (raw - 2339) * 2.359"}}}};
+
+            meta["particles"] = {
+                {"total_readings", (int)particle_readings.size()},
+                {"channels", PARTICLE_CHANNELS},
+                {"channel_mapping", {{"ch_1", "GALS-VE/-CH Ep >= 600 MeV"}, {"ch_2", "GALS-VE/-CH Ep >= 800 MeV"}, {"ch_3", "GALS-VE/-CH Ep >= 1100 MeV"}, {"ch_4", "GALS-VE/-S Cg-1 Ee > 0.15 MeV, Ep > 5 MeV"}, {"ch_5", "GALS-VE/-S Cg-2 Ee > 0.7 MeV, Ep > 15 MeV"}, {"ch_6", "GALS-VE/-S Cg-3 Ee > 1.7 MeV, Ep > 25 MeV"}, {"ch_7", "GALS-VE/-S Cg-4 Ee > 3.2 MeV, Ep > 40 MeV"}, {"ch_8", "SKIF-VE MIP Ep > 15 MeV, Ee > 800 keV"}}}};
+
+            meta["subpackets"] = {
+                {"skif_ve_v_esa", (int)subpackets_20.size()},
+                {"skif_ve_g_esa", (int)subpackets_30.size()},
+                {"skl_e_spectral", (int)subpackets_5c.size()},
+                {"housekeeping_a", (int)subpackets_00.size()},
+                {"skif_ve_ser", (int)subpackets_10.size()}};
+
+            saveJsonFile(directory + "/metadata.json", meta);
+
+            ggak_product.stats.total_frames = total_frames;
+            ggak_product.stats.data_frames = total_frames - fill_frames;
+            ggak_product.stats.fill_frames = fill_frames;
+            ggak_product.stats.checksum_pass = checksum_pass;
+            ggak_product.stats.checksum_fail = checksum_fail;
+            ggak_product.stats.counter_gaps = gap_info.gaps;
+            ggak_product.stats.missing_estimate = gap_info.missing_estimate;
+            ggak_product.stats.generation = sat_profile.generation;
+            ggak_product.stats.satellite_name = sat_profile.name;
+            ggak_product.stats.per_instrument_gaps = per_inst_gaps;
+            ggak_product.stats.per_instrument_missing = per_inst_missing;
+
+            ggak_product.set_product_source(sat_profile.name);
+            ggak_product.set_product_timestamp(time(0));
+            ggak_product.save(directory);
+
+            std::string sat_name = "ELEKTRO-L";
+            if (sat_profile.source_id == 0x30)
+                sat_name = "ELEKTRO-L (GGAK-E)";
+            else
+                sat_name = "ELEKTRO-L (GGAK-VE)";
+
+            satdump::products::DataSet dataset;
+            dataset.satellite_name = sat_name;
+            dataset.timestamp = time(0);
+            dataset.products_list.push_back("GGAK");
+            dataset.save(d_output_file_hint.substr(0, d_output_file_hint.rfind('/')));
+
+            logger->info("GGAK processing complete.");
+        }
+    } // namespace ggak
+} // namespace elektro_arktika

--- a/plugins/elektro_arktika_support/elektro_arktika/instruments/ggak/module_ggak_proc.cpp
+++ b/plugins/elektro_arktika_support/elektro_arktika/instruments/ggak/module_ggak_proc.cpp
@@ -5,6 +5,8 @@
 #include "products/dataset.h"
 
 #include <algorithm>
+#include <cmath>
+#include <cstdio>
 #include <filesystem>
 #include <fstream>
 
@@ -14,192 +16,13 @@ namespace elektro_arktika
     {
         namespace
         {
-            void decode_magnetometer_frame(const uint8_t *payload, size_t len,
-                                           uint32_t ct, uint8_t ft, uint8_t data_fill,
-                                           bool csum_ok, std::vector<MagReading> &out)
-            {
-                for (int i = 0; i < MAG_READINGS_PER_FRAME; i++)
-                {
-                    size_t off = i * MAG_READING_LEN;
-                    if (off + MAG_READING_LEN > len)
-                        break;
-                    const uint8_t *r = payload + off;
-
-                    if (is_fill_data(r, MAG_READING_LEN, data_fill))
-                        continue;
-
-                    MagReading rd{};
-                    rd.mag_total_raw = read_be16(r + 0);
-                    rd.mag_x_raw = read_be16(r + 2);
-                    rd.mag_y_raw = read_be16(r + 4);
-                    rd.mag_z_raw = read_be16(r + 6);
-                    rd.voltage_raw = read_be16(r + 8);
-                    rd.met_counter = read_be16(r + 10);
-                    rd.status_flag = r[12];
-                    rd.mode = r[13];
-                    rd.mode2 = r[14];
-                    rd.coarse_time = ct;
-                    rd.fine_time = ft;
-                    rd.checksum_ok = csum_ok;
-                    out.push_back(rd);
-                }
-            }
-
-            void decode_particle_frame(const uint8_t *payload, size_t len,
-                                       uint32_t ct, uint8_t ft, uint8_t data_fill,
-                                       bool csum_ok, std::vector<ParticleReading> &out)
-            {
-                for (int i = 0; i < PARTICLE_READINGS_PER_FRAME; i++)
-                {
-                    size_t off = i * PARTICLE_READING_LEN;
-                    if (off + PARTICLE_READING_LEN > len)
-                        break;
-                    const uint8_t *r = payload + off;
-
-                    if (r[0] != PARTICLE_MARKER_A0 && r[0] != PARTICLE_MARKER_A1)
-                        continue;
-                    if (is_fill_data(r, PARTICLE_READING_LEN, data_fill))
-                        continue;
-
-                    ParticleReading rd{};
-                    rd.sub_type = r[1];
-                    rd.counter = r[2];
-                    for (int ch = 0; ch < PARTICLE_CHANNELS; ch++)
-                        rd.channels[ch] = read_be16(r + 3 + ch * 2);
-                    rd.coarse_time = ct;
-                    rd.fine_time = ft;
-                    rd.checksum_ok = csum_ok;
-                    out.push_back(rd);
-                }
-            }
-
-            void decode_subpacket_69(const uint8_t *payload, size_t len,
-                                     uint8_t marker_hi,
-                                     uint32_t ct, uint8_t ft, uint8_t data_fill,
-                                     bool csum_ok, std::vector<SubPacket> &out)
-            {
-                constexpr int PKT_SIZE = 69;
-                const size_t offsets[] = {0, 69, 138};
-
-                for (int p = 0; p < 3; p++)
-                {
-                    if (offsets[p] + PKT_SIZE > len)
-                        break;
-                    const uint8_t *r = payload + offsets[p];
-
-                    if (r[0] != marker_hi)
-                        continue;
-                    if (is_fill_data(r, PKT_SIZE, data_fill))
-                        continue;
-
-                    SubPacket pkt{};
-                    pkt.seq = r[2];
-                    pkt.coarse_time = ct;
-                    pkt.fine_time = ft;
-                    pkt.checksum_ok = csum_ok;
-
-                    const uint8_t *data = r + 3;
-                    int data_len = 65;
-                    for (int ch = 0; ch + 1 < data_len; ch += 2)
-                        pkt.channels.push_back(static_cast<int32_t>(read_be16(data + ch)));
-
-                    out.push_back(std::move(pkt));
-                }
-            }
-
-            void decode_housekeeping_12(const uint8_t *payload, size_t len,
-                                        uint8_t marker_byte,
-                                        uint32_t ct, uint8_t ft, uint8_t data_fill,
-                                        bool csum_ok, std::vector<SubPacket> &out)
-            {
-                constexpr int BLK_SIZE = 12;
-                size_t off = 0;
-
-                while (off + BLK_SIZE <= len)
-                {
-                    const uint8_t *r = payload + off;
-
-                    if (r[0] != marker_byte)
-                    {
-                        off++;
-                        continue;
-                    }
-                    if (is_fill_data(r, BLK_SIZE, data_fill))
-                    {
-                        off += BLK_SIZE;
-                        continue;
-                    }
-
-                    SubPacket pkt{};
-                    pkt.seq = r[1];
-                    pkt.coarse_time = ct;
-                    pkt.fine_time = ft;
-                    pkt.checksum_ok = csum_ok;
-
-                    for (int ch = 0; ch < 5; ch++)
-                        pkt.channels.push_back(static_cast<int32_t>(read_be16(r + 2 + ch * 2)));
-
-                    out.push_back(std::move(pkt));
-                    off += BLK_SIZE;
-                }
-            }
-
-            void decode_spectral(const uint8_t *payload, size_t len,
-                                 uint8_t marker,
-                                 uint32_t ct, uint8_t ft, uint8_t data_fill,
-                                 bool csum_ok, std::vector<SubPacket> &out)
-            {
-                size_t off = 0;
-
-                while (off < len && off + SPECTRAL_MIN_PACKET_BYTES <= len)
-                {
-                    if (payload[off] != marker)
-                    {
-                        off++;
-                        continue;
-                    }
-
-                    // Find next marker (minimum distance = SPECTRAL_MIN_PACKET_BYTES)
-                    size_t next = off + SPECTRAL_MIN_PACKET_BYTES;
-                    while (next < len && payload[next] != marker)
-                        next++;
-                    size_t end = (next < len) ? next : len;
-
-                    // Strip trailing fill bytes
-                    size_t pkt_len = end - off;
-                    while (pkt_len > 3 && payload[off + pkt_len - 1] == data_fill)
-                        pkt_len--;
-
-                    size_t data_len = pkt_len - 3; // skip marker + type + seq
-                    if (pkt_len >= static_cast<size_t>(SPECTRAL_MIN_PACKET_BYTES) && (data_len % 2) == 0)
-                    {
-                        SubPacket pkt{};
-                        pkt.seq = payload[off + 2];
-                        pkt.coarse_time = ct;
-                        pkt.fine_time = ft;
-                        pkt.checksum_ok = csum_ok;
-
-                        const uint8_t *data = payload + off + 3;
-                        for (size_t ch = 0; ch + 1 < data_len; ch += 2)
-                            pkt.channels.push_back(static_cast<int32_t>(read_be16s(data + ch)));
-
-                        out.push_back(std::move(pkt));
-                        off = end;
-                    }
-                    else
-                    {
-                        off++;
-                    }
-                }
-            }
-
             CounterGapInfo analyze_counter_gaps(const std::vector<uint16_t> &counters)
             {
                 CounterGapInfo info{static_cast<int>(counters.size()), 0, 0};
                 for (size_t i = 1; i < counters.size(); i++)
                 {
                     int diff = (counters[i] - counters[i - 1] + 65536) % 65536;
-                    if (diff > 1 && diff < 60000)
+                    if (diff > 1 && diff < COUNTER_GAP_WRAP_THRESHOLD)
                     {
                         info.gaps++;
                         info.missing_estimate += diff - 1;
@@ -210,8 +33,9 @@ namespace elektro_arktika
 
             /**
              * Fill small gaps (up to max_gap_frames missed frames) via linear
-             * interpolation.  Only suitable for slowly-varying quantities
-             * like magnetic field at GEO.
+             * interpolation. Only suitable for slowly-varying quantities
+             * like magnetic field at GEO orbit where changes between adjacent
+             * samples are small relative to the measurement range.
              */
             int interpolate_small_gaps(GGAKChannel &ch, double cadence, int max_gap_frames)
             {
@@ -253,368 +77,14 @@ namespace elektro_arktika
                 return filled;
             }
 
-            void write_magnetometer_csv(const std::vector<MagReading> &readings,
-                                        const std::string &path)
+            GGAKChannel make_subpkt_avg(const char *name, const char *unit, const char *group,
+                                        const std::vector<SubPacket> &data)
             {
-                std::ofstream f(path);
-                if (!f.is_open())
-                    return;
-
-                f << "timestamp,elapsed_s,"
-                     "mag_total_raw,mag_x_raw,mag_y_raw,mag_z_raw,"
-                     "B_total_nT,Bx_nT,By_nT,Bz_nT,"
-                     "voltage_raw,voltage_V,met_counter,"
-                     "status,mode,mode2,activity_level,activity_label,"
-                     "checksum_ok\n";
-
-                char ts[32];
-                for (auto &r : readings)
-                {
-                    if (!r.is_valid())
-                        continue;
-                    double es = r.elapsed_seconds();
-                    format_timestamp(es, ts, sizeof(ts));
-
-                    f << ts << "," << std::fixed;
-                    f.precision(1);
-                    f << es << ",";
-                    f << r.mag_total_raw << "," << r.mag_x_raw << ","
-                      << r.mag_y_raw << "," << r.mag_z_raw << ",";
-                    f.precision(2);
-                    f << r.mag_total_nt() << "," << r.mag_x_nt() << ","
-                      << r.mag_y_nt() << "," << r.mag_z_nt() << ",";
-                    f << r.voltage_raw << ",";
-                    f.precision(2);
-                    f << r.voltage() << ",";
-                    f << r.met_counter << ",";
-                    f << (int)r.status_flag << "," << (int)r.mode << "," << (int)r.mode2 << ",";
-                    f << r.activity_level() << "," << r.activity_label() << ","
-                      << (r.checksum_ok ? 1 : 0) << "\n";
-                }
-            }
-
-            void write_particle_csv(const std::vector<ParticleReading> &readings,
-                                    const std::string &path)
-            {
-                std::ofstream f(path);
-                if (!f.is_open())
-                    return;
-
-                f << "timestamp,elapsed_s,sub_type,counter";
-                for (int i = 0; i < PARTICLE_CHANNELS; i++)
-                    f << ",ch_" << (i + 1);
-                f << ",checksum_ok\n";
-
-                char ts[32];
-                for (auto &r : readings)
-                {
-                    double es = r.elapsed_seconds();
-                    format_timestamp(es, ts, sizeof(ts));
-
-                    f << ts << "," << std::fixed;
-                    f.precision(1);
-                    f << es << ",0x";
-
-                    // sub_type as hex
-                    char hex[8];
-                    std::snprintf(hex, sizeof(hex), "%02X", r.sub_type);
-                    f << hex << "," << (int)r.counter;
-
-                    for (int i = 0; i < PARTICLE_CHANNELS; i++)
-                        f << "," << r.channels[i];
-                    f << "," << (r.checksum_ok ? 1 : 0) << "\n";
-                }
-            }
-
-            void write_subpacket_csv(const std::vector<SubPacket> &packets,
-                                     const std::string &path)
-            {
-                if (packets.empty())
-                    return;
-
-                std::ofstream f(path);
-                if (!f.is_open())
-                    return;
-
-                int max_ch = 0;
-                for (auto &p : packets)
-                    if (static_cast<int>(p.channels.size()) > max_ch)
-                        max_ch = static_cast<int>(p.channels.size());
-
-                f << "timestamp,elapsed_s,seq";
-                for (int i = 0; i < max_ch; i++)
-                    f << ",ch_" << (i + 1);
-                f << ",checksum_ok\n";
-
-                char ts[32];
-                for (auto &p : packets)
-                {
-                    double es = p.elapsed_seconds();
-                    format_timestamp(es, ts, sizeof(ts));
-
-                    f << ts << "," << std::fixed;
-                    f.precision(1);
-                    f << es << "," << (int)p.seq;
-
-                    for (size_t i = 0; i < static_cast<size_t>(max_ch); i++)
-                    {
-                        f << ",";
-                        if (i < p.channels.size())
-                            f << p.channels[i];
-                        else
-                            f << "0";
-                    }
-                    f << "," << (p.checksum_ok ? 1 : 0) << "\n";
-                }
-            }
-        } // anonymous namespace
-
-        void GGAKDecoderModule::process()
-        {
-            std::string directory = d_output_file_hint.substr(0, d_output_file_hint.rfind('/')) + "/GGAK";
-
-            if (!std::filesystem::exists(directory))
-                std::filesystem::create_directories(directory);
-
-            logger->info("Processing GGAK space environment data...");
-
-            uint8_t cadu[CADU_SIZE];
-
-            int prev_coarse_time = -1;
-            uint32_t coarse_time_offset = 0;
-
-            while (should_run())
-            {
-                read_data(cadu, CADU_SIZE);
-                total_frames++;
-
-                // Checksum verification
-                bool csum_ok = validate_checksum(cadu);
-                if (csum_ok)
-                    checksum_pass++;
-                else
-                    checksum_fail++;
-
-                GGAKFrameHeader hdr = parse_header(cadu);
-                frame_counts[hdr.frame_type]++;
-
-                if (is_fill_frame(hdr.frame_type))
-                {
-                    fill_frames++;
-                    ui_total_frames.store(total_frames, std::memory_order_relaxed);
-                    ui_fill_frames.store(fill_frames, std::memory_order_relaxed);
-                    continue;
-                }
-
-                // Auto-detect BND generation from first data frame
-                if (!profile_detected)
-                {
-                    if (hdr.source_id == 0x30)
-                        sat_profile = PROFILE_BND_E;
-                    else
-                        sat_profile = PROFILE_BND_VE;
-                    profile_detected = true;
-                    logger->info("Detected: %s (source_id=0x%02X)", sat_profile.name, sat_profile.source_id);
-                }
-
-                // Track 16-bit coarse_time wraparound (~193 day period)
-                if (prev_coarse_time >= 0 && (prev_coarse_time - static_cast<int>(hdr.coarse_time)) > 50000)
-                    coarse_time_offset += 65536;
-                prev_coarse_time = hdr.coarse_time;
-
-                master_counters.push_back(hdr.master_counter);
-                channel_counters[hdr.frame_type].push_back(hdr.channel_counter);
-
-                uint32_t ct = hdr.coarse_time + coarse_time_offset;
-                uint8_t ft = hdr.fine_time;
-                uint8_t data_fill = sat_profile.data_fill_byte;
-
-                // Payload region: bytes 13..221 of the CADU (after ASM + header)
-                const uint8_t *payload = cadu + PAYLOAD_OFFSET;
-
-                switch (hdr.frame_type)
-                {
-                case 0x70:
-                    decode_magnetometer_frame(payload, PAYLOAD_SIZE, ct, ft, data_fill, csum_ok, mag_readings);
-                    break;
-                case 0x40:
-                    decode_particle_frame(payload, PAYLOAD_SIZE, ct, ft, data_fill, csum_ok, particle_readings);
-                    break;
-                case 0x20:
-                    decode_subpacket_69(payload, PAYLOAD_SIZE, 0x90, ct, ft, data_fill, csum_ok, subpackets_20);
-                    break;
-                case 0x30:
-                    decode_subpacket_69(payload, PAYLOAD_SIZE, 0x98, ct, ft, data_fill, csum_ok, subpackets_30);
-                    break;
-                case 0x50:
-                    decode_spectral(payload, PAYLOAD_SIZE, SPECTRAL_CAL_MARKER, ct, ft, data_fill, csum_ok, subpackets_5c);
-                    break;
-                case 0x5C:
-                    decode_spectral(payload, PAYLOAD_SIZE, SPECTRAL_MARKER, ct, ft, data_fill, csum_ok, subpackets_5c);
-                    break;
-                case 0x00:
-                    decode_housekeeping_12(payload, PAYLOAD_SIZE, 0x80, ct, ft, data_fill, csum_ok, subpackets_00);
-                    break;
-                case 0x10:
-                    decode_housekeeping_12(payload, PAYLOAD_SIZE, 0x88, ct, ft, data_fill, csum_ok, subpackets_10);
-                    break;
-                default:
-                    break;
-                }
-
-                ui_total_frames.store(total_frames, std::memory_order_relaxed);
-                ui_fill_frames.store(fill_frames, std::memory_order_relaxed);
-                ui_mag_count.store((int)mag_readings.size(), std::memory_order_relaxed);
-                ui_particle_count.store((int)particle_readings.size(), std::memory_order_relaxed);
-                ui_subpackets_20_count.store((int)subpackets_20.size(), std::memory_order_relaxed);
-                ui_subpackets_30_count.store((int)subpackets_30.size(), std::memory_order_relaxed);
-                ui_subpackets_5c_count.store((int)subpackets_5c.size(), std::memory_order_relaxed);
-                ui_subpackets_00_count.store((int)subpackets_00.size(), std::memory_order_relaxed);
-                ui_subpackets_10_count.store((int)subpackets_10.size(), std::memory_order_relaxed);
-            }
-
-            cleanup();
-
-            auto by_time = [](const auto &a, const auto &b) {
-                return a.elapsed_seconds() < b.elapsed_seconds();
-            };
-            std::sort(mag_readings.begin(), mag_readings.end(), by_time);
-            std::sort(particle_readings.begin(), particle_readings.end(), by_time);
-            std::sort(subpackets_20.begin(), subpackets_20.end(), by_time);
-            std::sort(subpackets_30.begin(), subpackets_30.end(), by_time);
-            std::sort(subpackets_5c.begin(), subpackets_5c.end(), by_time);
-            std::sort(subpackets_00.begin(), subpackets_00.end(), by_time);
-            std::sort(subpackets_10.begin(), subpackets_10.end(), by_time);
-
-            logger->info("----------- GGAK %s", sat_profile.name);
-            logger->info("Total frames        : %d (%d data, %d fill)", total_frames,
-                         total_frames - fill_frames, fill_frames);
-            logger->info("Checksum            : %d pass / %d fail", checksum_pass, checksum_fail);
-            logger->info("FM-VE readings      : %zu", mag_readings.size());
-            logger->info("GALS-VE+MIP readings: %zu", particle_readings.size());
-            logger->info("SKIF-VE/V ESA pkts  : %zu", subpackets_20.size());
-            logger->info("SKIF-VE/G ESA pkts  : %zu", subpackets_30.size());
-            logger->info("SKL-E spectral pkts : %zu", subpackets_5c.size());
-            logger->info("Housekeeping-A pkts : %zu", subpackets_00.size());
-            logger->info("SKIF-VE SER pkts    : %zu", subpackets_10.size());
-
-            CounterGapInfo gap_info = analyze_counter_gaps(master_counters);
-            if (gap_info.gaps > 0)
-                logger->warn("Counter gaps: %d (est. %d frames missing)", gap_info.gaps, gap_info.missing_estimate);
-
-            std::map<std::string, int> per_inst_gaps, per_inst_missing;
-            for (auto &[ft_key, counters] : channel_counters)
-            {
-                CounterGapInfo ci = analyze_counter_gaps(counters);
-                if (ci.gaps > 0)
-                {
-                    std::string name = frame_type_name(ft_key);
-                    per_inst_gaps[name] = ci.gaps;
-                    per_inst_missing[name] = ci.missing_estimate;
-                    logger->warn("  %s channel gaps: %d (est. %d missing)", name.c_str(), ci.gaps, ci.missing_estimate);
-                }
-            }
-
-            for (int i = 0; i < STATUS_COUNT; i++)
-                inst_status[i] = SAVING;
-            inst_status[STATUS_BND] = DONE;
-
-            logger->info("Writing GGAK CSV and metadata...");
-
-            write_magnetometer_csv(mag_readings, directory + "/magnetometer.csv");
-            inst_status[STATUS_MAG] = DONE;
-
-            write_particle_csv(particle_readings, directory + "/particles.csv");
-            inst_status[STATUS_PARTICLES] = DONE;
-
-            write_subpacket_csv(subpackets_20, directory + "/skif_v_esa.csv");
-            write_subpacket_csv(subpackets_30, directory + "/skif_g_esa.csv");
-            inst_status[STATUS_SKIF_ESA] = DONE;
-
-            write_subpacket_csv(subpackets_5c, directory + "/skl_spectral.csv");
-            inst_status[STATUS_SKL] = DONE;
-
-            write_subpacket_csv(subpackets_00, directory + "/housekeeping.csv");
-            write_subpacket_csv(subpackets_10, directory + "/skif_ser.csv");
-            inst_status[STATUS_HK] = DONE;
-
-            GGAKProduct ggak_product;
-            ggak_product.instrument_name = "ggak";
-
-            {
-                constexpr int MAG_CH_COUNT = 5;
-                const char *mag_names[MAG_CH_COUNT] = {"|B|", "Bx", "By", "Bz", "Voltage"};
-                const char *mag_units[MAG_CH_COUNT] = {"nT", "nT", "nT", "nT", "V"};
-
-                ggak_product.mag_channels.resize(MAG_CH_COUNT);
-                for (int i = 0; i < MAG_CH_COUNT; i++)
-                {
-                    ggak_product.mag_channels[i].name = mag_names[i];
-                    ggak_product.mag_channels[i].unit = mag_units[i];
-                }
-
-                for (auto &r : mag_readings)
-                {
-                    if (!r.is_valid())
-                        continue;
-                    double t = r.elapsed_seconds();
-                    for (int i = 0; i < MAG_CH_COUNT; i++)
-                        ggak_product.mag_channels[i].timestamps.push_back(t);
-
-                    ggak_product.mag_channels[0].values.push_back(r.mag_total_nt());
-                    ggak_product.mag_channels[1].values.push_back(r.mag_x_nt());
-                    ggak_product.mag_channels[2].values.push_back(r.mag_y_nt());
-                    ggak_product.mag_channels[3].values.push_back(r.mag_z_nt());
-                    ggak_product.mag_channels[4].values.push_back(r.voltage());
-                }
-            }
-
-            if (d_parameters.value("interpolate_mag_gaps", false))
-            {
-                double mag_cadence = frame_cadence_seconds(0x70);
-                int total_filled = 0;
-                for (auto &ch : ggak_product.mag_channels)
-                    total_filled += interpolate_small_gaps(ch, mag_cadence, 2);
-                if (total_filled > 0)
-                    logger->info("Interpolated %d magnetometer gap samples", total_filled);
-            }
-
-            for (auto &ch : ggak_product.mag_channels)
-                ch.updateMinMax();
-
-            {
-                const char *particle_names[PARTICLE_CHANNELS] = {
-                    "Ep>=600MeV", "Ep>=800MeV", "Ep>=1100MeV",
-                    "Cg-1", "Cg-2", "Cg-3", "Cg-4", "MIP"};
-
-                ggak_product.particle_channels.resize(PARTICLE_CHANNELS);
-                for (int ch = 0; ch < PARTICLE_CHANNELS; ch++)
-                {
-                    ggak_product.particle_channels[ch].name = particle_names[ch];
-                    ggak_product.particle_channels[ch].unit = "Counts";
-                }
-
-                for (auto &r : particle_readings)
-                {
-                    double t = r.elapsed_seconds();
-                    for (int ch = 0; ch < PARTICLE_CHANNELS; ch++)
-                    {
-                        ggak_product.particle_channels[ch].timestamps.push_back(t);
-                        ggak_product.particle_channels[ch].values.push_back(static_cast<double>(r.channels[ch]));
-                    }
-                }
-
-                for (auto &ch : ggak_product.particle_channels)
-                    ch.updateMinMax();
-            }
-
-            auto make_subpkt_avg = [](const char *name, const char *unit, const char *group,
-                                      const std::vector<SubPacket> &data) -> GGAKChannel {
                 GGAKChannel gc;
                 gc.name = name;
                 gc.unit = unit;
                 gc.group = group;
-                for (auto &p : data)
+                for (const auto &p : data)
                 {
                     double avg = 0;
                     if (!p.channels.empty())
@@ -628,18 +98,19 @@ namespace elektro_arktika
                 }
                 gc.updateMinMax();
                 return gc;
-            };
+            }
 
-            auto make_subpkt_ch = [](const char *name, const char *unit, const char *group,
-                                     const std::vector<SubPacket> &data, int ch_idx,
-                                     double scale = 1.0) -> GGAKChannel {
+            GGAKChannel make_subpkt_ch(const char *name, const char *unit, const char *group,
+                                       const std::vector<SubPacket> &data, int ch_idx,
+                                       double scale = 1.0)
+            {
                 GGAKChannel gc;
                 gc.name = name;
                 gc.unit = unit;
                 gc.group = group;
-                for (auto &p : data)
+                for (const auto &p : data)
                 {
-                    if (ch_idx < (int)p.channels.size())
+                    if (ch_idx < static_cast<int>(p.channels.size()))
                     {
                         gc.timestamps.push_back(p.elapsed_seconds());
                         gc.values.push_back(p.channels[ch_idx] * scale);
@@ -647,103 +118,233 @@ namespace elektro_arktika
                 }
                 gc.updateMinMax();
                 return gc;
-            };
-
-            ggak_product.subpacket_channels.push_back(
-                make_subpkt_avg("SKIF-VE/V ESA (avg)", "counts", "SKIF-VE/V ESA", subpackets_20));
-            ggak_product.subpacket_channels.push_back(
-                make_subpkt_avg("SKIF-VE/G ESA (avg)", "counts", "SKIF-VE/G ESA", subpackets_30));
-            ggak_product.subpacket_channels.push_back(
-                make_subpkt_avg("SKL-E Spectral (avg)", "counts (signed)", "SKL-E Spectral", subpackets_5c));
-
-            ggak_product.subpacket_channels.push_back(
-                make_subpkt_ch("ISP-2M TSI", "W/m\xC2\xB2", "Housekeeping-A", subpackets_00, 2, 0.0331));
-            ggak_product.subpacket_channels.push_back(
-                make_subpkt_ch("BND-VE Thermal", "counts (14-bit)", "Housekeeping-A", subpackets_00, 1));
-            ggak_product.subpacket_channels.push_back(
-                make_subpkt_ch("HK Mux (ch_1)", "counts", "Housekeeping-A", subpackets_00, 0));
-
-            ggak_product.subpacket_channels.push_back(
-                make_subpkt_ch("SKIF-VE/V SER", "cts/frame", "SKIF-VE SER summary", subpackets_10, 2));
-            ggak_product.subpacket_channels.push_back(
-                make_subpkt_ch("SKIF-VE/G SER", "cts/frame", "SKIF-VE SER summary", subpackets_10, 4));
-
-            int valid_mag = ggak_product.mag_channels.empty()
-                                ? 0
-                                : (int)ggak_product.mag_channels[0].values.size();
-
-            nlohmann::json meta;
-            meta["instrument"] = "GGAK";
-            meta["generation"] = sat_profile.generation;
-            meta["satellite_name"] = sat_profile.name;
-            meta["source_id"] = sat_profile.source_id;
-            meta["total_frames"] = total_frames;
-            meta["data_frames"] = total_frames - fill_frames;
-            meta["fill_frames"] = fill_frames;
-            meta["checksum"] = {{"pass", checksum_pass}, {"fail", checksum_fail}};
-
-            nlohmann::json fc;
-            for (auto &[ft_key, count] : frame_counts)
-            {
-                char key[8];
-                std::snprintf(key, sizeof(key), "0x%02X", ft_key);
-                fc[key] = count;
             }
-            meta["frame_counts"] = fc;
 
-            meta["counter_analysis"] = {
-                {"total_frames", gap_info.total_frames},
-                {"gaps", gap_info.gaps},
-                {"missing_estimate", gap_info.missing_estimate}};
+            constexpr int SKIF_ESA_BINS = (SKIF_ESA_DATA_LEN - 1) / 2;
 
-            meta["timing"] = {
-                {"tick_rate_seconds", TIME_TICK_SECONDS},
-                {"fine_step_seconds", FINE_TIME_STEP},
-                {"capture_frames", total_frames}};
+            void make_subpkt_bins(const char *group,
+                                  const std::vector<SubPacket> &data,
+                                  std::vector<GGAKChannel> &out)
+            {
+                for (int b = 0; b < SKIF_ESA_BINS; b++)
+                {
+                    GGAKChannel gc;
+                    gc.group = group;
+                    gc.unit = "counts";
+                    char name_buf[32];
+                    if (b < SKIF_VE_ESA_STEPS)
+                        std::snprintf(name_buf, sizeof(name_buf), "%.2g keV", SKIF_VE_ESA_ENERGIES_KEV[b]);
+                    else
+                        std::snprintf(name_buf, sizeof(name_buf), "bin %d", b + 1);
+                    gc.name = name_buf;
 
-            meta["magnetometer"] = {
-                {"total_readings", (int)mag_readings.size()},
-                {"valid_readings", valid_mag},
-                {"calibration", {{"adc_offset", MAG_ADC_OFFSET}, {"scale_nT_per_count", MAG_SCALE}, {"formula", "nT = (raw - 2339) * 2.359"}}}};
+                    for (const auto &p : data)
+                    {
+                        if (b < static_cast<int>(p.channels.size()))
+                        {
+                            gc.timestamps.push_back(p.elapsed_seconds());
+                            gc.values.push_back(static_cast<double>(p.channels[b]));
+                        }
+                    }
+                    gc.updateMinMax();
+                    out.push_back(std::move(gc));
+                }
+            }
+        } // anonymous namespace
 
-            meta["particles"] = {
-                {"total_readings", (int)particle_readings.size()},
-                {"channels", PARTICLE_CHANNELS},
-                {"channel_mapping", {{"ch_1", "GALS-VE/-CH Ep >= 600 MeV"}, {"ch_2", "GALS-VE/-CH Ep >= 800 MeV"}, {"ch_3", "GALS-VE/-CH Ep >= 1100 MeV"}, {"ch_4", "GALS-VE/-S Cg-1 Ee > 0.15 MeV, Ep > 5 MeV"}, {"ch_5", "GALS-VE/-S Cg-2 Ee > 0.7 MeV, Ep > 15 MeV"}, {"ch_6", "GALS-VE/-S Cg-3 Ee > 1.7 MeV, Ep > 25 MeV"}, {"ch_7", "GALS-VE/-S Cg-4 Ee > 3.2 MeV, Ep > 40 MeV"}, {"ch_8", "SKIF-VE MIP Ep > 15 MeV, Ee > 800 keV"}}}};
+        void GGAKDecoderModule::refreshUiCounters()
+        {
+            ui_total_frames.store(reader.total_frames, std::memory_order_relaxed);
+            ui_fill_frames.store(reader.fill_frames, std::memory_order_relaxed);
+            ui_mag_count.store(static_cast<int>(reader.mag_readings.size()), std::memory_order_relaxed);
+            ui_particle_count.store(static_cast<int>(reader.particle_readings.size()), std::memory_order_relaxed);
+            ui_subpackets_20_count.store(static_cast<int>(reader.subpackets_20.size()), std::memory_order_relaxed);
+            ui_subpackets_30_count.store(static_cast<int>(reader.subpackets_30.size()), std::memory_order_relaxed);
+            ui_subpackets_5c_count.store(static_cast<int>(reader.subpackets_5c.size()), std::memory_order_relaxed);
+            ui_subpackets_00_count.store(static_cast<int>(reader.subpackets_00.size()), std::memory_order_relaxed);
+            ui_subpackets_10_count.store(static_cast<int>(reader.subpackets_10.size()), std::memory_order_relaxed);
+        }
 
-            meta["subpackets"] = {
-                {"skif_ve_v_esa", (int)subpackets_20.size()},
-                {"skif_ve_g_esa", (int)subpackets_30.size()},
-                {"skl_e_spectral", (int)subpackets_5c.size()},
-                {"housekeeping_a", (int)subpackets_00.size()},
-                {"skif_ve_ser", (int)subpackets_10.size()}};
+        void GGAKDecoderModule::decodeFrames()
+        {
+            uint8_t cadu[CADU_SIZE];
 
-            saveJsonFile(directory + "/metadata.json", meta);
+            while (should_run())
+            {
+                read_data(cadu, CADU_SIZE);
+                reader.pushFrame(cadu);
 
-            ggak_product.stats.total_frames = total_frames;
-            ggak_product.stats.data_frames = total_frames - fill_frames;
-            ggak_product.stats.fill_frames = fill_frames;
-            ggak_product.stats.checksum_pass = checksum_pass;
-            ggak_product.stats.checksum_fail = checksum_fail;
-            ggak_product.stats.counter_gaps = gap_info.gaps;
-            ggak_product.stats.missing_estimate = gap_info.missing_estimate;
-            ggak_product.stats.generation = sat_profile.generation;
-            ggak_product.stats.satellite_name = sat_profile.name;
-            ggak_product.stats.per_instrument_gaps = per_inst_gaps;
-            ggak_product.stats.per_instrument_missing = per_inst_missing;
+                if ((reader.total_frames & 0x3F) == 0)
+                    refreshUiCounters();
+            }
 
-            ggak_product.set_product_source(sat_profile.name);
+            refreshUiCounters();
+
+            cleanup();
+            reader.sortAll();
+        }
+
+        void GGAKDecoderModule::logSummary()
+        {
+            logger->info("----------- GGAK %s", reader.sat_profile.name);
+            logger->info("Total frames        : %d (%d data, %d fill)", reader.total_frames,
+                         reader.total_frames - reader.fill_frames, reader.fill_frames);
+            logger->info("Checksum            : %d pass / %d fail", reader.checksum_pass, reader.checksum_fail);
+            logger->info("FM-VE readings      : %zu", reader.mag_readings.size());
+            logger->info("GALS-VE+MIP readings: %zu", reader.particle_readings.size());
+            logger->info("SKIF-VE/V ESA pkts  : %zu", reader.subpackets_20.size());
+            logger->info("SKIF-VE/G ESA pkts  : %zu", reader.subpackets_30.size());
+            logger->info("SKL-E spectral pkts : %zu", reader.subpackets_5c.size());
+            logger->info("Housekeeping-A pkts : %zu", reader.subpackets_00.size());
+            logger->info("SKIF-VE SER pkts    : %zu", reader.subpackets_10.size());
+
+            master_gap_info = analyze_counter_gaps(reader.master_counters);
+            if (master_gap_info.gaps > 0)
+                logger->warn("Counter gaps: %d (est. %d frames missing)",
+                             master_gap_info.gaps, master_gap_info.missing_estimate);
+
+            for (auto &[ft_key, counters] : reader.channel_counters)
+            {
+                CounterGapInfo ci = analyze_counter_gaps(counters);
+                if (ci.gaps > 0)
+                {
+                    std::string name = frame_type_name(ft_key);
+                    per_inst_gaps[name] = ci.gaps;
+                    per_inst_missing[name] = ci.missing_estimate;
+                    logger->warn("  %s channel gaps: %d (est. %d missing)", name.c_str(), ci.gaps, ci.missing_estimate);
+                }
+            }
+        }
+
+        void GGAKDecoderModule::buildProduct(GGAKProduct &product)
+        {
+            product.mag_channels.clear();
+            product.particle_channels.clear();
+            product.subpacket_channels.clear();
+            product.stats = {};
+            product.instrument_name = "ggak";
+
+            {
+                constexpr int MAG_CH_COUNT = 5;
+                const char *mag_names[MAG_CH_COUNT] = {"|B|", "Bx", "By", "Bz", "Voltage"};
+                const char *mag_units[MAG_CH_COUNT] = {"nT", "nT", "nT", "nT", "V"};
+
+                product.mag_channels.resize(MAG_CH_COUNT);
+                for (int i = 0; i < MAG_CH_COUNT; i++)
+                {
+                    product.mag_channels[i].name = mag_names[i];
+                    product.mag_channels[i].unit = mag_units[i];
+                }
+
+                for (const auto &r : reader.mag_readings)
+                {
+                    if (!r.is_valid())
+                        continue;
+                    double t = r.elapsed_seconds();
+                    for (int i = 0; i < MAG_CH_COUNT; i++)
+                        product.mag_channels[i].timestamps.push_back(t);
+
+                    product.mag_channels[0].values.push_back(r.mag_total_nt());
+                    product.mag_channels[1].values.push_back(r.mag_x_nt());
+                    product.mag_channels[2].values.push_back(r.mag_y_nt());
+                    product.mag_channels[3].values.push_back(r.mag_z_nt());
+                    product.mag_channels[4].values.push_back(r.voltage());
+                }
+            }
+
+            if (d_parameters.value("interpolate_mag_gaps", false))
+            {
+                double mag_cadence = frame_cadence_seconds(0x70);
+                int total_filled = 0;
+                for (auto &ch : product.mag_channels)
+                    total_filled += interpolate_small_gaps(ch, mag_cadence, 2);
+                if (total_filled > 0)
+                    logger->info("Interpolated %d magnetometer gap samples", total_filled);
+            }
+
+            for (auto &ch : product.mag_channels)
+                ch.updateMinMax();
+
+            {
+                const char *particle_names[PARTICLE_CHANNELS] = {
+                    "Ep>=600MeV", "Ep>=800MeV", "Ep>=1100MeV",
+                    "Cg-1", "Cg-2", "Cg-3", "Cg-4", "MIP"};
+
+                product.particle_channels.resize(PARTICLE_CHANNELS);
+                for (int ch = 0; ch < PARTICLE_CHANNELS; ch++)
+                {
+                    product.particle_channels[ch].name = particle_names[ch];
+                    product.particle_channels[ch].unit = "Counts";
+                }
+
+                for (const auto &r : reader.particle_readings)
+                {
+                    double t = r.elapsed_seconds();
+                    for (int ch = 0; ch < PARTICLE_CHANNELS; ch++)
+                    {
+                        product.particle_channels[ch].timestamps.push_back(t);
+                        product.particle_channels[ch].values.push_back(static_cast<double>(r.channels[ch]));
+                    }
+                }
+
+                for (auto &ch : product.particle_channels)
+                    ch.updateMinMax();
+            }
+
+            make_subpkt_bins("SKIF-VE/V ESA", reader.subpackets_20, product.subpacket_channels);
+            make_subpkt_bins("SKIF-VE/G ESA", reader.subpackets_30, product.subpacket_channels);
+            product.subpacket_channels.push_back(
+                make_subpkt_avg("SKL-E Spectral (avg)", "counts (signed)", "SKL-E Spectral", reader.subpackets_5c));
+
+            product.subpacket_channels.push_back(
+                make_subpkt_ch("ISP-2M TSI", "W/m\xC2\xB2", "Housekeeping-A", reader.subpackets_00, 2, 0.0331));
+            product.subpacket_channels.push_back(
+                make_subpkt_ch("BND-VE Thermal", "counts (14-bit)", "Housekeeping-A", reader.subpackets_00, 1));
+            product.subpacket_channels.push_back(
+                make_subpkt_ch("HK Mux (ch_1)", "counts", "Housekeeping-A", reader.subpackets_00, 0));
+
+            product.subpacket_channels.push_back(
+                make_subpkt_ch("SKIF-VE/V SER", "cts/frame", "SKIF-VE SER summary", reader.subpackets_10, 2));
+            product.subpacket_channels.push_back(
+                make_subpkt_ch("SKIF-VE/G SER", "cts/frame", "SKIF-VE SER summary", reader.subpackets_10, 4));
+
+            product.stats.total_frames = reader.total_frames;
+            product.stats.data_frames = reader.total_frames - reader.fill_frames;
+            product.stats.fill_frames = reader.fill_frames;
+            product.stats.checksum_pass = reader.checksum_pass;
+            product.stats.checksum_fail = reader.checksum_fail;
+            product.stats.counter_gaps = master_gap_info.gaps;
+            product.stats.missing_estimate = master_gap_info.missing_estimate;
+            product.stats.generation = reader.sat_profile.generation;
+            product.stats.satellite_name = reader.sat_profile.name;
+            product.stats.observed_source_id = reader.observed_source_id;
+            product.stats.per_instrument_gaps = per_inst_gaps;
+            product.stats.per_instrument_missing = per_inst_missing;
+        }
+
+        void GGAKDecoderModule::process()
+        {
+            std::string directory = d_output_file_hint.substr(0, d_output_file_hint.rfind('/')) + "/GGAK";
+
+            if (!std::filesystem::exists(directory))
+                std::filesystem::create_directories(directory);
+
+            logger->info("Processing GGAK space environment data...");
+
+            decodeFrames();
+            logSummary();
+            
+            for (int i = 0; i < STATUS_COUNT; i++)
+                inst_status[i] = DONE;
+
+            GGAKProduct ggak_product;
+            buildProduct(ggak_product);
+            ggak_product.set_product_source(reader.sat_profile.name);
             ggak_product.set_product_timestamp(time(0));
             ggak_product.save(directory);
 
-            std::string sat_name = "ELEKTRO-L";
-            if (sat_profile.source_id == 0x30)
-                sat_name = "ELEKTRO-L (GGAK-E)";
-            else
-                sat_name = "ELEKTRO-L (GGAK-VE)";
-
             satdump::products::DataSet dataset;
-            dataset.satellite_name = sat_name;
+            dataset.satellite_name = reader.sat_profile.name;
             dataset.timestamp = time(0);
             dataset.products_list.push_back("GGAK");
             dataset.save(d_output_file_hint.substr(0, d_output_file_hint.rfind('/')));

--- a/plugins/elektro_arktika_support/main.cpp
+++ b/plugins/elektro_arktika_support/main.cpp
@@ -2,6 +2,9 @@
 #include "logger.h"
 
 #include "elektro_arktika/instruments/msugs/module_msugs.h"
+#include "elektro_arktika/instruments/ggak/module_ggak.h"
+#include "elektro_arktika/instruments/ggak/ggak_product.h"
+#include "elektro_arktika/instruments/ggak/ggak_product_handler.h"
 #include "elektro_arktika/lrit/module_elektro_lrit_data_decoder.h"
 
 class ElektroArktikaSupport : public satdump::Plugin
@@ -9,12 +12,34 @@ class ElektroArktikaSupport : public satdump::Plugin
 public:
     std::string getID() { return "elektro_arktika_support"; }
 
-    void init() { satdump::eventBus->register_handler<satdump::pipeline::RegisterModulesEvent>(registerPluginsHandler); }
+    void init()
+    {
+        satdump::eventBus->register_handler<satdump::pipeline::RegisterModulesEvent>(registerPluginsHandler);
+        satdump::eventBus->register_handler<satdump::products::RegisterProductsEvent>(registerProductsHandler);
+        satdump::eventBus->register_handler<satdump::handlers::RequestProductHandlerEvent>(registerProductHandlerHandler);
+    }
 
     static void registerPluginsHandler(const satdump::pipeline::RegisterModulesEvent &evt)
     {
         REGISTER_MODULE_EXTERNAL(evt.modules_registry, elektro_arktika::msugs::MSUGSDecoderModule);
+        REGISTER_MODULE_EXTERNAL(evt.modules_registry, elektro_arktika::ggak::GGAKDecoderModule);
         REGISTER_MODULE_EXTERNAL(evt.modules_registry, elektro::lrit::ELEKTROLRITDataDecoderModule);
+    }
+
+    static void registerProductsHandler(const satdump::products::RegisterProductsEvent &evt)
+    {
+        evt.product_loaders.emplace("ggak", satdump::products::RegisteredProduct{
+            [](std::string file) -> std::shared_ptr<satdump::products::Product> {
+                auto product = std::make_shared<elektro_arktika::ggak::GGAKProduct>();
+                product->load(file);
+                return product;
+            }});
+    }
+
+    static void registerProductHandlerHandler(const satdump::handlers::RequestProductHandlerEvent &evt)
+    {
+        if (evt.product->type == "ggak")
+            evt.handler = std::make_shared<elektro_arktika::ggak::GGAKProductHandler>(evt.product, evt.dataset_mode);
     }
 };
 

--- a/resources/instrument_cfgs/ggak.json
+++ b/resources/instrument_cfgs/ggak.json
@@ -1,0 +1,5 @@
+{
+    "name": "GGAK",
+    "presets": [
+    ]
+}

--- a/resources/pipelines/Elektro_Arktika.json
+++ b/resources/pipelines/Elektro_Arktika.json
@@ -265,6 +265,7 @@
             "products": {
                 "module": "elektro_arktika_ggak",
                 "parameters": {
+                    "interpolate_mag_gaps": false
                 }
             }
         }
@@ -309,6 +310,7 @@
             "products": {
                 "module": "elektro_arktika_ggak",
                 "parameters": {
+                    "interpolate_mag_gaps": false
                 }
             }
         }
@@ -353,6 +355,7 @@
             "products": {
                 "module": "elektro_arktika_ggak",
                 "parameters": {
+                    "interpolate_mag_gaps": false
                 }
             }
         }

--- a/resources/pipelines/Elektro_Arktika.json
+++ b/resources/pipelines/Elektro_Arktika.json
@@ -229,7 +229,8 @@
         "name": "ELEKTRO-L GGAK",
         "live": [
             1,
-            2
+            2,
+            3
         ],
         "frequencies": [
             [
@@ -244,6 +245,9 @@
                 "module": "pm_demod",
                 "parameters": {
                     "symbolrate": 5e3,
+                    // PLL bandwidth trade-off: lower = less noise (fewer lost frames)
+                    // but slower tracking.  GEO has minimal Doppler so 0.01-0.02 is safe.
+                    // Try 0.01 if counter gaps are high; revert if lock is unstable.
                     "pll_bw": 0.02,
                     "rrc_alpha": 0.5
                 }
@@ -252,10 +256,16 @@
                 "module": "ccsds_simple_psk_decoder",
                 "parameters": {
                     "constellation": "bpsk",
-                    "cadu_size": 1792,
+                    "cadu_size": 1792, // 224 bytes
                     "derandomize": false,
                     "nrzm": false,
-                    "rs_i": 0
+                    "rs_i": 0 // no Reed-Solomon FEC; lost frames are unrecoverable
+                }
+            },
+            "products": {
+                "module": "elektro_arktika_ggak",
+                "parameters": {
+                    // "interpolate_mag_gaps": true  // fill 1-2 frame magnetometer gaps via linear interpolation
                 }
             }
         }
@@ -264,7 +274,8 @@
         "name": "ARKTIKA-M N°1 GGAK",
         "live": [
             1,
-            2
+            2,
+            3
         ],
         "frequencies": [
             [
@@ -282,6 +293,8 @@
                     "satellite_frequency": 1703e6,
                     "satellite_norad": 47719,
                     "symbolrate": 5e3,
+                    // HEO orbit has significant Doppler; keep pll_bw >= 0.02
+                    // for reliable tracking.  Narrowing risks losing lock.
                     "pll_bw": 0.02,
                     "rrc_alpha": 0.5
                 }
@@ -295,6 +308,12 @@
                     "nrzm": false,
                     "rs_i": 0
                 }
+            },
+            "products": {
+                "module": "elektro_arktika_ggak",
+                "parameters": {
+                    // "interpolate_mag_gaps": true
+                }
             }
         }
     },
@@ -302,7 +321,8 @@
         "name": "ARKTIKA-M N°2 GGAK",
         "live": [
             1,
-            2
+            2,
+            3
         ],
         "frequencies": [
             [
@@ -320,6 +340,7 @@
                     "satellite_frequency": 1703e6,
                     "satellite_norad": 58584,
                     "symbolrate": 5e3,
+                    // HEO orbit: keep pll_bw >= 0.02 for Doppler tracking
                     "pll_bw": 0.02,
                     "rrc_alpha": 0.5
                 }
@@ -332,6 +353,12 @@
                     "derandomize": false,
                     "nrzm": false,
                     "rs_i": 0
+                }
+            },
+            "products": {
+                "module": "elektro_arktika_ggak",
+                "parameters": {
+                    // "interpolate_mag_gaps": true
                 }
             }
         }

--- a/resources/pipelines/Elektro_Arktika.json
+++ b/resources/pipelines/Elektro_Arktika.json
@@ -256,16 +256,15 @@
                 "module": "ccsds_simple_psk_decoder",
                 "parameters": {
                     "constellation": "bpsk",
-                    "cadu_size": 1792, // 224 bytes
+                    "cadu_size": 1792,
                     "derandomize": false,
                     "nrzm": false,
-                    "rs_i": 0 // no Reed-Solomon FEC; lost frames are unrecoverable
+                    "rs_i": 0
                 }
             },
             "products": {
                 "module": "elektro_arktika_ggak",
                 "parameters": {
-                    // "interpolate_mag_gaps": true  // fill 1-2 frame magnetometer gaps via linear interpolation
                 }
             }
         }
@@ -293,8 +292,6 @@
                     "satellite_frequency": 1703e6,
                     "satellite_norad": 47719,
                     "symbolrate": 5e3,
-                    // HEO orbit has significant Doppler; keep pll_bw >= 0.02
-                    // for reliable tracking.  Narrowing risks losing lock.
                     "pll_bw": 0.02,
                     "rrc_alpha": 0.5
                 }
@@ -312,7 +309,6 @@
             "products": {
                 "module": "elektro_arktika_ggak",
                 "parameters": {
-                    // "interpolate_mag_gaps": true
                 }
             }
         }
@@ -340,7 +336,6 @@
                     "satellite_frequency": 1703e6,
                     "satellite_norad": 58584,
                     "symbolrate": 5e3,
-                    // HEO orbit: keep pll_bw >= 0.02 for Doppler tracking
                     "pll_bw": 0.02,
                     "rrc_alpha": 0.5
                 }
@@ -358,7 +353,6 @@
             "products": {
                 "module": "elektro_arktika_ggak",
                 "parameters": {
-                    // "interpolate_mag_gaps": true
                 }
             }
         }


### PR DESCRIPTION
Adds support for the GGAK space environment telemetry on Elektro-L and Arktika-M. This is the 5 kbps downlink @ 1693 MHz that carries magnetometer, particle detector, and spectrometer data. 

The frame format is a proprietary 224-byte CADU (4B sync + 9B header + 209B payload + 2B checksum) — not standard CCSDS, so it needs its own decoder. The source ID in the header distinguishes BND-E (older Elektro-L N°1/N°2, source 0x30) from BND-VE (N°3+ and Arktika-M, source 0x31), and the decoder auto-detects which generation it's looking at from the first data frame.

Decoded instruments:
- FM-VE fluxgate magnetometer (Bx/By/Bz/|B|, 13 readings per frame)
- GALS-VE particle detectors + SKIF-VE MIP (8 channels, 11 readings per frame)
- SKIF-VE ESA electron/ion energy sweeps (12 steps, 50 eV – 20 keV)
- SKL-E spectral dosimeter
- Housekeeping / ISP-2M solar irradiance

The product handler has ImPlot time-series plots with an overlay mode for the magnetometer and a summary view that shows geomagnetic activity level.

Not decoded: DIR-E (solar X-ray) and VUSS-E (solar UV Lyman-alpha) are physically mounted on the solar panel bracket and their telemetry doesn't appear in the BND-VE data stream at all — they seem to be routed separately. Frame type 0x60 (Housekeeping-B, BND-E only) is recognized but not fully parsed. One channel in the SKIF-VE SER summary frames (0x10 ch_1) is still unidentified. The SKL-E spectral sub-packets carry mostly uninitialized buffer noise.

Pipeline definitions added for ELEKTRO-L GGAK, ARKTIKA-M N°1 GGAK, and ARKTIKA-M N°2 GGAK. Tested with recorded baseband from Elektro-L N°5 and Elektro-L N°2. Support is guaranteed only for N°5 at this moment, since it has the more documented and newer GGAK-VE onboard.