### PR TITLE
Fix missing stdlib includes in projection sources

### DIFF
--- a/src-core/projection/standard/equirect.cpp
+++ b/src-core/projection/standard/equirect.cpp
@@ -1,5 +1,5 @@
 #include "equirect.h"
-
+#include <stdlib.h>
 namespace proj
 {
     namespace

--- a/src-core/projection/standard/geos.cpp
+++ b/src-core/projection/standard/geos.cpp
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include "geos.h"
 
 namespace proj

--- a/src-core/projection/standard/proj.cpp
+++ b/src-core/projection/standard/proj.cpp
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include "proj.h"
 
 #include "common/geodetic/wgs84.h"

--- a/src-core/projection/standard/stereo.cpp
+++ b/src-core/projection/standard/stereo.cpp
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include "stereo.h"
 
 namespace proj

--- a/src-core/projection/standard/tmerc.cpp
+++ b/src-core/projection/standard/tmerc.cpp
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include "tmerc.h"
 
 namespace proj

--- a/src-core/projection/standard/tpers.cpp
+++ b/src-core/projection/standard/tpers.cpp
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include "tpers.h"
 
 namespace proj

--- a/src-core/projection/standard/webmerc.cpp
+++ b/src-core/projection/standard/webmerc.cpp
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include "webmerc.h"
 
 namespace proj


### PR DESCRIPTION
This fixes Apple Clang build failures in several projection sources.

The affected files use malloc/free without including stdlib.h, causing errors such as:

  error: use of undeclared identifier 'malloc'
  error: use of undeclared identifier 'free'

I hit this while building SatDump on Apple Silicon macOS using the documented macOS build instructions.

This PR adds the required C standard library include to the affected projection sources.