### PR TITLE
Recorder: persist FFT/pipeline state on Stop, not only on destructor

### DIFF
--- a/src-interface/recorder/recorder_proc.cpp
+++ b/src-interface/recorder/recorder_proc.cpp
@@ -35,6 +35,13 @@ namespace satdump
 #if defined(BUILD_ZIQ) || defined(BUILD_ZIQ2)
         out["ziq_depth"] = baseband_format.ziq_depth;
 #endif
+
+        if (!pipeline_selector.selected_pipeline.id.empty())
+        {
+            out["live_pipeline_id"] = pipeline_selector.selected_pipeline.id;
+            out["live_pipeline_level"] = pipeline_selector.pipelines_levels_select_id;
+            out["live_pipeline_params"] = pipeline_selector.getParameters();
+        }
         return out;
     }
 
@@ -77,6 +84,15 @@ namespace satdump
         if (in.contains("ziq_depth"))
             baseband_format.ziq_depth = in["ziq_depth"];
 #endif
+
+        if (in.contains("live_pipeline_id") && !in["live_pipeline_id"].get<std::string>().empty())
+        {
+            pipeline_selector.select_pipeline(in["live_pipeline_id"].get<std::string>());
+            if (in.contains("live_pipeline_level"))
+                pipeline_selector.pipelines_levels_select_id = in["live_pipeline_level"].get<int>();
+            if (in.contains("live_pipeline_params"))
+                pipeline_selector.setParameters(in["live_pipeline_params"]);
+        }
     }
 
     void RecorderApplication::start()
@@ -134,6 +150,8 @@ namespace satdump
         rec_cfg[sources[sdr_select_id].name]["xconverter_frequency"] = xconverter_frequency;
         rec_cfg[sources[sdr_select_id].name]["decimation"] = current_decimation;
         db->set_user_json("recorder_sdr_settings", rec_cfg);
+
+        save_settings();
     }
 
     void RecorderApplication::try_load_sdr_settings()


### PR DESCRIPTION
## Problem

In the 2.0 recorder, panel settings made on the left side (not in the Settings window) don't reliably survive a restart:

- **`recorder_state`** (FFT size/rate, waterfall rate, palette, FFT min/max, avg num, baseband type) is written **only in `~RecorderApplication()`**. The destructor doesn't always complete on shutdown, so these revert to the previous DB value on the next launch.
- The **selected live pipeline and its parameters** (e.g. DC blocking) are **not serialized at all**, so they always reset.

SDR source settings (frequency, gain, samplerate, decimation, AGC, bias) already persist correctly because they're written in `stop()`.

## Changes

`src-interface/recorder/recorder_proc.cpp`:

1. **`serialize_config()`** — additionally stores `live_pipeline_id`, `live_pipeline_level` and `live_pipeline_params` (via `pipeline_selector.getParameters()`).
2. **`deserialize_config()`** — restores the selected pipeline, level and parameters (`select_pipeline()` → level → `setParameters()`), guarded on a non-empty id.
3. **`stop()`** — calls `save_settings()` after writing the SDR settings, so `recorder_state` is persisted when the device is stopped, decoupled from the destructor.

## Testing

1. Open the recorder, change palette / FFT min-max / avg num, pick a live pipeline and toggle a processing param (e.g. DC blocking).
2. Start the device, then press **Stop**.
3. Restart — the FFT/waterfall/palette settings and the pipeline selection + params are restored.

Verified via `sqlite3 ~/.config/satdump/main.db "SELECT val FROM user WHERE id='recorder_state';"` — the key now contains the live pipeline fields and the actual (non-default) FFT/palette values.