### PR TITLE
Added baseband processing ETA

### DIFF
--- a/src-core/pipeline/modules/demod/module_demod_base.cpp
+++ b/src-core/pipeline/modules/demod/module_demod_base.cpp
@@ -3,6 +3,7 @@
 #include "core/config.h"
 #include "imgui/imgui.h"
 #include "logger.h"
+#include <string>
 
 namespace satdump
 {
@@ -112,6 +113,9 @@ namespace satdump
 
                 if (d_dc_block)
                     dc_blocker = std::make_shared<dsp::CorrectIQBlock<complex_t>>(input_data_type == DATA_DSP_STREAM ? input_stream : file_source->output_stream);
+
+                // Mark start time for ETA
+                start_time = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
 
                 // Cleanup things a bit
                 std::shared_ptr<dsp::stream<complex_t>> input_data = d_dc_block ? dc_blocker->output_stream : (input_data_type == DATA_DSP_STREAM ? input_stream : file_source->output_stream);
@@ -291,7 +295,10 @@ namespace satdump
                 ImGui::EndGroup();
 
                 if (!d_is_streaming_input)
+                {
                     ImGui::ProgressBar((double)progress / (double)filesize, ImVec2(ImGui::GetContentRegionAvail().x, 20 * ui_scale));
+                    drawETA();
+                }
 
                 drawStopButton();
 
@@ -337,6 +344,60 @@ namespace satdump
 
                     ImGui::End();
                 }
+            }
+
+            /** @brief Used to render the ETA nicely
+             *
+             * @arg seconds Time to render as MM:SS or HH:MM:SS if we are at that point (DD seems excessive)
+             */
+            std::string render_eta_string(time_t seconds)
+            {
+                int h = seconds / 3600;
+                int m = (seconds % 3600) / 60;
+                int s = seconds % 60;
+
+                // this sucks why can't we have std::format in this household
+                char buf[16];
+                if (h > 0)
+                {
+                    std::snprintf(buf, sizeof(buf), "%02d:%02d:%02d", h, m, s);
+                }
+                else
+                {
+                    std::snprintf(buf, sizeof(buf), "%02d:%02d", m, s);
+                }
+
+                return buf;
+            }
+
+            void BaseDemodModule::drawETA()
+            {
+                time_t current_time = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+                time_t elapsed = current_time - start_time;
+
+                double progress_fraction = (double)progress / (double)filesize;
+                double current_eta = elapsed * (1.0 - progress_fraction) / progress_fraction;
+
+                std::string eta_str;
+                if (progress_fraction > 0.001 && elapsed > 0)
+                {
+                    if (averaged_eta < 0)
+                        averaged_eta = current_eta;
+                    else
+                        // Exponential mean average as it fluctuates more than the average Briton's BAC
+                        averaged_eta = 0.01 * current_eta + 0.99 * averaged_eta;
+
+                    eta_str = render_eta_string(averaged_eta);
+                }
+                else
+                {
+                    eta_str = "--:--";
+                }
+
+                ImGui::Text("Elapsed: %s | Estimated remaining: %s",
+                            render_eta_string(elapsed).c_str(), //
+                            eta_str.c_str()                     //
+                );
             }
 
             void BaseDemodModule::drawStopButton()

--- a/src-core/pipeline/modules/demod/module_demod_base.cpp
+++ b/src-core/pipeline/modules/demod/module_demod_base.cpp
@@ -3,7 +3,6 @@
 #include "core/config.h"
 #include "imgui/imgui.h"
 #include "logger.h"
-#include <string>
 
 namespace satdump
 {

--- a/src-core/pipeline/modules/demod/module_demod_base.cpp
+++ b/src-core/pipeline/modules/demod/module_demod_base.cpp
@@ -345,7 +345,7 @@ namespace satdump
                 }
             }
 
-            std::string render_eta_string(time_t seconds)
+            std::string BaseDemodModule::render_eta_string(time_t seconds)
             {
                 int h = seconds / 3600;
                 int m = (seconds % 3600) / 60;

--- a/src-core/pipeline/modules/demod/module_demod_base.cpp
+++ b/src-core/pipeline/modules/demod/module_demod_base.cpp
@@ -345,10 +345,6 @@ namespace satdump
                 }
             }
 
-            /** @brief Used to render the ETA nicely
-             *
-             * @arg seconds Time to render as MM:SS or HH:MM:SS if we are at that point (DD seems excessive)
-             */
             std::string render_eta_string(time_t seconds)
             {
                 int h = seconds / 3600;

--- a/src-core/pipeline/modules/demod/module_demod_base.h
+++ b/src-core/pipeline/modules/demod/module_demod_base.h
@@ -16,8 +16,10 @@
 #include "common/widgets/waterfall_plot.h"
 #include "pipeline/module.h"
 #include <atomic>
+#include <ctime>
 #include <fstream>
-#include <thread>
+#include <chrono>
+#include <locale>
 
 namespace satdump
 {
@@ -90,6 +92,10 @@ namespace satdump
 
                 bool showWaterfall = false;
                 void drawFFT();
+                
+                void drawETA();
+                time_t start_time;
+                double averaged_eta = -1;
 
                 // Util
                 int8_t clamp(float x)

--- a/src-core/pipeline/modules/demod/module_demod_base.h
+++ b/src-core/pipeline/modules/demod/module_demod_base.h
@@ -93,6 +93,11 @@ namespace satdump
                 bool showWaterfall = false;
                 void drawFFT();
                 
+                /** @brief Used to render the ETA nicely
+                *
+                * @param seconds Time to render as MM:SS or HH:MM:SS if we are at that point (DD seems excessive)
+                */
+                std::string render_eta_string(time_t seconds);
                 void drawETA();
                 time_t start_time;
                 double averaged_eta = -1;


### PR DESCRIPTION
Adds a neat little ETA below the progress bar when decoding basebands. SUPER useful for X-band, as it allows you to see if you have time to finish decoding before the next pass.
<img width="2868" height="1716" alt="image" src="https://github.com/user-attachments/assets/eaa81560-588d-433e-9feb-240a2910d0f4" />


note: Needs a scaling adjustment as there is dead space at the bottom, the demod window makes itself scrollable instead of using it. Don't know imgui well enough to adjust it myself, couldn't find it after looking for a while
<img width="1588" height="992" alt="image" src="https://github.com/user-attachments/assets/6f66bf8e-fd45-4ff9-88e9-0c700e3e3cb6" />
