### PR TITLE
fix: resolve thread safety issues and race conditions in core components

### DIFF
--- a/src-core/dsp/block.h
+++ b/src-core/dsp/block.h
@@ -171,12 +171,12 @@ namespace satdump
             void link(Block *ptr, int output_index, int input_index, int nbuf) { set_input(ptr->get_output(output_index, nbuf), input_index); }
 
         private:
-            bool blk_should_run;
+            std::atomic<bool> blk_should_run{false}; // atomic: read from run() thread, written from start()/stop()
             std::mutex blk_th_mtx;
             std::thread blk_th;
             void run()
             {
-                while (blk_should_run)
+                while (blk_should_run.load())
                     if (work())
                         break;
             }
@@ -186,7 +186,7 @@ namespace satdump
              * @brief Used to signal to a block it should exit in order
              * to stop(). Usually only needed in sources.
              */
-            bool work_should_exit;
+            std::atomic<bool> work_should_exit{false}; // atomic: checked from work() thread, set from stop()
 
             /**
              * @brief The actual looping work function meant to handle
@@ -201,7 +201,7 @@ namespace satdump
              * @brief Check if the work function is running.
              * @return true if running
              */
-            bool is_work_running() { return blk_should_run; }
+            bool is_work_running() { return blk_should_run.load(); }
 
         public:
             /**

--- a/src-core/dsp/displays/time_disp.cpp
+++ b/src-core/dsp/displays/time_disp.cpp
@@ -21,12 +21,22 @@ namespace satdump
 
             float *samples = iblk.getSamples<float>();
 
-            for (int i = 0; i < iblk.size; i++)
+            if (iblk.size > 0)
             {
-                time_history_mtx.lock();
-                time_history.erase(time_history.begin(), time_history.begin() + 1);
-                time_history.push_back(samples[i]);
-                time_history_mtx.unlock();
+                std::lock_guard<std::mutex> lock(time_history_mtx);
+                int history_size = time_history.size();
+                if (history_size > 0)
+                {
+                    if (iblk.size >= history_size)
+                    {
+                        std::copy(samples + iblk.size - history_size, samples + iblk.size, time_history.begin());
+                    }
+                    else
+                    {
+                        std::copy(time_history.begin() + iblk.size, time_history.end(), time_history.begin());
+                        std::copy(samples, samples + iblk.size, time_history.end() - iblk.size);
+                    }
+                }
             }
 
             inputs[0].fifo->free(iblk);
@@ -35,13 +45,12 @@ namespace satdump
 
         void TimeDisplayBlock::draw(ImVec2 size)
         {
-            time_history_mtx.lock();
+            std::lock_guard<std::mutex> lock(time_history_mtx);
             if (ImPlot::BeginPlot("TimeSeries", size))
             {
                 ImPlot::PlotScatter("Real", time_history.data(), time_history.size());
                 ImPlot::EndPlot();
             }
-            time_history_mtx.unlock();
         }
     } // namespace ndsp
 } // namespace satdump

--- a/src-core/dsp/legacy/module_wrapper.cpp
+++ b/src-core/dsp/legacy/module_wrapper.cpp
@@ -18,6 +18,7 @@ namespace satdump
 
         void ModuleWrapperBlock::start()
         {
+            stopped = false;
             mod = pipeline::getModuleInstance(module_id, "", "/tmp/modulewrapper", mod_cfg);
             mod->input_fifo = std::make_shared<dsp::RingBuffer<uint8_t>>(1000000);
             mod->output_fifo = std::make_shared<dsp::RingBuffer<uint8_t>>(1000000);
@@ -38,6 +39,11 @@ namespace satdump
         {
             Block::stop(stop_now, force);
 
+            std::lock_guard<std::mutex> lock(stop_mtx);
+            if (stopped)
+                return;
+            stopped = true;
+
             mod->input_active = false;
             mod->stop();
             work2shouldrun = false;
@@ -57,17 +63,24 @@ namespace satdump
 
             if (iblk.isTerminator())
             {
-                mod->input_active = false;
-                mod->stop();
-                work2shouldrun = false;
-                mod->output_fifo->stopReader();
-                mod->output_fifo->stopWriter();
-                mod->input_fifo->stopReader();
-                mod->input_fifo->stopWriter();
-                if (work2Thread.joinable())
-                    work2Thread.join();
-                if (modThread.joinable())
-                    modThread.join();
+                {
+                    std::lock_guard<std::mutex> lock(stop_mtx);
+                    if (!stopped)
+                    {
+                        stopped = true;
+                        mod->input_active = false;
+                        mod->stop();
+                        work2shouldrun = false;
+                        mod->output_fifo->stopReader();
+                        mod->output_fifo->stopWriter();
+                        mod->input_fifo->stopReader();
+                        mod->input_fifo->stopWriter();
+                        if (work2Thread.joinable())
+                            work2Thread.join();
+                        if (modThread.joinable())
+                            modThread.join();
+                    }
+                }
 
                 if (iblk.terminatorShouldPropagate())
                     outputs[0].fifo->wait_enqueue(outputs[0].fifo->newBufferTerminator());
@@ -99,6 +112,7 @@ namespace satdump
                 else
                 {
                     outputs[0].fifo->free(oblk);
+                    std::this_thread::sleep_for(std::chrono::milliseconds(1));
                 }
             }
         }

--- a/src-core/dsp/legacy/module_wrapper.h
+++ b/src-core/dsp/legacy/module_wrapper.h
@@ -20,6 +20,8 @@ namespace satdump
             std::thread modThread;
             bool work2shouldrun;
             std::thread work2Thread;
+            std::mutex stop_mtx;
+            bool stopped = false;
 
             int output_read_size = 1024;
 

--- a/src-core/dsp/path/splitter.cpp
+++ b/src-core/dsp/path/splitter.cpp
@@ -26,30 +26,43 @@ namespace satdump
             {
                 if (iblk.terminatorShouldPropagate())
                 {
-                    vfos_mtx.lock();
-                    for (auto &o : outputs)
+                    // Snapshot outputs under lock to avoid deadlock:
+                    // wait_enqueue() can block if FIFO is full, and del_output()
+                    // also tries to acquire vfos_mtx → would deadlock.
+                    std::vector<BlockIO> outputs_snapshot;
+                    {
+                        std::lock_guard<std::mutex> lock(vfos_mtx);
+                        outputs_snapshot = outputs;
+                    }
+                    // Enqueue terminators WITHOUT holding vfos_mtx
+                    for (auto &o : outputs_snapshot)
                     {
                         IOInfo *i = ((IOInfo *)o.blkdata.get());
                         if (i->forward_terminator)
                             o.fifo->wait_enqueue(o.fifo->newBufferTerminator());
                     }
-                    vfos_mtx.unlock();
                 }
                 inputs[0].fifo->free(iblk);
                 return true;
             }
 
-            vfos_mtx.lock();
-            for (auto &o : outputs)
+            // Snapshot outputs under lock, then release before blocking enqueue.
+            // This prevents deadlock when del_output()/add_output() is called
+            // while a FIFO output is full and wait_enqueue() would block.
+            std::vector<BlockIO> outputs_snapshot;
             {
-                IOInfo *i = ((IOInfo *)o.blkdata.get());
+                std::lock_guard<std::mutex> lock(vfos_mtx);
+                outputs_snapshot = outputs;
+            }
 
+            // Enqueue data WITHOUT holding vfos_mtx
+            for (auto &o : outputs_snapshot)
+            {
                 DSPBuffer oblk = o.fifo->newBufferSamples(iblk.max_size, sizeof(T));
                 memcpy(oblk.getSamples<T>(), iblk.getSamples<T>(), iblk.size * sizeof(T));
                 oblk.size = iblk.size;
                 o.fifo->wait_enqueue(oblk);
             }
-            vfos_mtx.unlock();
 
             inputs[0].fifo->free(iblk);
 

--- a/src-core/init.cpp
+++ b/src-core/init.cpp
@@ -1,5 +1,5 @@
-#include "db/kepler/kepler_handler.h"
 #define SATDUMP_DLL_EXPORT 1
+#include "db/kepler/kepler_handler.h"
 #include "core/config.h"
 #include "core/plugin.h"
 #include "core/resources.h"
@@ -7,6 +7,7 @@
 #include "logger.h"
 #include "satdump_vars.h"
 #include <filesystem>
+#include <curl/curl.h>
 
 #include "db/db_handler.h"
 #include "db/iers/iers_handler.h"
@@ -60,11 +61,15 @@ namespace satdump
         if (std::filesystem::exists("satdump_cfg.json"))
             user_path = "./config";
         else
-            user_path = std::string(getenv("APPDATA")) + "/satdump";
+        {
+            const char* appdata = getenv("APPDATA");
+            user_path = (appdata ? std::string(appdata) : ".") + "/satdump";
+        }
 #elif __ANDROID__
         user_path = ".";
 #else
-        user_path = std::string(getenv("HOME")) + "/.config/satdump";
+        const char* home = getenv("HOME");
+        user_path = (home ? std::string(home) : ".") + "/.config/satdump";
 #endif
 
         try
@@ -178,11 +183,15 @@ namespace satdump
 
         // Start task scheduler
         taskScheduler->start_thread();
+
+        // Initialize libcurl globally
+        curl_global_init(CURL_GLOBAL_ALL);
     }
 
     void exitSatDump()
     {
         logger->info("Exiting SatDump! Bye!");
         taskScheduler.reset();
+        curl_global_cleanup();
     }
 } // namespace satdump

--- a/src-core/logger.cpp
+++ b/src-core/logger.cpp
@@ -181,7 +181,7 @@ namespace slog
 
     void Logger::log(LogLevel lvl, std::string v)
     {
-        sink_mtx.lock();
+        std::lock_guard<std::mutex> lock(sink_mtx);
         LogMsg m;
         m.str = v;
         m.lvl = lvl;
@@ -201,7 +201,6 @@ namespace slog
         if (m.lvl >= logger_lvl)
             for (auto &l : sinks)
                 l->receive(m);
-        sink_mtx.unlock();
     }
 
     void Logger::logf(LogLevel lvl, std::string fmt, va_list args)
@@ -258,21 +257,19 @@ namespace slog
 
     void Logger::add_sink(std::shared_ptr<LoggerSink> sink)
     {
-        sink_mtx.lock();
+        std::lock_guard<std::mutex> lock(sink_mtx);
         for (LogMsg &msg : init_log_buffer)
             sink->receive(msg);
         sinks.push_back(sink);
-        sink_mtx.unlock();
     }
 
     void Logger::del_sink(std::shared_ptr<LoggerSink> sink)
     {
-        sink_mtx.lock();
+        std::lock_guard<std::mutex> lock(sink_mtx);
         auto it = std::find_if(sinks.begin(), sinks.end(), [&sink](std::shared_ptr<LoggerSink> &c)
                                { return sink.get() == c.get(); });
         if (it != sinks.end())
             sinks.erase(it);
-        sink_mtx.unlock();
     }
 }
 

--- a/src-core/pipeline/pipeline_run.cpp
+++ b/src-core/pipeline/pipeline_run.cpp
@@ -83,10 +83,9 @@ namespace satdump
 
                     if (ui)
                     {
-                        uiCallListMutex->lock();
+                        std::lock_guard<std::mutex> lock(*uiCallListMutex);
                         uiCallList->push_back(m1);
                         uiCallList->push_back(m2);
-                        uiCallListMutex->unlock();
                     }
 
                     std::thread module1_thread([&m1]() { m1->process(); });
@@ -105,9 +104,8 @@ namespace satdump
 
                     if (ui)
                     {
-                        uiCallListMutex->lock();
+                        std::lock_guard<std::mutex> lock(*uiCallListMutex);
                         uiCallList->clear();
-                        uiCallListMutex->unlock();
                     }
 
                     lastFile = m2->getOutput();
@@ -149,18 +147,16 @@ namespace satdump
 
                     if (ui)
                     {
-                        uiCallListMutex->lock();
+                        std::lock_guard<std::mutex> lock(*uiCallListMutex);
                         uiCallList->push_back(module);
-                        uiCallListMutex->unlock();
                     }
 
                     module->process();
 
                     if (ui)
                     {
-                        uiCallListMutex->lock();
+                        std::lock_guard<std::mutex> lock(*uiCallListMutex);
                         uiCallList->clear();
-                        uiCallListMutex->unlock();
                     }
 
                     lastFile = module->getOutput();
@@ -189,18 +185,16 @@ namespace satdump
 
                 if (ui)
                 {
-                    uiCallListMutex->lock();
+                    std::lock_guard<std::mutex> lock(*uiCallListMutex);
                     uiCallList->push_back(module);
-                    uiCallListMutex->unlock();
                 }
 
                 module->process();
 
                 if (ui)
                 {
-                    uiCallListMutex->lock();
+                    std::lock_guard<std::mutex> lock(*uiCallListMutex);
                     uiCallList->clear();
-                    uiCallListMutex->unlock();
                 }
 
                 module.reset();

--- a/src-core/utils/event_bus.h
+++ b/src-core/utils/event_bus.h
@@ -6,6 +6,7 @@
  */
 
 #include <functional>
+#include <shared_mutex>
 #include <string>
 #include <typeinfo>
 #include <vector>
@@ -23,11 +24,16 @@ namespace satdump
      * (typeinfo does NOT allow casting between
      * several interpretations of the exact same
      * struct)
+     *
+     * Thread-safety: register_handler() uses exclusive write lock,
+     * fire_event() uses shared read lock — multiple concurrent
+     * fire_event() calls are allowed, register_handler() is exclusive.
      */
     class EventBus
     {
     private:
         std::vector<std::pair<std::string, std::function<void(void *)>>> all_handlers;
+        mutable std::shared_mutex handlers_mtx; // read/write lock for thread safety
 
     public:
         /**
@@ -39,6 +45,7 @@ namespace satdump
         template <typename T>
         void register_handler(std::function<void(T)> handler_fun)
         {
+            std::unique_lock<std::shared_mutex> lock(handlers_mtx); // exclusive write lock
             all_handlers.push_back({std::string(typeid(T).name()), [handler_fun](void *raw)
                                     {
                                         T evt = *((T *)raw); // Cast struct to original type
@@ -55,9 +62,10 @@ namespace satdump
         template <typename T>
         void fire_event(T evt)
         {
+            std::shared_lock<std::shared_mutex> lock(handlers_mtx); // shared read lock
             for (std::pair<std::string, std::function<void(void *)>> h : all_handlers) // Iterate through all registered functions
                 if (std::string(typeid(T).name()) == h.first)                          // Check struct type is the same
-                    h.second((void *)&evt);                                            // Fire handler up
+                    h.second((void *)&evt);                                             // Fire handler up
         }
 
         /**
@@ -70,6 +78,7 @@ namespace satdump
          */
         void fire_event(void *evt, std::string evt_name)
         {
+            std::shared_lock<std::shared_mutex> lock(handlers_mtx); // shared read lock
             for (std::pair<std::string, std::function<void(void *)>> h : all_handlers) // Iterate through all registered functions
                 if (evt_name == h.first)                                               // Check struct type is the same
                     h.second(evt);                                                     // Fire handler up

--- a/src-core/utils/http.cpp
+++ b/src-core/utils/http.cpp
@@ -39,8 +39,6 @@ namespace satdump
         bool ret = 1;
         char error_buffer[CURL_ERROR_SIZE] = {0};
 
-        curl_global_init(CURL_GLOBAL_ALL);
-
         curl = curl_easy_init();
         if (curl)
         {
@@ -88,7 +86,6 @@ namespace satdump
             if (chunk != NULL)
                 curl_slist_free_all(chunk);
         }
-        curl_global_cleanup();
         return ret;
     }
 
@@ -98,8 +95,6 @@ namespace satdump
         CURLcode res;
         bool ret = 1;
         char error_buffer[CURL_ERROR_SIZE] = {0};
-
-        curl_global_init(CURL_GLOBAL_ALL);
 
         curl = curl_easy_init();
         if (curl)
@@ -141,7 +136,6 @@ namespace satdump
             if (chunk != NULL)
                 curl_slist_free_all(chunk);
         }
-        curl_global_cleanup();
         return ret;
     }
 } // namespace satdump

--- a/src-core/utils/task_queue.cpp
+++ b/src-core/utils/task_queue.cpp
@@ -6,23 +6,32 @@ namespace satdump
 
     TaskQueue::~TaskQueue()
     {
+        // Signal the thread to stop and wait for it
+        {
+            std::lock_guard<std::mutex> lock(queue_mtx);
+            should_stop = true;
+        }
+        queue_cv.notify_one();
         if (task_thread.joinable())
             task_thread.join();
     }
 
     void TaskQueue::threadFunc()
     {
-    recheck:
-        queue_mtx.lock();
-        bool queue_has_data = task_queue.size() > 0;
-        queue_mtx.unlock();
-
-        if (queue_has_data)
+        while (true)
         {
-            queue_mtx.lock();
-            auto task = task_queue.front();
-            task_queue.pop();
-            queue_mtx.unlock();
+            std::function<void()> task;
+            {
+                std::unique_lock<std::mutex> lock(queue_mtx);
+                // Wait until there's a task or we should stop
+                queue_cv.wait(lock, [this] { return !task_queue.empty() || should_stop; });
+
+                if (should_stop && task_queue.empty())
+                    break;
+
+                task = std::move(task_queue.front());
+                task_queue.pop();
+            }
 
             try
             {
@@ -32,8 +41,6 @@ namespace satdump
             {
                 // TODOREWORK?
             }
-
-            goto recheck;
         }
 
         thread_exited = true;
@@ -41,18 +48,30 @@ namespace satdump
 
     void TaskQueue::push(std::function<void()> task)
     {
-        queue_mtx.lock();
+        bool join_old = false;
+        std::thread old_thread;
 
-        task_queue.push(task);
-
-        if (thread_exited)
         {
-            if (task_thread.joinable())
-                task_thread.join();
-            thread_exited = false;
-            task_thread = std::thread(&TaskQueue::threadFunc, this);
+            std::lock_guard<std::mutex> lock(queue_mtx);
+            task_queue.push(std::move(task));
+
+            if (thread_exited.load())
+            {
+                if (task_thread.joinable())
+                {
+                    old_thread = std::move(task_thread);
+                    join_old = true;
+                }
+                thread_exited = false;
+                task_thread = std::thread(&TaskQueue::threadFunc, this);
+            }
         }
 
-        queue_mtx.unlock();
+        if (join_old)
+        {
+            old_thread.join();
+        }
+
+        queue_cv.notify_one();
     }
 } // namespace satdump

--- a/src-core/utils/task_queue.h
+++ b/src-core/utils/task_queue.h
@@ -5,6 +5,8 @@
  * @brief A simple single-thread thread pool.
  */
 
+#include <atomic>
+#include <condition_variable>
 #include <functional>
 #include <mutex>
 #include <queue>
@@ -25,9 +27,11 @@ namespace satdump
     private:
         std::thread task_thread;
         std::mutex queue_mtx;
+        std::condition_variable queue_cv;
         std::queue<std::function<void()>> task_queue;
 
-        bool thread_exited = true;
+        std::atomic<bool> thread_exited{true};
+        bool should_stop = false;
 
     private:
         void threadFunc();


### PR DESCRIPTION
This PR addresses several concurrency bugs found through code review of the threading and synchronization patterns in `src-core/`.

## Changes

### TaskQueue: deadlock and busy-wait (utils/task_queue.cpp, .h)
- Replace `goto`-based busy-wait loop with `condition_variable::wait()` so the worker thread sleeps instead of spinning at 100% CPU
- Move `thread::join()` outside the mutex critical section to eliminate a deadlock where the thread waited on itself while holding the lock
- Convert `thread_exited` to `std::atomic<bool>` for safe cross-thread access
- Add `should_stop` flag and `notify_one()` signal in destructor for clean shutdown

### SplitterBlock: deadlock on full queue (dsp/path/splitter.cpp)
- Snapshot the output list under `vfos_mtx`, release the lock, then call `wait_enqueue()` without holding the mutex
- Previously, holding `vfos_mtx` while blocking on a full queue would deadlock if the consumer also needed `vfos_mtx` to proceed

### EventBus: data race on global singleton (utils/event_bus.h)
- Add `std::shared_mutex` (`handlers_mtx`) to protect `all_handlers`
- `register_handler()` takes `unique_lock` (exclusive write)
- `fire_event()` takes `shared_lock` (concurrent reads allowed)
- Without this, concurrent register + fire calls were undefined behaviour

### Block: non-atomic loop guard flags (dsp/block.h)
- Convert `blk_should_run` and `work_should_exit` from plain `bool` to `std::atomic<bool>` to prevent data races between the worker thread writing these flags and other threads reading them

### Logger: mutex leak on exception (logger.cpp)
- Replace manual `lock()`/`unlock()` pairs in `log()`, `add_sink()`, `del_sink()` with `std::lock_guard<std::mutex>` so the mutex is released even if an exception is thrown between the two calls

### Pipeline: mutex leak on exception (pipeline/pipeline_run.cpp)
- Replace 6 manual `lock()`/`unlock()` pairs on `uiCallListMutex` with `std::lock_guard<std::mutex>` for exception-safe locking

### Init: null pointer dereference on missing env variable (init.cpp)
- `getenv("APPDATA")` and `getenv("HOME")` can return `nullptr` when the variable is not set; passing `nullptr` to `std::string` constructor is undefined behaviour
- Add null checks with safe fallback to current directory

### libcurl: unsafe concurrent global init/cleanup (init.cpp, utils/http.cpp)
- `curl_global_init()` and `curl_global_cleanup()` were called inside every HTTP request function; libcurl documentation explicitly states these must be called exactly once globally and are not thread-safe
- Move `curl_global_init(CURL_GLOBAL_ALL)` to `initSatDump()` and `curl_global_cleanup()` to `exitSatDump()`

### ModuleWrapper: CPU spin on empty read (dsp/legacy/module_wrapper.cpp)
- Add 1ms sleep when `read()` returns 0 or negative to avoid busy-waiting at 100% CPU when no data is available in the legacy DSP path
- Synchronize internal thread joins on `stop()` to prevent use-after-free

### TimeDisplay: per-sample lock overhead (dsp/displays/time_disp.cpp)
- Acquire the mutex once per buffer update instead of once per sample
- Use `std::copy` for bulk memory transfer instead of a sample-by-sample loop
- Reduces lock contention significantly at high sample rates

## Testing
All changes compile cleanly on Windows (MSVC 2022) and are logically equivalent to the original code with correct synchronization added.