### PR TITLE
cleanup: remove redundant is_started check in RtlSdrSource::stop()

### DIFF
--- a/plugins/sdr_sources/rtlsdr_sdr_support/rtlsdr_sdr.cpp
+++ b/plugins/sdr_sources/rtlsdr_sdr_support/rtlsdr_sdr.cpp
@@ -211,8 +211,7 @@ void RtlSdrSource::stop()
         rtlsdr_cancel_async(rtlsdr_dev_obj);
         thread_should_run = false;
         logger->info("Waiting for the thread...");
-        if (is_started)
-            output_stream->stopWriter();
+        output_stream->stopWriter();
         if (work_thread.joinable())
             work_thread.join();
         logger->info("Thread stopped");


### PR DESCRIPTION
`is_started` is a plain (non-atomic) bool only ever written in `start()` and at the end of `stop()`. 

The second `if (is_started)` check inside `stop()` is always true if the outer check passed, since nothing modifies the variable in between. 

Removing it for clarity; no functional change.
