### PR TITLE
Fix Airspy source: radio button gain-type display and Stop deadlock

### DIFF
--- a/plugins/sdr_sources/airspy_sdr_support/airspy_sdr.cpp
+++ b/plugins/sdr_sources/airspy_sdr_support/airspy_sdr.cpp
@@ -136,6 +136,7 @@ void AirspySource::start()
     airspy_set_samplerate(airspy_dev_obj, current_samplerate);
 
     is_started = true;
+    output_stream->clearWriteStop();
 
     set_frequency(d_frequency);
 
@@ -152,6 +153,7 @@ void AirspySource::stop()
     if (is_started)
     {
         airspy_set_rf_bias(airspy_dev_obj, false);
+        output_stream->stopWriter();
         airspy_stop_rx(airspy_dev_obj);
         airspy_close(airspy_dev_obj);
     }
@@ -194,7 +196,7 @@ void AirspySource::drawControlUI()
         gain_type = 1;
         gain_changed = true;
     }
-    if (RImGui::RadioButton("Manual", gain_type == 22))
+    if (RImGui::RadioButton("Manual", gain_type == 2))
     {
         gain_type = 2;
         gain_changed = true;


### PR DESCRIPTION
## Summary

   This PR fixes two independent issues in the Airspy SDR source plugin (`airspy_sdr_support`):

   1. A UI display bug where the "Manual" gain radio button never shows as selected.
   2. A deadlock when clicking **Stop**, which freezes the entire UI and prevents the stop command from being sent to `satdump_sdr_server`.

   ## Bug 1: "Manual" radio button never highlights

   In `airspy_sdr.cpp`, `drawControlUI()`:

```cpp
   if (RImGui::RadioButton("Manual", gain_type == 22))
   {
       gain_type = 2;
       gain_changed = true;
   }
```

   The `active` state passed to `RadioButton()` compares against `22` instead of `2`. Since `gain_type` never equals `22`, the radio button's filled indicator never renders, even though clicking it correctly sets `gain_type = 2` and reveals the manual gain sliders.

   **Fix:** compare against `2`, consistent with the value actually assigned.

   ## Bug 2: Stop freezes the UI and never reaches the SDR server

   `AirspySource::stop()` calls `airspy_stop_rx()`, which blocks until libairspy's internal streaming thread returns from `_rx_callback()`. That callback can itself be blocked inside `stream->swap()`, waiting for the downstream consumer to call `flush()`. If the consumer has already stopped reading, `swap()` never returns — and since `stop()` never calls `output_stream->stopWriter()`, nothing wakes it up. The result is a permanent deadlock on the UI thread (which calls `stop()` synchronously), so the code that sends the stop command to `satdump_sdr_server` is never reached.

   RTL-SDR does not hit this because `rtlsdr_cancel_async()` is non-blocking by design, so ordering relative to `stopWriter()` doesn't matter there. `airspy_stop_rx()` has no such guarantee — it must be preceded by an explicit stream unblock.

   **Fix:** call `output_stream->stopWriter()` before `airspy_stop_rx()`, and `output_stream->clearWriteStop()` on `start()` so a subsequent Start/Stop cycle works correctly.

   ## Changes

   - `airspy_sdr.cpp`:
     - `drawControlUI()`: fix `gain_type == 22` → `gain_type == 2`
     - `stop()`: call `output_stream->stopWriter()` before `airspy_stop_rx()`
     - `start()`: call `output_stream->clearWriteStop()` to allow repeated Start/Stop cycles

   ## Testing

   - Verified the "Manual" radio button indicator now correctly highlights when selected.
   - Verified Start → Stop → Start cycles work correctly with a physical Airspy device; the UI no longer freezes on Stop, and the stop command is correctly sent to `satdump_sdr_server`.
   - Confirmed RTL-SDR behavior is unaffected (not part of this change).