### PR TITLE
core: Handle AVX512 in CPU features parser

### DIFF
--- a/src-core/common/cpu_features.cpp
+++ b/src-core/common/cpu_features.cpp
@@ -26,6 +26,8 @@ namespace cpu_features
             f.CPU_X86_AVX = f.CPU_X86_SSE42 = f.CPU_X86_SSE41 = f.CPU_X86_SSE4A = f.CPU_X86_SSE3 = f.CPU_X86_SSE2 = true;
         if (machine_string.find("avx2") != std::string::npos)
             f.CPU_X86_AVX2 = f.CPU_X86_AVX = f.CPU_X86_SSE42 = f.CPU_X86_SSE41 = f.CPU_X86_SSE4A = f.CPU_X86_SSE3 = f.CPU_X86_SSE2 = true;
+        if (machine_string.find("avx512") != std::string::npos)
+            f.CPU_X86_AVX512 = f.CPU_X86_AVX2 = f.CPU_X86_AVX = f.CPU_X86_SSE42 = f.CPU_X86_SSE41 = f.CPU_X86_SSE4A = f.CPU_X86_SSE3 = f.CPU_X86_SSE2 = true;
 
         // ARM NEON
         if (machine_string.find("neon") != std::string::npos)
@@ -57,6 +59,8 @@ namespace cpu_features
             printf("- AVX\n");
         if (f.CPU_X86_AVX2)
             printf("- AVX2\n");
+        if (f.CPU_X86_AVX512)
+            printf("- AVX512\n");
 
         if (f.CPU_ARM_NEON)
             printf("- NEON\n");

--- a/src-core/common/cpu_features.h
+++ b/src-core/common/cpu_features.h
@@ -11,6 +11,7 @@ namespace cpu_features
         bool CPU_X86_SSE42 = false;
         bool CPU_X86_AVX = false;
         bool CPU_X86_AVX2 = false;
+        bool CPU_X86_AVX512 = false;
         bool CPU_ARM_NEON = false;
         bool CPU_ARM_NEON7 = false;
         bool CPU_ARM_NEON8 = false;


### PR DESCRIPTION
The AMD Ryzen HX370 reports volk machine "avx512dq_64_mmx_orc" , which is currently not recognized by the CPU features parser and the SIMD AVX2 extension plugin fails to load with the following error on satdump start:
```
CPU Does not support AVX2. Extension plugin NOT loading!
```
Fix this by handling the AVX512 machine as backward compatible with AVX2, which fits the volk machine definition at:

https://github.com/gnuradio/volk/blob/main/gen/machines.xml

```
<machine name="avx512dq">
<archs>generic 32|64| mmx| sse sse2 sse3 ssse3 sse4_1 sse4_2 popcount avx fma avx2 avx512f avx512dq orc|</archs> </machine>
```

Core 0 cpuinfo dump flags field from the AMD Ryzen HX370 confirms AVX2 presence:
```
$ cat /proc/cpuinfo
processor       : 0
vendor_id       : AuthenticAMD
cpu family      : 26
model           : 36
model name      : AMD Ryzen AI 9 HX 370 w/ Radeon 890M
stepping        : 0
microcode       : 0xb20401b
cpu MHz         : 2019.566
cache size      : 1024 KB
physical id     : 0
siblings        : 24
core id         : 0
cpu cores       : 12
apicid          : 0
initial apicid  : 0
fpu             : yes
fpu_exception   : yes
cpuid level     : 16
wp              : yes
flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good amd_lbr_v2 nopl xtopology nonstop_tsc cpuid extd_apicid aperfmperf rapl pni pclmulqdq monitor ssse3 fma cx16 sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand lahf_lm cmp_legacy svm extapic cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw ibs skinit wdt tce topoext perfctr_core perfctr_nb bpext perfctr_llc mwaitx cpuid_fault cpb cat_l3 cdp_l3 hw_pstate ssbd mba perfmon_v2 ibrs ibpb stibp ibrs_enhanced vmmcall fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid cqm rdt_a avx512f avx512dq adx smap avx512ifma clflushopt clwb avx512cd sha_ni avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local user_shstk avx_vnni avx512_bf16 clzero irperf xsaveerptr rdpru wbnoinvd cppc arat npt lbrv svm_lock nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold avic v_vmsave_vmload vgif x2avic v_spec_ctrl vnmi avx512vbmi umip pku ospke avx512_vbmi2 gfni vaes vpclmulqdq avx512_vnni avx512_bitalg avx512_vpopcntdq rdpid bus_lock_detect movdiri movdir64b overflow_recov succor smca fsrm avx512_vp2intersect flush_l1d amd_lbr_pmc_freeze
bugs            : sysret_ss_attrs spectre_v1 spectre_v2 spec_store_bypass srso spectre_v2_user vmscape
bogomips        : 3992.62
TLB size        : 192 4K pages
clflush size    : 64
cache_alignment : 64
address sizes   : 48 bits physical, 48 bits virtual
power management: ts ttp tm hwpstate cpb eff_freq_ro [13] [14]
```