### PR TITLE
Fix out_of_range in satdump_exception_t on prefix-mapped builds

### DIFF
--- a/src-core/core/exception.h
+++ b/src-core/core/exception.h
@@ -1,12 +1,52 @@
 #pragma once
 
+#include <cstddef>
+#include <cstring>
 #include <stdexcept>
 #include <string>
 
 #define satdump_exception(arg) satdump::satdump_exception_t(arg, __FILE__, __LINE__)
 
+// Length of CMAKE_SOURCE_DIR (including the trailing separator), provided by
+// the build system. Default to 0 so the header stays usable if it is missing.
+#ifndef SOURCE_PATH_SIZE
+#define SOURCE_PATH_SIZE 0
+#endif
+
 namespace satdump
 {
+    namespace exception_detail
+    {
+        // Strip the build machine's source directory from a __FILE__ path.
+        //
+        // SOURCE_PATH_SIZE only describes __FILE__ when the compiler embeds
+        // absolute paths. Builds passing -ffile-prefix-map (as Debian and other
+        // distributions do for reproducible builds) hand us an already relative
+        // path such as "./src-core/core/plugin.cpp", where that offset is both
+        // meaningless and, for most paths, past the end of the string.
+        inline std::string trim_source_path(const char *file)
+        {
+            if (file == nullptr)
+                return std::string();
+
+            const char *p = file;
+
+            if (p[0] == '/')
+            {
+                // Absolute path: skip the source directory when it is present.
+                if (std::strlen(p) > (std::size_t)SOURCE_PATH_SIZE)
+                    p += SOURCE_PATH_SIZE;
+            }
+            else if (p[0] == '.' && p[1] == '/')
+            {
+                // Already relative: only the leading "./" needs to go.
+                p += 2;
+            }
+
+            return std::string(p);
+        }
+    }
+
     class satdump_exception_t : public std::runtime_error
     {
         std::string msg;
@@ -14,7 +54,7 @@ namespace satdump
     public:
         satdump_exception_t(const std::string &arg, const char *file, int line) : std::runtime_error(arg)
         {
-            msg = arg + " => " + std::string(file).substr(SOURCE_PATH_SIZE) + ":" + std::to_string(line);
+            msg = arg + " => " + exception_detail::trim_source_path(file) + ":" + std::to_string(line);
         }
 
         ~satdump_exception_t() throw()


### PR DESCRIPTION
satdump_exception_t's constructor trimmed __FILE__ with substr(SOURCE_PATH_SIZE) and no bounds check. SOURCE_PATH_SIZE is the length of CMAKE_SOURCE_DIR computed at configure time, which only describes __FILE__ when the compiler embeds absolute paths.

Builds passing -ffile-prefix-map (Debian and other distributions do this for reproducible builds) get a relative __FILE__ such as "./src-core/core/plugin.cpp". That is 26 characters against a SOURCE_PATH_SIZE of 66, so substr() threw std::out_of_range from inside the exception constructor itself, destroying the error being reported.

Because the constructor runs on the error path, any throw there aborts the process with a message about substr rather than the actual fault. On Debian this turned a recoverable plugin-loading failure into an uninformative startup crash:

  terminate called after throwing an instance of 'std::out_of_range'
    what():  basic_string::substr: __pos (which is 66) > this->size() (which is 26)

Even where the path was long enough to avoid the throw, slicing a prefix-mapped path at that offset yielded a garbled location.

Trim by inspecting the path instead: skip the source directory only for absolute paths that are actually longer than it, and drop a leading "./" from paths that are already relative. Also default SOURCE_PATH_SIZE to 0 so the header stays usable when the build system does not define it.